### PR TITLE
Add reusable previewable table layout with development demos

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1249,7 +1249,9 @@
         "subscriptionTest": "Subscription Test",
         "skuGenerator": "SKU Generator Test",
         "deliveryDebugger": "Delivery Debugger",
-        "reservationsTest": "Reservations Test"
+        "reservationsTest": "Reservations Test",
+        "tablePreviewProducts": "Table preview — products",
+        "tablePreviewContacts": "Table preview — contacts"
       }
     }
   },

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -1229,7 +1229,9 @@
         "subscriptionTest": "Test Subskrypcji",
         "skuGenerator": "Test Generatora SKU",
         "deliveryDebugger": "Debugger Dostaw",
-        "reservationsTest": "Test Rezerwacji"
+        "reservationsTest": "Test Rezerwacji",
+        "tablePreviewProducts": "Podgląd tabel — produkty",
+        "tablePreviewContacts": "Podgląd tabel — kontakty"
       }
     }
   },

--- a/src/app/[locale]/dashboard/development/table-preview/contacts/[[...entityId]]/page.tsx
+++ b/src/app/[locale]/dashboard/development/table-preview/contacts/[[...entityId]]/page.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { formatDistanceToNow } from "date-fns";
+import { Badge } from "@/components/ui/badge";
+import { PreviewableTable } from "@/components/ui/previewable-table";
+import type { ColumnConfig } from "@/components/ui/advanced-data-table";
+
+import { ContactPreviewCard } from "@/modules/development/components/previewable-table/contact-preview-card";
+import {
+  type PreviewContact,
+  previewContacts,
+} from "@/modules/development/samples/previewable-table-data";
+
+const contactColumns: ColumnConfig<PreviewContact>[] = [
+  {
+    key: "name",
+    header: "Contact",
+    sortable: true,
+    filterType: "text",
+    isPrimary: true,
+    render: (value, row) => (
+      <div className="space-y-1">
+        <span className="font-medium">{value}</span>
+        <span className="text-xs text-muted-foreground">{row.role}</span>
+      </div>
+    ),
+  },
+  {
+    key: "company",
+    header: "Company",
+    filterType: "text",
+    render: (value) => <span className="text-sm">{value}</span>,
+  },
+  {
+    key: "email",
+    header: "Email",
+    filterType: "text",
+    render: (value) => <span className="text-sm text-muted-foreground">{value}</span>,
+  },
+  {
+    key: "phone",
+    header: "Phone",
+    render: (value) => <span className="text-sm">{value}</span>,
+  },
+  {
+    key: "tags",
+    header: "Tags",
+    filterType: "multi-select",
+    filterOptions: Array.from(new Set(previewContacts.flatMap((contact) => contact.tags))).map(
+      (tag) => ({
+        value: tag,
+        label: tag,
+      })
+    ),
+    render: (value: string[]) => (
+      <div className="flex flex-wrap gap-1">
+        {value.map((tag) => (
+          <Badge key={tag} variant="secondary" className="rounded-full px-2 py-0.5 text-xs">
+            {tag}
+          </Badge>
+        ))}
+      </div>
+    ),
+  },
+  {
+    key: "lastInteraction",
+    header: "Last interaction",
+    sortable: true,
+    render: (value: string) => (
+      <span className="text-sm text-muted-foreground">
+        {formatDistanceToNow(new Date(value), { addSuffix: true })}
+      </span>
+    ),
+  },
+];
+
+interface PageProps {
+  params: {
+    locale: string;
+    entityId?: string[];
+  };
+}
+
+export default function ContactTablePreviewPage({ params }: PageProps) {
+  const selectedId = params.entityId?.[0] ?? null;
+
+  return (
+    <PreviewableTable<PreviewContact>
+      basePath="/dashboard/development/table-preview/contacts"
+      selectedId={selectedId}
+      data={previewContacts}
+      columns={contactColumns}
+      searchPlaceholder="Search contacts or companies"
+      header={{
+        title: "Contact preview layout",
+        description:
+          "Demonstration of the reusable layout configured for CRM records with inline profile preview.",
+      }}
+      renderDetail={(row, onClose) => <ContactPreviewCard contact={row} onClose={onClose} />}
+      emptyMessage="No contacts found"
+      responsive
+      persistFiltersInUrl={false}
+      defaultSort={{ key: "lastInteraction", direction: "desc" }}
+    />
+  );
+}

