### PR TITLE
Add warehouse locations page

### DIFF
--- a/src/app/[locale]/dashboard/warehouse/locations/loading.tsx
+++ b/src/app/[locale]/dashboard/warehouse/locations/loading.tsx
@@ -1,0 +1,39 @@
+import Loader from "@/components/ui/Loader";
+import { createClient } from "@/utils/supabase/server";
+
+export default async function Loading() {
+  const supabase = await createClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  let logoUrl: string | null = null;
+  let orgName: string | null = null;
+  let orgName2: string | null = null;
+
+  if (session) {
+    const userId = session.user.id;
+
+    const { data: preferences } = await supabase
+      .from("user_preferences")
+      .select("organization_id")
+      .eq("user_id", userId)
+      .single();
+
+    const orgId = preferences?.organization_id;
+
+    if (orgId) {
+      const { data: org } = await supabase
+        .from("organization_profiles")
+        .select("logo_url, name, name_2")
+        .eq("organization_id", orgId)
+        .single();
+
+      logoUrl = org?.logo_url ?? null;
+      orgName = org?.name ?? null;
+      orgName2 = org?.name_2 ?? null;
+    }
+  }
+
+  return <Loader logoUrl={logoUrl} orgName={orgName} orgName2={orgName2} />;
+}

--- a/src/app/[locale]/dashboard/warehouse/locations/page.tsx
+++ b/src/app/[locale]/dashboard/warehouse/locations/page.tsx
@@ -1,0 +1,5 @@
+import LocationsView from "@/modules/warehouse/locations/LocationsView";
+
+export default async function LocationsPage() {
+  return <LocationsView />;
+}


### PR DESCRIPTION
## Summary
- add a new route for dashboard warehouse locations
- show loader matching other warehouse pages

## Testing
- `npm run lint` *(fails: cannot find package '@next/eslint-plugin-next')*
- `npm run type-check` *(fails: cannot find module '@supabase/ssr')*
- `npm run format:check` *(fails: code style issues found)*

------
https://chatgpt.com/codex/tasks/task_e_685be5e2dbe08328946dbfdf380e3216