### PR TITLE
Add catalog module

### DIFF
--- a/src/app/[locale]/dashboard/catalog/categories/loading.tsx
+++ b/src/app/[locale]/dashboard/catalog/categories/loading.tsx
@@ -1,0 +1,39 @@
+import Loader from "@/components/ui/Loader";
+import { createClient } from "@/utils/supabase/server";
+
+export default async function Loading() {
+  const supabase = await createClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  let logoUrl: string | null = null;
+  let orgName: string | null = null;
+  let orgName2: string | null = null;
+
+  if (session) {
+    const userId = session.user.id;
+
+    const { data: preferences } = await supabase
+      .from("user_preferences")
+      .select("organization_id")
+      .eq("user_id", userId)
+      .single();
+
+    const orgId = preferences?.organization_id;
+
+    if (orgId) {
+      const { data: org } = await supabase
+        .from("organization_profiles")
+        .select("logo_url, name, name_2")
+        .eq("organization_id", orgId)
+        .single();
+
+      logoUrl = org?.logo_url ?? null;
+      orgName = org?.name ?? null;
+      orgName2 = org?.name_2 ?? null;
+    }
+  }
+
+  return <Loader logoUrl={logoUrl} orgName={orgName} orgName2={orgName2} />;
+}

--- a/src/app/[locale]/dashboard/catalog/categories/page.tsx
+++ b/src/app/[locale]/dashboard/catalog/categories/page.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+async function simulateLoading(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export default async function CatalogCategoriesPage() {
+  await simulateLoading(2000);
+
+  return <div className="text-xl">Kategorie produktów</div>;
+}

--- a/src/app/[locale]/dashboard/catalog/products/loading.tsx
+++ b/src/app/[locale]/dashboard/catalog/products/loading.tsx
@@ -1,0 +1,39 @@
+import Loader from "@/components/ui/Loader";
+import { createClient } from "@/utils/supabase/server";
+
+export default async function Loading() {
+  const supabase = await createClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  let logoUrl: string | null = null;
+  let orgName: string | null = null;
+  let orgName2: string | null = null;
+
+  if (session) {
+    const userId = session.user.id;
+
+    const { data: preferences } = await supabase
+      .from("user_preferences")
+      .select("organization_id")
+      .eq("user_id", userId)
+      .single();
+
+    const orgId = preferences?.organization_id;
+
+    if (orgId) {
+      const { data: org } = await supabase
+        .from("organization_profiles")
+        .select("logo_url, name, name_2")
+        .eq("organization_id", orgId)
+        .single();
+
+      logoUrl = org?.logo_url ?? null;
+      orgName = org?.name ?? null;
+      orgName2 = org?.name_2 ?? null;
+    }
+  }
+
+  return <Loader logoUrl={logoUrl} orgName={orgName} orgName2={orgName2} />;
+}

--- a/src/app/[locale]/dashboard/catalog/products/page.tsx
+++ b/src/app/[locale]/dashboard/catalog/products/page.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+
+async function simulateLoading(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export default async function CatalogProductsPage() {
+  await simulateLoading(2000);
+
+  return <div className="text-xl">Katalog produktów</div>;
+}

--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -64,6 +64,20 @@ export const routing = defineRouting({
       pl: "/dashboard/magazyn/dostawy",
     },
 
+    // === Catalog module ===
+    "/dashboard/catalog/products": {
+      en: "/dashboard/catalog/products",
+      pl: "/dashboard/katalog/produkty",
+    },
+    "/dashboard/catalog/products/list": {
+      en: "/dashboard/catalog/products/list",
+      pl: "/dashboard/katalog/produkty/lista",
+    },
+    "/dashboard/catalog/categories": {
+      en: "/dashboard/catalog/categories",
+      pl: "/dashboard/katalog/kategorie",
+    },
+
     // === Org Management module ===
     "/dashboard/organization/profile": {
       en: "/dashboard/organization/profile",

--- a/src/modules/catalog/config.ts
+++ b/src/modules/catalog/config.ts
@@ -1,0 +1,23 @@
+import { ModuleConfig } from "@/lib/types/module";
+
+export const catalogModule: ModuleConfig = {
+  id: "catalog",
+  slug: "catalog",
+  title: "Katalog",
+  description: "Katalog produktów dla sklepu internetowego",
+  color: "#f97316",
+  items: [
+    {
+      id: "products",
+      label: "Produkty",
+      path: "/dashboard/catalog/products",
+      icon: "Package",
+    },
+    {
+      id: "categories",
+      label: "Kategorie",
+      path: "/dashboard/catalog/categories",
+      icon: "Folder",
+    },
+  ],
+};

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -4,6 +4,7 @@ import { homeModule } from "./home/config";
 import { supportModule } from "./support/config";
 import { ModuleConfig } from "@/lib/types/module";
 import { getWarehouseModule } from "./warehouse/config";
+import { catalogModule } from "./catalog/config";
 
 /**
  * Ładuje wszystkie dostępne moduły, biorąc pod uwagę dynamiczne dane jak typy produktów itp.
@@ -14,6 +15,7 @@ export async function getAllModules(activeOrgId: string): Promise<ModuleConfig[]
   return [
     homeModule,
     warehouseModule, // dynamicznie załadowany
+    catalogModule,
     teamsModule,
     orgManagmentModule,
     supportModule,


### PR DESCRIPTION
## Summary
- create `catalog` module for product listings
- add placeholder pages for catalog products and categories
- update routing for catalog links
- include module in module loader

## Testing
- `pnpm lint` *(fails: Cannot find package '@next/eslint-plugin-next')*
- `pnpm format:check` *(fails: code style issues found)*
- `pnpm type-check` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685a5a2a0e3083288dedfe30e1a0e970