--- a/src/app/[locale]/dashboard/development/table-preview/products/[[...entityId]]/page.tsx
+++ b/src/app/[locale]/dashboard/development/table-preview/products/[[...entityId]]/page.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { format } from "date-fns";
+import { Badge } from "@/components/ui/badge";
+import { PreviewableTable } from "@/components/ui/previewable-table";
+import type { ColumnConfig } from "@/components/ui/advanced-data-table";
+import { cn } from "@/lib/utils";
+
+import { ProductPreviewCard } from "@/modules/development/components/previewable-table/product-preview-card";
+import {
+  type PreviewProduct,
+  previewProducts,
+} from "@/modules/development/samples/previewable-table-data";
+
+const productColumns: ColumnConfig<PreviewProduct>[] = [
+  {
+    key: "name",
+    header: "Product",
+    sortable: true,
+    filterType: "text",
+    isPrimary: true,
+    render: (value, row) => (
+      <div className="flex flex-col">
+        <span className="font-medium">{value}</span>
+        <span className="text-xs text-muted-foreground">SKU {row.sku}</span>
+      </div>
+    ),
+  },
+  {
+    key: "category",
+    header: "Category",
+    filterType: "select",
+    filterOptions: Array.from(new Set(previewProducts.map((product) => product.category))).map(
+      (category) => ({
+        value: category,
+        label: category,
+      })
+    ),
+    render: (value) => <span className="text-sm">{value}</span>,
+  },
+  {
+    key: "price",
+    header: "Price",
+    align: "right",
+    sortable: true,
+    render: (value: number) => <span className="font-medium">${value.toFixed(2)}</span>,
+  },
+  {
+    key: "stock",
+    header: "Stock",
+    align: "center",
+    sortable: true,
+    filterType: "number-range",
+    render: (value: number) => (
+      <span className={cn("text-sm font-medium", value === 0 ? "text-destructive" : "")}>
+        {value}
+      </span>
+    ),
+  },
+  {
+    key: "status",
+    header: "Status",
+    filterType: "select",
+    filterOptions: [
+      { value: "active", label: "Active" },
+      { value: "draft", label: "Draft" },
+      { value: "archived", label: "Archived" },
+    ],
+    render: (value: PreviewProduct["status"]) => (
+      <Badge
+        variant="outline"
+        className={cn(
+          "rounded-full px-2.5 py-1 text-xs",
+          value === "active" && "border-emerald-500/40 text-emerald-600 dark:text-emerald-300",
+          value === "draft" && "border-amber-500/40 text-amber-600 dark:text-amber-300",
+          value === "archived" && "border-slate-500/40 text-slate-600 dark:text-slate-300"
+        )}
+      >
+        {value.toUpperCase()}
+      </Badge>
+    ),
+  },
+  {
+    key: "updatedAt",
+    header: "Updated",
+    sortable: true,
+    render: (value: string) => (
+      <span className="text-sm text-muted-foreground">{format(new Date(value), "PPP p")}</span>
+    ),
+  },
+];
+
+interface PageProps {
+  params: {
+    locale: string;
+    entityId?: string[];
+  };
+}
+
+export default function ProductTablePreviewPage({ params }: PageProps) {
+  const selectedId = params.entityId?.[0] ?? null;
+
+  return (
+    <PreviewableTable<PreviewProduct>
+      basePath="/dashboard/development/table-preview/products"
+      selectedId={selectedId}
+      data={previewProducts}
+      columns={productColumns}
+      searchPlaceholder="Search products, SKU or categories"
+      header={{
+        title: "Product preview layout",
+        description:
+          "Demo of the reusable master-detail table layout that embeds the product page preview inline.",
+      }}
+      renderDetail={(row, onClose) => <ProductPreviewCard product={row} onClose={onClose} />}
+      emptyMessage="No products found"
+      responsive
+      persistFiltersInUrl={false}
+      defaultSort={{ key: "updatedAt", direction: "desc" }}
+    />
+  );
+}

--- a/src/components/ui/previewable-table/index.ts
+++ b/src/components/ui/previewable-table/index.ts
@@ -1,0 +1,1 @@
+export * from "./previewable-table";

