### PR TITLE
Add warehouse location components

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
     "react-hook-form": "^7.56.2",
     "react-toastify": "^11.0.5",
     "resend": "^4.5.1",
+    "@dnd-kit/core": "^7.0.1",
+    "@dnd-kit/sortable": "^7.0.1",
+    "@dnd-kit/utilities": "^7.0.1",
     "zod": "^3.24.3"
   },
   "devDependencies": {

--- a/src/modules/warehouse/locations/LocationForm.tsx
+++ b/src/modules/warehouse/locations/LocationForm.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import LocationImageUploader from "./LocationImageUploader";
+
+const schema = z.object({
+  name: z.string().min(1, "Nazwa jest wymagana"),
+  parentId: z.string().nullable().optional(),
+});
+
+export interface LocationOption {
+  id: string;
+  name: string;
+}
+
+interface Props {
+  children: React.ReactNode;
+  defaultValues?: {
+    name?: string;
+    parentId?: string | null;
+    imageUrl?: string | null;
+    locationId?: string;
+  };
+  parentOptions: LocationOption[];
+  onSubmit: (values: z.infer<typeof schema>) => void;
+}
+
+export default function LocationForm({
+  children,
+  defaultValues,
+  parentOptions,
+  onSubmit,
+}: Props) {
+  const form = useForm({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      name: defaultValues?.name || "",
+      parentId: defaultValues?.parentId || null,
+    },
+  });
+
+  const handleSubmit = form.handleSubmit((values) => {
+    onSubmit(values as z.infer<typeof schema>);
+  });
+
+  return (
+    <Sheet>
+      <SheetTrigger asChild>{children}</SheetTrigger>
+      <SheetContent side="right" className="w-full max-w-md">
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <SheetHeader>
+            <SheetTitle>{defaultValues ? "Edytuj lokalizację" : "Nowa lokalizacja"}</SheetTitle>
+          </SheetHeader>
+          <Input {...form.register("name") } placeholder="Nazwa" />
+          <select
+            {...form.register("parentId")}
+            className="w-full rounded border bg-background p-2 text-sm"
+          >
+            <option value="">Brak nadrzędnej</option>
+            {parentOptions.map((opt) => (
+              <option key={opt.id} value={opt.id}>
+                {opt.name}
+              </option>
+            ))}
+          </select>
+          {defaultValues?.locationId && (
+            <LocationImageUploader imageUrl={defaultValues.imageUrl} locationId={defaultValues.locationId} />
+          )}
+          <SheetFooter>
+            <Button type="submit" variant="themed">
+              Zapisz
+            </Button>
+          </SheetFooter>
+        </form>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/modules/warehouse/locations/LocationImageUploader.tsx
+++ b/src/modules/warehouse/locations/LocationImageUploader.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import { Button } from "@/components/ui/button";
+import { toast } from "react-toastify";
+import { createClient } from "@/utils/supabase/client";
+
+interface Props {
+  imageUrl?: string | null;
+  locationId: string;
+}
+
+export default function LocationImageUploader({ imageUrl, locationId }: Props) {
+  const [preview, setPreview] = useState<string | null>(imageUrl || null);
+  const [uploading, setUploading] = useState(false);
+
+  const supabase = createClient();
+
+  const updateLocationImageUrl = async (url: string) => {
+    const { error } = await supabase
+      .from("warehouse_locations")
+      .update({ image_url: url })
+      .eq("id", locationId);
+
+    if (error) {
+      toast.error("❌ Nie udało się zaktualizować zdjęcia.");
+      return false;
+    }
+
+    return true;
+  };
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const fileExt = file.name.split(".").pop();
+    const fileName = `${locationId}.${fileExt}`;
+    const filePath = fileName;
+
+    setUploading(true);
+
+    const { error: uploadError } = await supabase.storage
+      .from("location-images")
+      .upload(filePath, file, { upsert: true });
+
+    if (uploadError) {
+      toast.error(`❌ Błąd podczas wgrywania zdjęcia: ${uploadError.message}`);
+      setUploading(false);
+      return;
+    }
+
+    const {
+      data: { publicUrl },
+    } = supabase.storage.from("location-images").getPublicUrl(filePath);
+
+    const success = await updateLocationImageUrl(publicUrl);
+
+    if (success) {
+      setPreview(publicUrl);
+      toast.success("✅ Zdjęcie zaktualizowane.");
+    }
+
+    setUploading(false);
+  };
+
+  return (
+    <div className="space-y-2">
+      {preview && (
+        <div className="relative h-32 w-32 rounded border bg-white">
+          <Image src={preview} alt="Zdjęcie lokalizacji" fill className="object-contain" />
+        </div>
+      )}
+      <input
+        type="file"
+        accept="image/*"
+        onChange={handleFileChange}
+        disabled={uploading}
+        className="text-sm"
+      />
+      <Button type="button" variant="themed" disabled={uploading}>
+        {uploading ? "Wgrywam..." : "Zmień zdjęcie"}
+      </Button>
+    </div>
+  );
+}

--- a/src/modules/warehouse/locations/LocationTree.tsx
+++ b/src/modules/warehouse/locations/LocationTree.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useState } from "react";
+import {
+  DndContext,
+  DragEndEvent,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  arrayMove,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { Card } from "@/components/ui/card";
+import ProductList, { Product } from "./ProductList";
+
+export interface Location {
+  id: string;
+  name: string;
+  products?: Product[];
+  children?: Location[];
+}
+
+interface Props {
+  locations: Location[];
+}
+
+function SortableItem({ location }: { location: Location }) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: location.id,
+    disabled: location.products && location.products.length > 0,
+  });
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      {...listeners}
+      className={`rounded border p-2 ${isDragging ? "opacity-50" : ""}`}
+    >
+      <div className="flex items-center justify-between">
+        <span>{location.name}</span>
+        {location.products && location.products.length > 0 && (
+          <span className="text-xs text-muted-foreground">{location.products.length} prod.</span>
+        )}
+      </div>
+      {location.products && location.products.length > 0 && (
+        <div className="mt-2">
+          <ProductList products={location.products} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function LocationNode({ location, depth }: { location: Location; depth: number }) {
+  return (
+    <li className="mb-2">
+      <SortableItem location={location} />
+      {depth < 3 && location.children && location.children.length > 0 && (
+        <ul className="ml-4 mt-2 space-y-2">
+          <SortableContext items={location.children.map((c) => c.id)} strategy={verticalListSortingStrategy}>
+            {location.children.map((child) => (
+              <LocationNode key={child.id} location={child} depth={depth + 1} />
+            ))}
+          </SortableContext>
+        </ul>
+      )}
+    </li>
+  );
+}
+
+export default function LocationTree({ locations: initial }: Props) {
+  const [locations, setLocations] = useState<Location[]>(initial);
+
+  const sensors = useSensors(useSensor(PointerSensor));
+
+  const reorder = (
+    nodes: Location[],
+    activeId: string,
+    overId: string
+  ): { moved: boolean; nodes: Location[] } => {
+    const activeIndex = nodes.findIndex((n) => n.id === activeId);
+    const overIndex = nodes.findIndex((n) => n.id === overId);
+    if (activeIndex !== -1 && overIndex !== -1) {
+      return { moved: true, nodes: arrayMove(nodes, activeIndex, overIndex) };
+    }
+    let moved = false;
+    const newNodes = nodes.map((n) => {
+      if (!n.children) return n;
+      const res = reorder(n.children, activeId, overId);
+      if (res.moved) {
+        moved = true;
+        return { ...n, children: res.nodes };
+      }
+      return n;
+    });
+    return { moved, nodes: newNodes };
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    setLocations((locs) => reorder(locs, active.id as string, over.id as string).nodes);
+  };
+
+  return (
+    <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
+      <Card className="p-4">
+        <ul className="space-y-2">
+          <SortableContext items={locations.map((l) => l.id)} strategy={verticalListSortingStrategy}>
+            {locations.map((loc) => (
+              <LocationNode key={loc.id} location={loc} depth={1} />
+            ))}
+          </SortableContext>
+        </ul>
+      </Card>
+    </DndContext>
+  );
+}

--- a/src/modules/warehouse/locations/ProductList.tsx
+++ b/src/modules/warehouse/locations/ProductList.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+
+export interface Product {
+  id: string;
+  name: string;
+}
+
+export default function ProductList({ products }: { products: Product[] }) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Nazwa produktu</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {products.map((p) => (
+          <TableRow key={p.id}>
+            <TableCell>{p.name}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+}

--- a/src/modules/warehouse/locations/index.ts
+++ b/src/modules/warehouse/locations/index.ts
@@ -1,0 +1,6 @@
+export { default as LocationTree } from "./LocationTree";
+export { default as LocationForm } from "./LocationForm";
+export { default as LocationImageUploader } from "./LocationImageUploader";
+export { default as ProductList } from "./ProductList";
+export type { Location } from "./LocationTree";
+export type { Product } from "./ProductList";


### PR DESCRIPTION
## Summary
- add location tree with drag & drop using `@dnd-kit`
- add sheet-based form for creating or editing a location
- support image uploads for locations
- list products under locations
- export new components
- include `@dnd-kit` packages in dependencies

## Testing
- `pnpm lint` *(fails: Cannot find package '@next/eslint-plugin-next')*
- `pnpm type-check` *(fails: node_modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_685be8525b548328b82a6a3a8e4eb048