### PR TITLE
Fix snapshot trigger to support reservations table and surface reserved stock in product details

### DIFF
--- a/src/modules/warehouse/products/components/product-location-breakdown.tsx
+++ b/src/modules/warehouse/products/components/product-location-breakdown.tsx
@@ -82,12 +82,15 @@ export function ProductLocationBreakdown({
     );
   }
 
+  const totalAvailable = locations.reduce((sum, loc) => sum + loc.available_quantity, 0);
+  const totalReserved = locations.reduce((sum, loc) => sum + loc.reserved_quantity, 0);
+
   return (
     <div className="rounded-lg border p-6">
       <h3 className="mb-4 text-base font-semibold">Stock by Location</h3>
       <div className="space-y-4">
         {locations.map((loc) => {
-          const percentage = totalQuantity > 0 ? (loc.available_quantity / totalQuantity) * 100 : 0;
+          const percentage = totalQuantity > 0 ? (loc.quantity_on_hand / totalQuantity) * 100 : 0;
           const IconComponent = (Icons as any)[loc.location.icon_name] || MapPin;
 
           return (
@@ -111,12 +114,17 @@ export function ProductLocationBreakdown({
                 </div>
                 <div className="text-right">
                   <div className="text-lg font-bold">{loc.available_quantity}</div>
-                  <div className="text-xs text-muted-foreground">{percentage.toFixed(1)}%</div>
+                  <div className="text-xs text-muted-foreground">
+                    Available • {percentage.toFixed(1)}%
+                  </div>
                 </div>
               </div>
               <Progress value={percentage} className="h-2" />
               <div className="mt-2 flex items-center justify-between text-xs text-muted-foreground">
-                <span>{loc.reserved_quantity > 0 && `Reserved: ${loc.reserved_quantity}`}</span>
+                <span>
+                  On hand: {loc.quantity_on_hand}
+                  {loc.reserved_quantity > 0 ? ` • Reserved: ${loc.reserved_quantity}` : ""}
+                </span>
                 <span>
                   {loc.total_value && loc.total_value > 0
                     ? `Value: ${loc.total_value.toFixed(2)} PLN`
@@ -129,13 +137,18 @@ export function ProductLocationBreakdown({
       </div>
 
       {/* Summary Footer */}
-      <div className="mt-4 flex items-center justify-between rounded-lg bg-muted/30 p-3 text-sm">
-        <span className="font-medium">Total</span>
-        <div className="flex items-center gap-4">
-          <span className="text-muted-foreground">
-            {locations.length} location{locations.length !== 1 ? "s" : ""}
-          </span>
-          <span className="font-bold">{totalQuantity} units</span>
+      <div className="mt-4 rounded-lg bg-muted/30 p-3 text-sm">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <span className="font-medium">Total</span>
+          <div className="flex flex-col gap-1 text-sm sm:text-right">
+            <span className="text-muted-foreground">
+              {locations.length} location{locations.length !== 1 ? "s" : ""}
+            </span>
+            <span className="font-bold">{totalQuantity} units on hand</span>
+            <span className="text-muted-foreground">
+              Available: {totalAvailable} • Reserved: {totalReserved}
+            </span>
+          </div>
         </div>
       </div>
     </div>

--- a/supabase/migrations/20251113093000_fix_snapshot_trigger_for_reservations.sql
+++ b/supabase/migrations/20251113093000_fix_snapshot_trigger_for_reservations.sql
@@ -1,0 +1,69 @@
+-- =============================================
+-- Fix trigger_refresh_stock_snapshot to support tables without destination/source location columns
+-- This update ensures triggers on stock_reservations work correctly by handling location_id as well.
+-- =============================================
+
+CREATE OR REPLACE FUNCTION trigger_refresh_stock_snapshot()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_record JSONB;
+  v_location_ids UUID[];
+  v_location_id UUID;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    v_record := to_jsonb(OLD);
+  ELSE
+    v_record := to_jsonb(NEW);
+  END IF;
+
+  v_location_ids := ARRAY(
+    SELECT DISTINCT loc_id
+    FROM unnest(ARRAY[
+      NULLIF(v_record->>'destination_location_id', '')::uuid,
+      NULLIF(v_record->>'source_location_id', '')::uuid,
+      NULLIF(v_record->>'location_id', '')::uuid
+    ]) AS loc_id
+    WHERE loc_id IS NOT NULL
+  );
+
+  FOREACH v_location_id IN ARRAY v_location_ids LOOP
+    IF TG_OP = 'DELETE' THEN
+      PERFORM refresh_stock_snapshot(
+        OLD.organization_id,
+        OLD.branch_id,
+        v_location_id,
+        OLD.product_id,
+        OLD.variant_id
+      );
+    ELSE
+      PERFORM refresh_stock_snapshot(
+        NEW.organization_id,
+        NEW.branch_id,
+        v_location_id,
+        NEW.product_id,
+        NEW.variant_id
+      );
+    END IF;
+  END LOOP;
+
+  IF TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  ELSE
+    RETURN NEW;
+  END IF;
+END;
+$$;
+
+COMMENT ON FUNCTION trigger_refresh_stock_snapshot IS
+  'Refreshes stock snapshots for any table providing location context (supports stock_movements and stock_reservations).';
+
+DO $$
+BEGIN
+  RAISE NOTICE 'trigger_refresh_stock_snapshot updated to support reservations table';
+END $$;
+
+-- =============================================
+-- Migration Complete
+-- =============================================


### PR DESCRIPTION
## Summary
- update trigger_refresh_stock_snapshot to gather location identifiers generically
- ensure reservations trigger uses location_id when destination/source columns are absent
- surface reservation balances in product detail breakdown by querying product_available_inventory and displaying on-hand, available, and reserved totals per location

## Testing
- pnpm lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915caaba28083289443124d822a1c8d)