--- a/src/components/ui/previewable-table/previewable-table.tsx
+++ b/src/components/ui/previewable-table/previewable-table.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+
+import {
+  AdvancedDataTable,
+  type AdvancedDataTableProps,
+} from "@/components/ui/advanced-data-table";
+import { useTableStore } from "@/components/ui/advanced-data-table/store/table-store";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { cn } from "@/lib/utils";
+
+export interface PreviewableTableHeader {
+  title?: string;
+  description?: string;
+  actions?: React.ReactNode;
+}
+
+export interface PreviewableTableProps<T>
+  extends Omit<AdvancedDataTableProps<T>, "onRowClick" | "renderDetail"> {
+  /** Base path used when resetting the preview (without selected id). */
+  basePath: string;
+  /** Optional controlled selected id taken from the current route. */
+  selectedId?: string | null;
+  /** Custom builder for the path that should be pushed when a row is selected. */
+  detailPathBuilder?: (row: T, id: string) => string;
+  /** Optional wrapper header rendered above the table. */
+  header?: PreviewableTableHeader;
+  /** Additional class name applied to the outer layout container. */
+  layoutClassName?: string;
+  /** Placeholder shown above the table when nothing is selected. */
+  idleState?: React.ReactNode;
+  /** Content displayed when an id is present in the URL but no row matches it. */
+  notFoundState?: React.ReactNode;
+  /** Callback fired whenever the active row changes due to URL sync. */
+  onActiveRowChange?: (row: T | null) => void;
+  /** Custom renderer for the detail preview. */
+  renderDetail?: AdvancedDataTableProps<T>["renderDetail"];
+}
+
+const defaultGetRowId = (row: any) => String(row.id);
+
+export function PreviewableTable<T>({
+  basePath,
+  selectedId: controlledSelectedId,
+  detailPathBuilder,
+  header,
+  layoutClassName,
+  idleState,
+  notFoundState,
+  onActiveRowChange,
+  renderDetail,
+  data,
+  columns,
+  getRowId = defaultGetRowId,
+  ...tableProps
+}: PreviewableTableProps<T>) {
+  const router = useRouter();
+
+  const openDetail = useTableStore((state) => state.openDetail) as (row: T) => void;
+  const closeDetail = useTableStore((state) => state.closeDetail);
+  const setLayoutMode = useTableStore((state) => state.setLayoutMode);
+
+  const [internalSelectedId, setInternalSelectedId] = React.useState<string | null>(
+    controlledSelectedId ?? null
+  );
+
+  // Keep the internal state in sync when the selection is controlled by the route.
+  React.useEffect(() => {
+    if (controlledSelectedId !== undefined) {
+      setInternalSelectedId(controlledSelectedId ?? null);
+    }
+  }, [controlledSelectedId]);
+
+  const selectedId =
+    controlledSelectedId !== undefined ? (controlledSelectedId ?? null) : internalSelectedId;
+
+  const selectedRow = React.useMemo(() => {
+    if (!selectedId) return null;
+    return data.find((item) => getRowId(item) === selectedId) ?? null;
+  }, [data, getRowId, selectedId]);
+
+  // Sync the Zustand table store with the currently selected row so the detail panel opens.
+  React.useEffect(() => {
+    if (selectedRow) {
+      openDetail(selectedRow);
+    } else if (!selectedId) {
+      closeDetail();
+    }
+  }, [closeDetail, openDetail, selectedId, selectedRow]);
+
+  // Force the layout mode based on whether something is selected.
+  React.useEffect(() => {
+    if (selectedId) {
+      setLayoutMode("sidebar-detail");
+    } else {
+      setLayoutMode("full");
+    }
+  }, [selectedId, setLayoutMode]);
+
+  // Notify about active row changes.
+  React.useEffect(() => {
+    onActiveRowChange?.(selectedRow);
+  }, [onActiveRowChange, selectedRow]);
+
+  const handleRowClick = React.useCallback(
+    (row: T) => {
+      const id = getRowId(row);
+      if (controlledSelectedId === undefined) {
+        setInternalSelectedId(id);
+      }
+      const targetPath = detailPathBuilder ? detailPathBuilder(row, id) : `${basePath}/${id}`;
+      router.push(targetPath, { scroll: false });
+    },
+    [basePath, controlledSelectedId, detailPathBuilder, getRowId, router]
+  );
+
+  const handleClose = React.useCallback(() => {
+    if (controlledSelectedId === undefined) {
+      setInternalSelectedId(null);
+    }
+    closeDetail();
+    router.push(basePath, { scroll: false });
+  }, [basePath, closeDetail, controlledSelectedId, router]);
+
+  const wrappedRenderDetail = React.useMemo(() => {
+    if (!renderDetail) return undefined;
+    return (row: T, _onClose: () => void) => renderDetail(row, handleClose);
+  }, [handleClose, renderDetail]);
+
+  const selectionNotFound = Boolean(selectedId && !selectedRow && !tableProps.loading);
+
+  const defaultNotFoundState = (
+    <Alert variant="destructive" className="mb-4">
+      <AlertTitle>Preview unavailable</AlertTitle>
+      <AlertDescription>The requested record could not be found.</AlertDescription>
+    </Alert>
+  );
+
+  const defaultIdleState = (
+    <Alert className="mb-4">
+      <AlertTitle>Select a record</AlertTitle>
+      <AlertDescription>
+        Choose an entry from the table to open its detail preview without leaving the page.
+      </AlertDescription>
+    </Alert>
+  );
+
+  const { className: tableClassName, ...restTableProps } = tableProps;
+
+  return (
+    <div className={cn("flex h-full flex-col gap-4", layoutClassName)}>
+      {header ? (
+        <div className="space-y-2">
+          {header.title ? <h1 className="text-2xl font-semibold">{header.title}</h1> : null}
+          {header.description ? (
+            <p className="text-sm text-muted-foreground">{header.description}</p>
+          ) : null}
+          {header.actions ? <div className="flex flex-wrap gap-2">{header.actions}</div> : null}
+        </div>
+      ) : null}
+
+      {!selectedId && (idleState ?? defaultIdleState)}
+      {selectionNotFound && (notFoundState ?? defaultNotFoundState)}
+
+      <AdvancedDataTable<T>
+        {...(restTableProps as AdvancedDataTableProps<T>)}
+        data={data}
+        columns={columns}
+        getRowId={getRowId}
+        onRowClick={handleRowClick}
+        renderDetail={wrappedRenderDetail}
+        className={cn("flex-1", tableClassName)}
+      />
+    </div>
+  );
+}

