### PR TITLE
Implement location details and deletion

### DIFF
--- a/src/app/[locale]/dashboard/warehouse/locations/[id]/loading.tsx
+++ b/src/app/[locale]/dashboard/warehouse/locations/[id]/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div className="p-6">Ładowanie...</div>;
+}

--- a/src/app/[locale]/dashboard/warehouse/locations/[id]/page.tsx
+++ b/src/app/[locale]/dashboard/warehouse/locations/[id]/page.tsx
@@ -1,0 +1,70 @@
+import Image from "next/image";
+import { notFound } from "next/navigation";
+import { loadAppContextServer } from "@/lib/api/load-app-context-server";
+import { loadLocation, loadLocations } from "@/modules/warehouse/api/locations";
+import { Link } from "@/i18n/navigation";
+
+export default async function LocationDetails({
+  params,
+}: {
+  params: { id: string; locale: string };
+}) {
+  const appContext = await loadAppContextServer();
+  const orgId = appContext?.active_org_id;
+  if (!orgId) return notFound();
+
+  const location = await loadLocation(params.id);
+  if (!location || location.organization_id !== orgId) return notFound();
+
+  const all = await loadLocations(orgId);
+  const children = all.filter((l) => l.parent_id === params.id);
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-4 p-6">
+      <h1 className="text-2xl font-bold">{location.name}</h1>
+      {location.image_url && (
+        <div className="relative h-48 w-full max-w-md">
+          <Image
+            src={location.image_url}
+            alt={location.name}
+            fill
+            className="rounded border object-cover"
+          />
+        </div>
+      )}
+      <div className="space-y-1 text-sm">
+        {location.code && (
+          <p>
+            <strong>Kod:</strong> {location.code}
+          </p>
+        )}
+        {location.color && (
+          <p className="flex items-center gap-2">
+            <strong>Kolor:</strong>
+            <span
+              className="inline-block h-4 w-4 rounded"
+              style={{ backgroundColor: location.color }}
+            />
+          </p>
+        )}
+        {location.icon_name && (
+          <p className="flex items-center gap-2">
+            <strong>Ikona:</strong> <i className={`lucide lucide-${location.icon_name}`} />
+          </p>
+        )}
+      </div>
+      {children.length > 0 && (
+        <div>
+          <h2 className="mt-4 text-lg font-semibold">Podlokalizacje</h2>
+          <ul className="ml-4 list-disc space-y-1">
+            {children.map((child) => (
+              <li key={child.id}>
+                <Link href={`/dashboard/warehouse/locations/${child.id}`}>{child.name}</Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -51,6 +51,10 @@ export const routing = defineRouting({
       en: "/dashboard/warehouse/locations",
       pl: "/dashboard/magazyn/lokalizacje",
     },
+    "/dashboard/warehouse/locations/[id]": {
+      en: "/dashboard/warehouse/locations/[id]",
+      pl: "/dashboard/magazyn/lokalizacje/[id]",
+    },
     "/dashboard/warehouse/inventory/movements": {
       en: "/dashboard/warehouse/inventory/movements",
       pl: "/dashboard/magazyn/zapasy/ruchy",

--- a/src/modules/warehouse/api/locations.ts
+++ b/src/modules/warehouse/api/locations.ts
@@ -21,11 +21,7 @@ export async function loadLocations(orgId: string) {
 
 export async function createLocation(data: TablesInsert<"locations">) {
   const supabase = await createClient();
-  const { data: result, error } = await supabase
-    .from("locations")
-    .insert(data)
-    .select()
-    .single();
+  const { data: result, error } = await supabase.from("locations").insert(data).select().single();
 
   if (error) {
     console.error("Błąd tworzenia lokalizacji:", error);
@@ -52,7 +48,53 @@ export async function updateLocation(id: string, data: TablesUpdate<"locations">
   return result as Tables<"locations">;
 }
 
+export async function loadLocation(id: string) {
+  const supabase = await createClient();
+  const { data, error } = await supabase.from("locations").select("*").eq("id", id).single();
+
+  if (error) {
+    console.error("Błąd ładowania lokalizacji:", error);
+    return null;
+  }
+
+  return data as Tables<"locations">;
+}
+
+export async function isLocationEmpty(id: string) {
+  const supabase = await createClient();
+
+  const { data: children, error: childError } = await supabase
+    .from("locations")
+    .select("id")
+    .eq("parent_id", id)
+    .limit(1);
+
+  if (childError) {
+    console.error("Błąd sprawdzania dzieci lokalizacji:", childError);
+    return false;
+  }
+
+  if (children && children.length > 0) return false;
+
+  const { data: stock, error: stockError } = await supabase
+    .from("product_stock_locations")
+    .select("id")
+    .eq("location_id", id)
+    .is("deleted_at", null)
+    .limit(1);
+
+  if (stockError) {
+    console.error("Błąd sprawdzania stanu lokalizacji:", stockError);
+    return false;
+  }
+
+  return (stock?.length ?? 0) === 0;
+}
+
 export async function deleteLocation(id: string) {
+  const empty = await isLocationEmpty(id);
+  if (!empty) return false;
+
   const supabase = await createClient();
   const { error } = await supabase.from("locations").delete().eq("id", id);
 
@@ -63,4 +105,3 @@ export async function deleteLocation(id: string) {
 
   return true;
 }
-

--- a/src/modules/warehouse/locations/LocationManager.tsx
+++ b/src/modules/warehouse/locations/LocationManager.tsx
@@ -14,7 +14,10 @@ import Image from "next/image";
 import useSWR from "swr";
 import { loadLocations } from "../api/locations";
 import { LocationForm } from "./LocationForm";
-import { Pencil, Plus } from "lucide-react";
+import { Pencil, Plus, Trash } from "lucide-react";
+import { Link } from "@/i18n/navigation";
+import { deleteLocation } from "../api/locations";
+import { toast } from "react-toastify";
 import { Tables } from "../../../../supabase/types/types";
 
 export function LocationManager({
@@ -54,7 +57,12 @@ export function LocationManager({
               {loc.icon_name && (
                 <i className={`lucide lucide-${loc.icon_name} text-muted-foreground`} />
               )}
-              <span className="font-medium">{loc.name}</span>
+              <Link
+                href={`/dashboard/warehouse/locations/${loc.id}`}
+                className="font-medium hover:underline"
+              >
+                {loc.name}
+              </Link>
               {loc.code && <span className="ml-1 text-xs text-muted-foreground">({loc.code})</span>}
             </div>
             <div className="flex gap-1">
@@ -84,6 +92,27 @@ export function LocationManager({
                   }}
                 >
                   <Plus className="h-4 w-4" />
+                </span>
+              </Button>
+              <Button variant="ghost" size="icon" asChild>
+                <span
+                  role="button"
+                  tabIndex={0}
+                  className="inline-flex h-8 w-8 items-center justify-center"
+                  onClick={async (e) => {
+                    e.stopPropagation();
+                    const ok = confirm("Usunąć lokalizację?");
+                    if (!ok) return;
+                    const success = await deleteLocation(loc.id);
+                    if (success) {
+                      toast.success("Lokalizacja usunięta");
+                      await mutate();
+                    } else {
+                      toast.error("Nie można usunąć lokalizacji");
+                    }
+                  }}
+                >
+                  <Trash className="h-4 w-4" />
                 </span>
               </Button>
             </div>


### PR DESCRIPTION
## Summary
- enable viewing individual warehouse locations
- prevent deleting non-empty locations
- link location names to details page
- allow deleting locations from tree
- keep routing translation for detail pages

## Testing
- `pnpm lint` *(fails: Cannot find package '@next/eslint-plugin-next')*
- `pnpm type-check` *(fails: modules not found)*
- `pnpm format:check`

------
https://chatgpt.com/codex/tasks/task_e_685e6eb456b083289f259ec57b447889