### PR TITLE
Switch location views to Supabase data

### DIFF
--- a/src/modules/warehouse/api/load-locations.ts
+++ b/src/modules/warehouse/api/load-locations.ts
@@ -1,0 +1,17 @@
+import { createClient } from "@/utils/supabase/client";
+import type { Tables } from "../../../../supabase/types/types";
+
+export async function loadLocations(): Promise<Tables<"locations">[]> {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from("locations")
+    .select("*")
+    .order("sort_order", { ascending: true });
+
+  if (error) {
+    console.error("Błąd ładowania lokalizacji:", error);
+    return [];
+  }
+
+  return data ?? [];
+}

--- a/src/modules/warehouse/locations/useLocations.ts
+++ b/src/modules/warehouse/locations/useLocations.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import useSWR from "swr";
+import { loadLocations } from "../api/load-locations";
+import type { Tables } from "../../../supabase/types/types";
+
+export type LocationRow = Tables<"locations">;
+
+export function useLocations() {
+  const { data, error, isLoading, mutate } = useSWR<LocationRow[]>(
+    "locations",
+    loadLocations,
+  );
+
+  return {
+    locations: data ?? [],
+    isLoading,
+    error,
+    mutate,
+  };
+}


### PR DESCRIPTION
## Summary
- add helper to load locations from Supabase
- expose `useLocations` hook with SWR
- refactor `LocationTree` to use Supabase data
- refactor `LocationDetail` to use Supabase data
- refactor `QRScanner` to use Supabase data for QR assignments

## Testing
- `pnpm lint` *(fails: Cannot find package '@next/eslint-plugin-next')*
- `pnpm type-check` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685d1b2cccd88328bcc40031227232ee