--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -378,6 +378,22 @@ export const routing = defineRouting({
       en: "/dashboard/development/sku-generator",
       pl: "/dashboard/deweloperskie/generator-sku",
     },
+    "/dashboard/development/table-preview/products": {
+      en: "/dashboard/development/table-preview/products",
+      pl: "/dashboard/deweloperskie/podglad-tabel/produkty",
+    },
+    "/dashboard/development/table-preview/products/[id]": {
+      en: "/dashboard/development/table-preview/products/[id]",
+      pl: "/dashboard/deweloperskie/podglad-tabel/produkty/[id]",
+    },
+    "/dashboard/development/table-preview/contacts": {
+      en: "/dashboard/development/table-preview/contacts",
+      pl: "/dashboard/deweloperskie/podglad-tabel/kontakty",
+    },
+    "/dashboard/development/table-preview/contacts/[id]": {
+      en: "/dashboard/development/table-preview/contacts/[id]",
+      pl: "/dashboard/deweloperskie/podglad-tabel/kontakty/[id]",
+    },
     "/dashboard/development/reservations-test": {
       en: "/dashboard/development/reservations-test",
       pl: "/dashboard/deweloperskie/test-rezerwacji",

--- a/src/modules/development/components/previewable-table/contact-preview-card.tsx
+++ b/src/modules/development/components/previewable-table/contact-preview-card.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import * as React from "react";
+import { formatDistanceToNow } from "date-fns";
+import { Mail, MessageCircle, Phone, Tags, UserRound, X } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Separator } from "@/components/ui/separator";
+
+import type { PreviewContact } from "@/modules/development/samples/previewable-table-data";
+
+interface ContactPreviewCardProps {
+  contact: PreviewContact;
+  onClose: () => void;
+}
+
+export function ContactPreviewCard({ contact, onClose }: ContactPreviewCardProps) {
+  return (
+    <Card className="m-4 flex h-[calc(100%-2rem)] flex-col overflow-hidden border-0 shadow-none">
+      <CardHeader className="flex items-start justify-between space-y-0 pb-4">
+        <div className="space-y-1">
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <UserRound className="h-5 w-5 text-primary" />
+            {contact.name}
+          </CardTitle>
+          <p className="text-sm text-muted-foreground">{contact.role}</p>
+          <div className="flex flex-wrap gap-2 pt-2">
+            {contact.tags.map((tag) => (
+              <Badge key={tag} variant="secondary" className="rounded-full px-2.5 py-1 text-xs">
+                <Tags className="mr-1 h-3 w-3" />
+                {tag}
+              </Badge>
+            ))}
+          </div>
+        </div>
+        <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close preview">
+          <X className="h-4 w-4" />
+        </Button>
+      </CardHeader>
+      <Separator />
+      <ScrollArea className="flex-1">
+        <CardContent className="space-y-6 py-6">
+          <section className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <InfoLine label="Company" value={contact.company} />
+            <InfoLine label="Email" value={contact.email} icon={<Mail className="h-3.5 w-3.5" />} />
+            <InfoLine
+              label="Phone"
+              value={contact.phone}
+              icon={<Phone className="h-3.5 w-3.5" />}
+            />
+            <InfoLine
+              label="Last interaction"
+              value={`${formatDistanceToNow(new Date(contact.lastInteraction), { addSuffix: true })}`}
+            />
+          </section>
+
+          <section className="space-y-2">
+            <h3 className="text-sm font-semibold text-muted-foreground">Notes</h3>
+            <p className="rounded-md border bg-muted/40 p-4 text-sm leading-relaxed text-foreground/90">
+              {contact.notes}
+            </p>
+          </section>
+        </CardContent>
+      </ScrollArea>
+      <Separator />
+      <CardFooter className="flex flex-col gap-2 py-4 md:flex-row md:items-center md:justify-between">
+        <span className="text-xs text-muted-foreground">
+          Designed for the contacts module migration.
+        </span>
+        <div className="flex gap-2">
+          <Button variant="outline">
+            <MessageCircle className="mr-2 h-4 w-4" />
+            Quick note
+          </Button>
+          <Button onClick={onClose}>
+            <X className="mr-2 h-4 w-4" />
+            Close preview
+          </Button>
+        </div>
+      </CardFooter>
+    </Card>
+  );
+}
+
+function InfoLine({
+  label,
+  value,
+  icon,
+}: {
+  label: string;
+  value: string;
+  icon?: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1 rounded-lg border bg-muted/30 p-4 text-sm">
+      <p className="flex items-center gap-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {icon}
+        {label}
+      </p>
+      <p className="font-medium text-foreground/90">{value}</p>
+    </div>
+  );
+}

--- a/src/modules/development/components/previewable-table/product-preview-card.tsx
+++ b/src/modules/development/components/previewable-table/product-preview-card.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { format } from "date-fns";
+import { ArrowUpRight, ExternalLink, Package, X } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { Link } from "@/i18n/navigation";
+import { cn } from "@/lib/utils";
+
+import type { PreviewProduct } from "@/modules/development/samples/previewable-table-data";
+
+interface ProductPreviewCardProps {
+  product: PreviewProduct;
+  onClose: () => void;
+}
+
+const statusVariant: Record<PreviewProduct["status"], string> = {
+  active: "bg-emerald-100 text-emerald-800 dark:bg-emerald-500/15 dark:text-emerald-200",
+  draft: "bg-amber-100 text-amber-800 dark:bg-amber-500/15 dark:text-amber-200",
+  archived: "bg-slate-100 text-slate-700 dark:bg-slate-500/15 dark:text-slate-200",
+};
+
+export function ProductPreviewCard({ product, onClose }: ProductPreviewCardProps) {
+  return (
+    <Card className="m-4 flex h-[calc(100%-2rem)] flex-col overflow-hidden border-0 shadow-none">
+      <CardHeader className="flex items-start justify-between space-y-0 pb-4">
+        <div className="flex items-center gap-3">
+          <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-primary/10 text-primary">
+            <Package className="h-6 w-6" />
+          </div>
+          <div>
+            <CardTitle className="flex items-center gap-3 text-lg">
+              {product.name}
+              <Badge className={cn("rounded-full px-2.5", statusVariant[product.status])}>
+                {product.status.toUpperCase()}
+              </Badge>
+            </CardTitle>
+            <p className="text-sm text-muted-foreground">SKU {product.sku}</p>
+          </div>
+        </div>
+        <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close preview">
+          <X className="h-4 w-4" />
+        </Button>
+      </CardHeader>
+      <Separator />
+      <CardContent className="flex-1 space-y-6 overflow-y-auto py-6">
+        <section className="space-y-2">
+          <h3 className="text-sm font-semibold text-muted-foreground">Overview</h3>
+          <p className="text-sm leading-relaxed text-foreground/90">{product.description}</p>
+        </section>
+
+        <section className="grid grid-cols-1 gap-4 rounded-lg border bg-muted/40 p-4 text-sm md:grid-cols-2">
+          <div className="space-y-1">
+            <p className="text-xs font-medium text-muted-foreground">Category</p>
+            <p className="font-medium">{product.category}</p>
+          </div>
+          <div className="space-y-1">
+            <p className="text-xs font-medium text-muted-foreground">Price</p>
+            <p className="font-medium">${product.price.toFixed(2)}</p>
+          </div>
+          <div className="space-y-1">
+            <p className="text-xs font-medium text-muted-foreground">In stock</p>
+            <p className="font-medium">{product.stock}</p>
+          </div>
+          <div className="space-y-1">
+            <p className="text-xs font-medium text-muted-foreground">Last update</p>
+            <p className="font-medium">{format(new Date(product.updatedAt), "PPP p")}</p>
+          </div>
+        </section>
+      </CardContent>
+      <Separator />
+      <CardFooter className="flex flex-col gap-2 py-4 md:flex-row md:items-center md:justify-between">
+        <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+          <span>Preview layout demo</span>
+          <span>&bull;</span>
+          <span>Optimised for in-place product inspection</span>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="outline" asChild>
+            <Link href={`/dashboard/warehouse/products/${product.id}`} scroll={false}>
+              <ExternalLink className="mr-2 h-4 w-4" />
+              Open product page
+            </Link>
+          </Button>
+          <Button onClick={onClose}>
+            <ArrowUpRight className="mr-2 h-4 w-4" />
+            Close preview
+          </Button>
+        </div>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/src/modules/development/config.ts
+++ b/src/modules/development/config.ts
@@ -75,6 +75,18 @@ export const developmentModule: ModuleConfig = {
       icon: "Truck",
     },
     {
+      id: "table-preview-products",
+      label: "modules.development.items.tablePreviewProducts",
+      path: "/dashboard/development/table-preview/products",
+      icon: "Table2",
+    },
+    {
+      id: "table-preview-contacts",
+      label: "modules.development.items.tablePreviewContacts",
+      path: "/dashboard/development/table-preview/contacts",
+      icon: "IdCard",
+    },
+    {
       id: "status-stepper",
       label: "Status Stepper",
       path: "/dashboard/development/status-stepper",

--- a/src/modules/development/samples/previewable-table-data.ts
+++ b/src/modules/development/samples/previewable-table-data.ts
@@ -1,0 +1,149 @@
+export interface PreviewProduct {
+  id: string;
+  name: string;
+  sku: string;
+  category: string;
+  price: number;
+  stock: number;
+  status: "draft" | "active" | "archived";
+  description: string;
+  updatedAt: string;
+}
+
+export interface PreviewContact {
+  id: string;
+  name: string;
+  company: string;
+  email: string;
+  phone: string;
+  role: string;
+  tags: string[];
+  lastInteraction: string;
+  notes: string;
+}
+
+export const previewProducts: PreviewProduct[] = [
+  {
+    id: "prd-1001",
+    name: "Nordic Steel Water Bottle",
+    sku: "NSWB-500",
+    category: "Accessories",
+    price: 24.9,
+    stock: 156,
+    status: "active",
+    description:
+      "Double-walled insulated bottle crafted from recycled stainless steel. Keeps drinks hot for 12h and cold for 24h.",
+    updatedAt: "2024-03-01T10:30:00.000Z",
+  },
+  {
+    id: "prd-1002",
+    name: "Aurora Performance Hoodie",
+    sku: "APH-XS-NEB",
+    category: "Apparel",
+    price: 68.0,
+    stock: 42,
+    status: "active",
+    description:
+      "Lightweight technical hoodie designed for shifting weather conditions. Breathable mesh panels and hidden pocket system.",
+    updatedAt: "2024-02-26T09:10:00.000Z",
+  },
+  {
+    id: "prd-1003",
+    name: "Summit Trail Backpack 28L",
+    sku: "STB-28",
+    category: "Outdoor",
+    price: 119.0,
+    stock: 18,
+    status: "draft",
+    description:
+      "Compact hiking backpack with modular strap system, integrated rain cover and laptop sleeve for hybrid commuters.",
+    updatedAt: "2024-02-20T14:22:00.000Z",
+  },
+  {
+    id: "prd-1004",
+    name: "Flux Wireless Earbuds",
+    sku: "FLX-EARB-01",
+    category: "Electronics",
+    price: 149.99,
+    stock: 75,
+    status: "active",
+    description:
+      "Adaptive noise-cancelling earbuds with multi-device pairing and 42-hour battery life including the charging case.",
+    updatedAt: "2024-02-12T08:45:00.000Z",
+  },
+  {
+    id: "prd-1005",
+    name: "Lumen Smart Desk Lamp",
+    sku: "LUM-LAMP-02",
+    category: "Home",
+    price: 89.5,
+    stock: 0,
+    status: "archived",
+    description:
+      "Minimalist aluminium desk lamp with wireless charging pad, ambient light sensor and automation-ready firmware.",
+    updatedAt: "2024-01-30T16:05:00.000Z",
+  },
+];
+
+export const previewContacts: PreviewContact[] = [
+  {
+    id: "cnt-901",
+    name: "Amelia Richards",
+    company: "Northwind Trading",
+    email: "amelia.richards@example.com",
+    phone: "+44 20 7946 0737",
+    role: "Head of Procurement",
+    tags: ["VIP", "Strategic"],
+    lastInteraction: "2024-02-26T11:15:00.000Z",
+    notes:
+      "Planning a Q2 assortment refresh. Interested in exclusive colorways and sustainable packaging options.",
+  },
+  {
+    id: "cnt-902",
+    name: "Mateusz Kowalski",
+    company: "Baltic Outfitters",
+    email: "mateusz.kowalski@example.com",
+    phone: "+48 22 123 45 67",
+    role: "Operations Manager",
+    tags: ["Logistics", "Beta"],
+    lastInteraction: "2024-03-02T09:00:00.000Z",
+    notes:
+      "Testing our fulfillment API. Needs sandbox credentials for two additional team members.",
+  },
+  {
+    id: "cnt-903",
+    name: "Priya Desai",
+    company: "Orbit Supply Co.",
+    email: "priya.desai@example.com",
+    phone: "+1 415 555 1299",
+    role: "Category Buyer",
+    tags: ["Wholesale"],
+    lastInteraction: "2024-02-18T17:25:00.000Z",
+    notes:
+      "Requested lead time analytics for the new transit hub. Considering three-month pilot contract.",
+  },
+  {
+    id: "cnt-904",
+    name: "Leonor García",
+    company: "Atelier Verde",
+    email: "leonor.garcia@example.com",
+    phone: "+34 91 123 4567",
+    role: "Design Director",
+    tags: ["Creative", "Sustainability"],
+    lastInteraction: "2024-02-05T12:50:00.000Z",
+    notes:
+      "Needs fabric swatches for recycled nylon line. Prefers asynchronous communication via shared workspace.",
+  },
+  {
+    id: "cnt-905",
+    name: "Jonah Lin",
+    company: "Harbor & Co.",
+    email: "jonah.lin@example.com",
+    phone: "+1 206 555 7842",
+    role: "Account Executive",
+    tags: ["Partner"],
+    lastInteraction: "2024-01-29T15:40:00.000Z",
+    notes:
+      "Prepping annual co-marketing campaign. Requested early access to the refreshed contacts workspace UI.",
+  },
+];


### PR DESCRIPTION
## Summary
- create a generic `PreviewableTable` wrapper that syncs the advanced data table selection with the router and provides default messaging for idle or missing previews
- add sample data plus dedicated preview cards to showcase product and contact detail panes inside the new layout
- expose two development showroom pages and wire them into module navigation and i18n routing for quick access

## Testing
- pnpm lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69171400304c8328b38d247fdda645ec)