### PR TITLE
Enable Supabase location CRUD

### DIFF
--- a/src/modules/warehouse/api/locations.ts
+++ b/src/modules/warehouse/api/locations.ts
@@ -1,0 +1,14 @@
+"use server";
+
+import { createClient } from "@/utils/supabase/server";
+import { TablesInsert, TablesUpdate } from "../../../../supabase/types/types";
+
+export async function createLocation(data: TablesInsert<"locations">) {
+  const supabase = await createClient();
+  return await supabase.from("locations").insert(data).select().single();
+}
+
+export async function updateLocation(id: string, data: TablesUpdate<"locations">) {
+  const supabase = await createClient();
+  return await supabase.from("locations").update(data).eq("id", id).single();
+}


### PR DESCRIPTION
## Summary
- add server actions for creating and updating locations
- wire LocationModal to persist data to Supabase
- refresh router after saving a location

## Testing
- `pnpm lint` *(fails: Cannot find package '@next/eslint-plugin-next')*
- `pnpm type-check` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_685d58beb0e083288c2b02f217f2ed30