### PR TITLE
feat: add missing contact form translations

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1875,6 +1875,10 @@
         "customFields": "Custom Fields",
         "remarks": "Remarks"
       },
+      "entityTypes": {
+        "business": "Business",
+        "individual": "Individual"
+      },
       "fields": {
         "customerType": "Customer Type",
         "salutation": "Salutation",
@@ -1952,10 +1956,34 @@
         "department": "Department name",
         "notes": "Add any additional notes here..."
       },
+      "actions": {
+        "addBillingAddress": "Add Billing Address",
+        "addShippingAddress": "Add Shipping Address",
+        "addContactPerson": "Add Contact Person",
+        "add": "Add",
+        "update": "Update",
+        "cancel": "Cancel"
+      },
+      "dialogs": {
+        "addContactPerson": "Add Contact Person",
+        "editContactPerson": "Edit Contact Person",
+        "title": "Title",
+        "workPhone": "Work Phone",
+        "designation": "Job Title",
+        "department": "Department",
+        "notes": "Notes",
+        "primaryContact": "Primary Contact",
+        "active": "Active",
+        "cancel": "Cancel",
+        "add": "Add",
+        "update": "Update"
+      },
       "messages": {
         "createSuccess": "Contact created successfully",
         "updateSuccess": "Contact updated successfully",
         "error": "Failed to save contact",
+        "noAddresses": "No addresses added yet",
+        "noContactPersons": "No contact persons added yet",
         "customFieldsPlaceholder": "No custom fields defined",
         "customFieldsInfo": "Custom fields can be configured in organization settings"
       }

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -1855,6 +1855,10 @@
         "customFields": "Pola Niestandardowe",
         "remarks": "Uwagi"
       },
+      "entityTypes": {
+        "business": "Firma",
+        "individual": "Osoba prywatna"
+      },
       "fields": {
         "customerType": "Typ Klienta",
         "salutation": "Tytuł",
@@ -1932,10 +1936,34 @@
         "department": "Nazwa działu",
         "notes": "Dodaj dodatkowe notatki tutaj..."
       },
+      "actions": {
+        "addBillingAddress": "Dodaj Adres Fakturowy",
+        "addShippingAddress": "Dodaj Adres Dostawy",
+        "addContactPerson": "Dodaj Osobę Kontaktową",
+        "add": "Dodaj",
+        "update": "Aktualizuj",
+        "cancel": "Anuluj"
+      },
+      "dialogs": {
+        "addContactPerson": "Dodaj Osobę Kontaktową",
+        "editContactPerson": "Edytuj Osobę Kontaktową",
+        "title": "Tytuł",
+        "workPhone": "Telefon Służbowy",
+        "designation": "Stanowisko",
+        "department": "Dział",
+        "notes": "Notatki",
+        "primaryContact": "Główny Kontakt",
+        "active": "Aktywny",
+        "cancel": "Anuluj",
+        "add": "Dodaj",
+        "update": "Aktualizuj"
+      },
       "messages": {
         "createSuccess": "Kontakt został utworzony pomyślnie",
         "updateSuccess": "Kontakt został zaktualizowany pomyślnie",
         "error": "Nie udało się zapisać kontaktu",
+        "noAddresses": "Nie dodano jeszcze żadnych adresów",
+        "noContactPersons": "Nie dodano jeszcze żadnych osób kontaktowych",
         "customFieldsPlaceholder": "Brak zdefiniowanych pól niestandardowych",
         "customFieldsInfo": "Pola niestandardowe można skonfigurować w ustawieniach organizacji"
       }


### PR DESCRIPTION
## Summary
- add missing contact form entity type labels under the form translation scope
- extend form-scoped action, dialog, and message strings for contact form subcomponents in English and Polish

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690b6da0aba083289771fcd0e045c689