### PR TITLE
Add warehouse locations route

### DIFF
--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -63,6 +63,10 @@ export const routing = defineRouting({
       en: "/dashboard/warehouse/deliveries",
       pl: "/dashboard/magazyn/dostawy",
     },
+    "/dashboard/warehouse/locations": {
+      en: "/dashboard/warehouse/locations",
+      pl: "/dashboard/magazyn/lokalizacje",
+    },
 
     // === Org Management module ===
     "/dashboard/organization/profile": {
@@ -160,3 +164,5 @@ export const routing = defineRouting({
 
 export type Pathnames = keyof typeof routing.pathnames;
 export type Locale = (typeof routing.locales)[number];
+
+export default routing;


### PR DESCRIPTION
## Summary
- include dashboard warehouse locations path in i18n routing
- export routing object as default

## Testing
- `pnpm lint` *(fails: Local package.json exists, but node_modules missing)*
- `pnpm type-check` *(fails: Cannot find module 'next')*

------
https://chatgpt.com/codex/tasks/task_e_685bde41214c8328b6aed96ab06db5b3