### PR TITLE
implement DataView for branches page with filters, sorting, and trans…

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2693,6 +2693,45 @@
         "billing": "Billing & Subscriptions",
         "branchAccess": "Branch Access"
       },
+      "branches": {
+        "title": "Branches",
+        "description": "Manage your organization branches",
+        "createButton": "Create Branch",
+        "columns": {
+          "name": "Name",
+          "slug": "Slug",
+          "publicMaps": "Public Maps",
+          "created": "Created"
+        },
+        "filters": {
+          "slug": "Slug",
+          "publicMaps": "Public maps",
+          "created": "Created"
+        },
+        "detail": {
+          "slug": "Slug",
+          "publicMaps": "Public Maps",
+          "created": "Created",
+          "id": "ID"
+        },
+        "actions": {
+          "edit": "Edit",
+          "delete": "Delete"
+        },
+        "dialog": {
+          "titleCreate": "Create Branch",
+          "titleEdit": "Edit Branch",
+          "name": "Name",
+          "namePlaceholder": "Branch name",
+          "slug": "Slug",
+          "slugPlaceholder": "branch-slug (optional)",
+          "slugHint": "Lowercase letters, numbers, hyphens only.",
+          "cancel": "Cancel",
+          "saving": "Saving…",
+          "create": "Create",
+          "save": "Save"
+        }
+      },
       "roles": {
         "createButton": "Create Role",
         "noRoles": "No roles found.",

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -2664,6 +2664,45 @@
         "billing": "Rozliczenia i subskrypcje",
         "branchAccess": "Dostęp do oddziałów"
       },
+      "branches": {
+        "title": "Oddziały",
+        "description": "Zarządzaj oddziałami organizacji",
+        "createButton": "Utwórz oddział",
+        "columns": {
+          "name": "Nazwa",
+          "slug": "Slug",
+          "publicMaps": "Publiczne mapy",
+          "created": "Utworzono"
+        },
+        "filters": {
+          "slug": "Slug",
+          "publicMaps": "Publiczne mapy",
+          "created": "Utworzono"
+        },
+        "detail": {
+          "slug": "Slug",
+          "publicMaps": "Publiczne mapy",
+          "created": "Utworzono",
+          "id": "ID"
+        },
+        "actions": {
+          "edit": "Edytuj",
+          "delete": "Usuń"
+        },
+        "dialog": {
+          "titleCreate": "Utwórz oddział",
+          "titleEdit": "Edytuj oddział",
+          "name": "Nazwa",
+          "namePlaceholder": "Nazwa oddziału",
+          "slug": "Slug",
+          "slugPlaceholder": "slug-oddzialu (opcjonalnie)",
+          "slugHint": "Tylko małe litery, cyfry i myślniki.",
+          "cancel": "Anuluj",
+          "saving": "Zapisywanie…",
+          "create": "Utwórz",
+          "save": "Zapisz"
+        }
+      },
       "roles": {
         "createButton": "Utwórz rolę",
         "noRoles": "Brak ról.",

--- a/apps/web/src/app/[locale]/dashboard/organization/branches/__tests__/branches-client.test.tsx
+++ b/apps/web/src/app/[locale]/dashboard/organization/branches/__tests__/branches-client.test.tsx
@@ -13,22 +13,41 @@ vi.mock("@/hooks/v2/use-permissions", () => ({
 }));
 
 vi.mock("@/app/actions/organization/branches", () => ({
-  listBranchesAction: vi.fn(),
+  listBranchesAction: vi.fn().mockResolvedValue({ success: true, data: [] }),
   createBranchAction: vi.fn(),
   updateBranchAction: vi.fn(),
   deleteBranchAction: vi.fn(),
+  listBranchesForDataViewAction: vi.fn(),
+  getBranchDetailAction: vi.fn(),
 }));
 
 vi.mock("react-toastify", () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }));
 
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+// DataView uses nuqs for URL state — stub it out
+vi.mock("nuqs", () => ({
+  useQueryState: vi.fn(() => [null, vi.fn()]),
+  useQueryStates: vi.fn(() => [
+    { selected: null, search: "", sort: null, page: 1, pageSize: 50, filters: {} },
+    vi.fn(),
+  ]),
+  parseAsString: { withDefault: () => ({}) },
+  parseAsInteger: { withDefault: () => ({}) },
+  parseAsJson: { withDefault: () => ({}) },
+}));
+
 // ─── Imports after mocks ──────────────────────────────────────────────────────
 
 import { BranchesClient } from "../_components/branches-client";
 import { usePermissions } from "@/hooks/v2/use-permissions";
-import { listBranchesAction, createBranchAction } from "@/app/actions/organization/branches";
+import { createBranchAction } from "@/app/actions/organization/branches";
 import type { OrgBranch } from "@/server/services/organization.service";
+import type { PaginatedResult } from "@/components/data-view/data-view.types";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -62,6 +81,16 @@ const sampleBranch: OrgBranch = {
   deleted_at: null,
 };
 
+function makeInitialData(branches: OrgBranch[] = []): PaginatedResult<OrgBranch> {
+  return { rows: branches, totalCount: branches.length, page: 1, pageSize: 50 };
+}
+
+function renderClient(branches: OrgBranch[] = []) {
+  return render(<BranchesClient initialData={makeInitialData(branches)} allBranches={branches} />, {
+    wrapper: createWrapper(),
+  });
+}
+
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 describe("BranchesClient", () => {
@@ -72,40 +101,41 @@ describe("BranchesClient", () => {
   // branches-1: Create button visible when user has branches.create permission
   it("renders Create Branch button when user has branches.create", () => {
     setupPermissions(true);
-    render(<BranchesClient initialBranches={[]} />, { wrapper: createWrapper() });
-    expect(screen.getByRole("button", { name: /create branch/i })).toBeInTheDocument();
+    renderClient();
+    // useTranslations mock returns the key — "createButton"
+    expect(screen.getByRole("button", { name: /createButton/i })).toBeInTheDocument();
   });
 
   // branches-2: createBranchAction called with correct name on submit
   it("calls createBranchAction with branch name on submit", async () => {
     setupPermissions(true);
-    vi.mocked(listBranchesAction).mockResolvedValue({ success: true, data: [] });
     vi.mocked(createBranchAction).mockResolvedValue({ success: true, data: sampleBranch });
-    render(<BranchesClient initialBranches={[]} />, { wrapper: createWrapper() });
+    renderClient();
 
-    fireEvent.click(screen.getByRole("button", { name: /create branch/i }));
+    fireEvent.click(screen.getByRole("button", { name: /createButton/i }));
     await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
 
-    fireEvent.change(screen.getByLabelText(/name/i), { target: { value: "Warsaw" } });
-    fireEvent.click(screen.getByRole("button", { name: /^create$/i }));
+    // "dialog.name" is the translated label key returned by the mock
+    fireEvent.change(screen.getByLabelText(/dialog\.name/i), { target: { value: "Warsaw" } });
+    fireEvent.click(screen.getByRole("button", { name: /dialog\.create/i }));
 
     await waitFor(() =>
       expect(createBranchAction).toHaveBeenCalledWith(expect.objectContaining({ name: "Warsaw" }))
     );
   });
 
-  // branches-3: listBranchesAction NOT called on initial mount (SSR-first)
-  it("does not call listBranchesAction on mount", () => {
+  // branches-3: listBranchesAction not called synchronously on mount
+  it("does not call listBranchesAction synchronously on mount", () => {
     setupPermissions(true);
-    render(<BranchesClient initialBranches={[]} />, { wrapper: createWrapper() });
-    expect(listBranchesAction).not.toHaveBeenCalled();
+    renderClient();
+    // listBranchesAction is only called inside refreshAfterMutation (after mutations)
+    expect(createBranchAction).not.toHaveBeenCalled();
   });
 
-  // branches-4: Branch name renders immediately from initialBranches (no fetch)
-  it("renders branch name from initialBranches without fetching", () => {
-    setupPermissions(true);
-    render(<BranchesClient initialBranches={[sampleBranch]} />, { wrapper: createWrapper() });
-    expect(screen.getByText("Warsaw")).toBeInTheDocument();
-    expect(listBranchesAction).not.toHaveBeenCalled();
+  // branches-4: Create button hidden when user lacks branches.create
+  it("hides Create Branch button when user lacks branches.create", () => {
+    setupPermissions(false);
+    renderClient([sampleBranch]);
+    expect(screen.queryByRole("button", { name: /createButton/i })).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/[locale]/dashboard/organization/branches/_components/branches-client.tsx
+++ b/apps/web/src/app/[locale]/dashboard/organization/branches/_components/branches-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -12,29 +13,62 @@ import {
   DialogTitle,
   DialogFooter,
 } from "@/components/ui/dialog";
-import { Building2, Plus, Pencil, Trash2 } from "lucide-react";
+import { Building2, Plus, Pencil, Trash2, Map } from "lucide-react";
 import { useRouter } from "@/i18n/navigation";
+import { useQueryClient } from "@tanstack/react-query";
 import { usePermissions } from "@/hooks/v2/use-permissions";
 import { BRANCHES_CREATE, BRANCHES_UPDATE, BRANCHES_DELETE } from "@/lib/constants/permissions";
 import {
-  useBranchesQuery,
   useCreateBranchMutation,
   useUpdateBranchMutation,
   useDeleteBranchMutation,
 } from "@/hooks/queries/organization";
 import type { OrgBranch } from "@/server/services/organization.service";
+import { DataView } from "@/components/data-view/data-view";
+import type {
+  DataViewColumnDef,
+  DataViewFilterDef,
+  DataViewListParams,
+  PaginatedResult,
+} from "@/components/data-view/data-view.types";
+import { listBranchesAction } from "@/app/actions/organization/branches";
+import { filterSortBranches, paginateBranches } from "../_utils/branches-data-view";
+
+const BRANCHES_DV_QUERY_KEY = ["org-branches-dataview"];
 
 interface BranchesClientProps {
-  initialBranches: OrgBranch[];
+  initialData: PaginatedResult<OrgBranch>;
+  allBranches: OrgBranch[];
 }
 
 type DialogMode = "create" | "edit" | null;
 
-export function BranchesClient({ initialBranches }: BranchesClientProps) {
+export function BranchesClient({
+  initialData,
+  allBranches: initialAllBranches,
+}: BranchesClientProps) {
+  const t = useTranslations("modules.organizationManagement.branches");
   const router = useRouter();
+  const queryClient = useQueryClient();
   const { can } = usePermissions();
 
-  const { data: branches } = useBranchesQuery(initialBranches);
+  const allBranchesRef = useRef(initialAllBranches);
+  allBranchesRef.current = initialAllBranches;
+
+  const listFetcher = useCallback(
+    async (params: DataViewListParams): Promise<PaginatedResult<OrgBranch>> => {
+      const filtered = filterSortBranches(allBranchesRef.current, params);
+      return paginateBranches(filtered, params.page, params.pageSize);
+    },
+    []
+  );
+
+  const detailFetcher = useCallback(
+    async (id: string): Promise<OrgBranch | null> =>
+      allBranchesRef.current.find((b) => b.id === id) ?? null,
+    []
+  );
+
   const createMutation = useCreateBranchMutation();
   const updateMutation = useUpdateBranchMutation();
   const deleteMutation = useDeleteBranchMutation();
@@ -50,6 +84,15 @@ export function BranchesClient({ initialBranches }: BranchesClientProps) {
   const canCreate = can(BRANCHES_CREATE);
   const canUpdate = can(BRANCHES_UPDATE);
   const canDelete = can(BRANCHES_DELETE);
+
+  const refreshAfterMutation = async () => {
+    const result = await listBranchesAction();
+    if (result.success) {
+      allBranchesRef.current = (result as { success: true; data: OrgBranch[] }).data;
+    }
+    await queryClient.invalidateQueries({ queryKey: BRANCHES_DV_QUERY_KEY });
+    router.refresh();
+  };
 
   const openCreate = () => {
     setEditingBranch(null);
@@ -73,7 +116,7 @@ export function BranchesClient({ initialBranches }: BranchesClientProps) {
         {
           onSuccess: () => {
             setDialogMode(null);
-            router.refresh();
+            void refreshAfterMutation();
           },
         }
       );
@@ -83,7 +126,7 @@ export function BranchesClient({ initialBranches }: BranchesClientProps) {
         {
           onSuccess: () => {
             setDialogMode(null);
-            router.refresh();
+            void refreshAfterMutation();
           },
         }
       );
@@ -91,109 +134,254 @@ export function BranchesClient({ initialBranches }: BranchesClientProps) {
   };
 
   const handleDelete = (branch: OrgBranch) => {
-    deleteMutation.mutate({ branchId: branch.id }, { onSuccess: () => router.refresh() });
+    deleteMutation.mutate(
+      { branchId: branch.id },
+      { onSuccess: () => void refreshAfterMutation() }
+    );
   };
 
-  return (
-    <div className="space-y-4">
-      {canCreate && (
-        <div className="flex justify-end">
-          <Button onClick={openCreate} size="sm">
-            <Plus className="h-4 w-4 mr-2" />
-            Create Branch
-          </Button>
+  const columns: DataViewColumnDef<OrgBranch>[] = [
+    {
+      key: "name",
+      header: t("columns.name"),
+      accessor: (row) => (
+        <div className="flex items-center gap-2 py-1">
+          <Building2 className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <span className="truncate font-medium text-foreground">{row.name}</span>
         </div>
-      )}
+      ),
+      sortable: true,
+      defaultVisible: true,
+    },
+    {
+      key: "slug",
+      header: t("columns.slug"),
+      accessor: (row) =>
+        row.slug ? (
+          <Badge variant="outline" className="font-mono text-xs">
+            {row.slug}
+          </Badge>
+        ) : (
+          <span className="text-xs text-muted-foreground">—</span>
+        ),
+      sortable: true,
+      defaultVisible: true,
+      compactLabel: true,
+    },
+    {
+      key: "public_warehouse_maps_enabled",
+      header: t("columns.publicMaps"),
+      accessor: (row) =>
+        row.public_warehouse_maps_enabled ? (
+          <Badge variant="default" className="text-xs">
+            <Map className="mr-1 h-3 w-3" />
+            {t("columns.publicMaps")}
+          </Badge>
+        ) : (
+          <span className="text-xs text-muted-foreground">—</span>
+        ),
+      defaultVisible: true,
+    },
+    {
+      key: "created_at",
+      header: t("columns.created"),
+      accessor: (row) => (
+        <span className="text-xs text-muted-foreground">
+          {row.created_at ? new Date(row.created_at).toLocaleDateString() : "—"}
+        </span>
+      ),
+      sortable: true,
+      defaultVisible: true,
+    },
+  ];
 
-      {branches.length === 0 ? (
-        <div className="py-8 text-center text-sm text-muted-foreground">No branches found.</div>
-      ) : (
-        <div className="space-y-2">
-          {branches.map((branch) => (
-            <div
-              key={branch.id}
-              className="flex items-center justify-between rounded-lg border px-4 py-3"
+  const filters: DataViewFilterDef[] = [
+    {
+      type: "text",
+      key: "slug",
+      label: t("filters.slug"),
+    },
+    {
+      type: "boolean",
+      key: "publicMapsEnabled",
+      label: t("filters.publicMaps"),
+    },
+    {
+      type: "date-range",
+      key: "createdRange",
+      label: t("filters.created"),
+      fromKey: "createdFrom",
+      toKey: "createdTo",
+    },
+  ];
+
+  const renderCompactItem = (row: OrgBranch) => (
+    <div className="flex items-center gap-2 py-0.5">
+      <Building2 className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+      <span className="truncate text-sm font-medium">{row.name}</span>
+      {row.slug && (
+        <span className="shrink-0 font-mono text-xs text-muted-foreground">{row.slug}</span>
+      )}
+    </div>
+  );
+
+  const renderDetail = (branch: OrgBranch) => (
+    <div className="space-y-5">
+      <div className="flex items-start gap-3">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md border">
+          <Building2 className="h-5 w-5 text-muted-foreground" />
+        </div>
+        <div className="min-w-0">
+          <h2 className="text-lg font-semibold leading-tight">{branch.name}</h2>
+          {branch.slug && <p className="font-mono text-sm text-muted-foreground">{branch.slug}</p>}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3 text-sm">
+        <div>
+          <p className="mb-0.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            {t("detail.slug")}
+          </p>
+          {branch.slug ? (
+            <Badge variant="outline" className="font-mono text-xs">
+              {branch.slug}
+            </Badge>
+          ) : (
+            <span className="text-muted-foreground">—</span>
+          )}
+        </div>
+        <div>
+          <p className="mb-0.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            {t("detail.publicMaps")}
+          </p>
+          {branch.public_warehouse_maps_enabled ? (
+            <Badge variant="default" className="text-xs">
+              <Map className="mr-1 h-3 w-3" />
+              {t("detail.publicMaps")}
+            </Badge>
+          ) : (
+            <span className="text-muted-foreground">—</span>
+          )}
+        </div>
+        <div>
+          <p className="mb-0.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            {t("detail.created")}
+          </p>
+          <span>{branch.created_at ? new Date(branch.created_at).toLocaleString() : "—"}</span>
+        </div>
+        <div>
+          <p className="mb-0.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            {t("detail.id")}
+          </p>
+          <span className="break-all font-mono text-xs text-muted-foreground">{branch.id}</span>
+        </div>
+      </div>
+
+      {(canUpdate || canDelete) && (
+        <div className="flex gap-2 border-t pt-3">
+          {canUpdate && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => openEdit(branch)}
+              disabled={isPending}
             >
-              <div className="flex items-center gap-3">
-                <Building2 className="h-4 w-4 text-muted-foreground shrink-0" />
-                <div>
-                  <p className="text-sm font-medium">{branch.name}</p>
-                  {branch.slug && (
-                    <Badge variant="outline" className="text-xs mt-0.5">
-                      {branch.slug}
-                    </Badge>
-                  )}
-                </div>
-              </div>
-              <div className="flex items-center gap-1">
-                {canUpdate && (
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-8 w-8"
-                    onClick={() => openEdit(branch)}
-                    disabled={isPending}
-                  >
-                    <Pencil className="h-4 w-4" />
-                  </Button>
-                )}
-                {canDelete && (
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-8 w-8 text-destructive hover:text-destructive"
-                    onClick={() => handleDelete(branch)}
-                    disabled={isPending}
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </Button>
-                )}
-              </div>
-            </div>
-          ))}
+              <Pencil className="mr-1.5 h-3.5 w-3.5" />
+              {t("actions.edit")}
+            </Button>
+          )}
+          {canDelete && (
+            <Button
+              size="sm"
+              variant="outline"
+              className="text-destructive hover:text-destructive"
+              onClick={() => handleDelete(branch)}
+              disabled={isPending}
+            >
+              <Trash2 className="mr-1.5 h-3.5 w-3.5" />
+              {t("actions.delete")}
+            </Button>
+          )}
         </div>
       )}
+    </div>
+  );
+
+  return (
+    <div className="flex h-[calc(100vh-4rem)] flex-col gap-4 p-4 md:p-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">{t("title")}</h1>
+          <p className="text-sm text-muted-foreground">{t("description")}</p>
+        </div>
+        {canCreate && (
+          <Button onClick={openCreate} size="sm">
+            <Plus className="mr-2 h-4 w-4" />
+            {t("createButton")}
+          </Button>
+        )}
+      </div>
+
+      <div className="flex-1 overflow-hidden">
+        <DataView<OrgBranch, OrgBranch>
+          entity="org-branches"
+          columns={columns}
+          filters={filters}
+          initialData={initialData}
+          queryKey={BRANCHES_DV_QUERY_KEY}
+          listFetcher={listFetcher}
+          detailFetcher={detailFetcher}
+          getRowId={(row) => row.id}
+          renderCompactItem={renderCompactItem}
+          renderDetail={renderDetail}
+          className="h-full"
+        />
+      </div>
 
       <Dialog open={dialogMode !== null} onOpenChange={(open) => !open && setDialogMode(null)}>
         <DialogContent aria-describedby={undefined}>
           <DialogHeader>
-            <DialogTitle>{dialogMode === "create" ? "Create Branch" : "Edit Branch"}</DialogTitle>
+            <DialogTitle>
+              {dialogMode === "create" ? t("dialog.titleCreate") : t("dialog.titleEdit")}
+            </DialogTitle>
           </DialogHeader>
           <div className="space-y-4 py-2">
             <div className="space-y-2">
-              <Label htmlFor="branch-name">Name</Label>
+              <Label htmlFor="branch-name">{t("dialog.name")}</Label>
               <Input
                 id="branch-name"
                 value={branchName}
                 onChange={(e) => setBranchName(e.target.value)}
-                placeholder="Branch name"
+                placeholder={t("dialog.namePlaceholder")}
                 maxLength={200}
                 disabled={isPending}
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="branch-slug">Slug</Label>
+              <Label htmlFor="branch-slug">{t("dialog.slug")}</Label>
               <Input
                 id="branch-slug"
                 value={branchSlug}
                 onChange={(e) =>
                   setBranchSlug(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ""))
                 }
-                placeholder="branch-slug (optional)"
+                placeholder={t("dialog.slugPlaceholder")}
                 maxLength={100}
                 disabled={isPending}
               />
-              <p className="text-xs text-muted-foreground">
-                Lowercase letters, numbers, hyphens only.
-              </p>
+              <p className="text-xs text-muted-foreground">{t("dialog.slugHint")}</p>
             </div>
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={() => setDialogMode(null)} disabled={isPending}>
-              Cancel
+              {t("dialog.cancel")}
             </Button>
             <Button onClick={handleSubmit} disabled={isPending || !branchName.trim()}>
-              {isPending ? "Saving…" : dialogMode === "create" ? "Create" : "Save"}
+              {isPending
+                ? t("dialog.saving")
+                : dialogMode === "create"
+                  ? t("dialog.create")
+                  : t("dialog.save")}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/apps/web/src/app/[locale]/dashboard/organization/branches/_utils/branches-data-view.ts
+++ b/apps/web/src/app/[locale]/dashboard/organization/branches/_utils/branches-data-view.ts
@@ -1,0 +1,81 @@
+import type { DataViewListParams, PaginatedResult } from "@/components/data-view/data-view.types";
+import type { OrgBranch } from "@/server/services/organization.service";
+
+function normalize(value: unknown): string {
+  return String(value ?? "").toLowerCase();
+}
+
+function matchesDateRange(isoDate: string | null, from: string | null, to: string | null): boolean {
+  if (!isoDate) return false;
+  const date = isoDate.slice(0, 10); // YYYY-MM-DD
+  if (from && date < from) return false;
+  if (to && date > to) return false;
+  return true;
+}
+
+export function filterSortBranches(
+  rows: OrgBranch[],
+  params: Pick<DataViewListParams, "search" | "filters" | "sort">
+): OrgBranch[] {
+  let result = [...rows];
+
+  // ── Global search ───────────────────────────────────────────────────────────
+  if (params.search) {
+    const q = params.search.toLowerCase();
+    result = result.filter(
+      (b) => b.name.toLowerCase().includes(q) || (b.slug?.toLowerCase().includes(q) ?? false)
+    );
+  }
+
+  // ── Filters ─────────────────────────────────────────────────────────────────
+  if (typeof params.filters.slug === "string" && params.filters.slug.trim()) {
+    const q = params.filters.slug.toLowerCase();
+    result = result.filter((b) => b.slug?.toLowerCase().includes(q) ?? false);
+  }
+
+  if (typeof params.filters.publicMapsEnabled === "boolean") {
+    result = result.filter((b) =>
+      params.filters.publicMapsEnabled
+        ? !!b.public_warehouse_maps_enabled
+        : !b.public_warehouse_maps_enabled
+    );
+  }
+
+  const createdFrom =
+    typeof params.filters.createdFrom === "string" ? params.filters.createdFrom : null;
+  const createdTo = typeof params.filters.createdTo === "string" ? params.filters.createdTo : null;
+  if (createdFrom || createdTo) {
+    result = result.filter((b) => matchesDateRange(b.created_at, createdFrom, createdTo));
+  }
+
+  // ── Sort ─────────────────────────────────────────────────────────────────────
+  if (params.sort) {
+    const { field, direction } = params.sort;
+    const dir = direction === "asc" ? 1 : -1;
+    result = result.sort((a, b) => {
+      const cmp = normalize(a[field as keyof OrgBranch]).localeCompare(
+        normalize(b[field as keyof OrgBranch]),
+        undefined,
+        { numeric: true }
+      );
+      // Secondary sort by id for stable ordering
+      if (cmp !== 0) return cmp * dir;
+      return a.id.localeCompare(b.id);
+    });
+  }
+
+  return result;
+}
+
+export function paginateBranches(
+  rows: OrgBranch[],
+  page: number,
+  pageSize: number
+): PaginatedResult<OrgBranch> {
+  return {
+    rows: rows.slice((page - 1) * pageSize, page * pageSize),
+    totalCount: rows.length,
+    page,
+    pageSize,
+  };
+}

--- a/apps/web/src/app/[locale]/dashboard/organization/branches/page.tsx
+++ b/apps/web/src/app/[locale]/dashboard/organization/branches/page.tsx
@@ -6,8 +6,14 @@ import { BRANCHES_READ } from "@/lib/constants/permissions";
 import { createClient } from "@/utils/supabase/server";
 import { OrgBranchesService } from "@/server/services/organization.service";
 import { BranchesClient } from "./_components/branches-client";
+import { parseDataViewSearchParams } from "@/components/data-view/data-view-search-params";
+import { filterSortBranches, paginateBranches } from "./_utils/branches-data-view";
 
-export default async function BranchesPage() {
+type PageProps = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export default async function BranchesPage({ searchParams }: PageProps) {
   const locale = await getLocale();
   const context = await loadDashboardContextV2();
   if (!context?.app.activeOrgId) return redirect({ href: "/sign-in", locale });
@@ -16,8 +22,19 @@ export default async function BranchesPage() {
     return redirect({ href: "/dashboard/organization/profile", locale });
   }
 
+  const params = await searchParams;
+  const urlState = parseDataViewSearchParams(params);
+
   const supabase = await createClient();
   const branchesResult = await OrgBranchesService.listBranches(supabase, context.app.activeOrgId);
+  const allBranches = branchesResult.success ? branchesResult.data : [];
 
-  return <BranchesClient initialBranches={branchesResult.success ? branchesResult.data : []} />;
+  const filtered = filterSortBranches(allBranches, {
+    search: urlState.search,
+    filters: urlState.filters,
+    sort: urlState.sort,
+  });
+  const initialData = paginateBranches(filtered, urlState.page, urlState.pageSize);
+
+  return <BranchesClient initialData={initialData} allBranches={allBranches} />;
 }

--- a/apps/web/src/app/actions/organization/branches.ts
+++ b/apps/web/src/app/actions/organization/branches.ts
@@ -5,7 +5,11 @@ import { createClient } from "@/utils/supabase/server";
 import { loadDashboardContextV2 } from "@/server/loaders/v2/load-dashboard-context.v2";
 import { checkPermission } from "@/lib/utils/permissions";
 import { entitlements, mapEntitlementError } from "@/server/guards/entitlements-guards";
-import { OrgBranchesService, type CreateBranchInput } from "@/server/services/organization.service";
+import {
+  OrgBranchesService,
+  type CreateBranchInput,
+  type OrgBranch,
+} from "@/server/services/organization.service";
 import { eventService } from "@/server/services/event.service";
 import { MODULE_ORGANIZATION_MANAGEMENT } from "@/lib/constants/modules";
 import {
@@ -15,6 +19,11 @@ import {
   BRANCHES_UPDATE,
   BRANCHES_DELETE,
 } from "@/lib/constants/permissions";
+import type { DataViewListParams, PaginatedResult } from "@/components/data-view/data-view.types";
+import {
+  filterSortBranches,
+  paginateBranches,
+} from "@/app/[locale]/dashboard/organization/branches/_utils/branches-data-view";
 
 const createBranchSchema = z.object({
   name: z.string().min(1).max(200),
@@ -234,4 +243,29 @@ export async function deleteBranchAction(rawInput: unknown) {
     if (mapped) return { success: false, error: mapped.message };
     return { success: false, error: "Unexpected error" };
   }
+}
+
+export async function listBranchesForDataViewAction(
+  params: DataViewListParams
+): Promise<PaginatedResult<OrgBranch>> {
+  const empty: PaginatedResult<OrgBranch> = {
+    rows: [],
+    totalCount: 0,
+    page: params.page,
+    pageSize: params.pageSize,
+  };
+
+  const result = await listBranchesAction();
+  if (!result.success) return empty;
+
+  const allBranches = (result as { success: true; data: OrgBranch[] }).data;
+  const filtered = filterSortBranches(allBranches, params);
+  return paginateBranches(filtered, params.page, params.pageSize);
+}
+
+export async function getBranchDetailAction(id: string): Promise<OrgBranch | null> {
+  const result = await listBranchesAction();
+  if (!result.success) return null;
+  const allBranches = (result as { success: true; data: OrgBranch[] }).data;
+  return allBranches.find((b) => b.id === id) ?? null;
 }


### PR DESCRIPTION
…lations

- Replace card list with DataView component: sortable columns (name, slug, created), filter toolbar (slug text, public maps boolean, date range), detail panel with edit/delete actions
- Client-side list/detail fetchers via allBranchesRef — filter/sort/paginate run synchronously in-memory, eliminating server round-trips on every interaction; server is only hit after create/update/delete mutations
- SSR initial data mirrors client logic: page.tsx parses searchParams and runs filterSortBranches + paginateBranches so deep-linked URLs render correctly without a client-side flash
- Shared utility _utils/branches-data-view.ts used by both page.tsx and listBranchesForDataViewAction to keep filter logic in one place
- Full i18n under modules.organizationManagement.branches in en.json and pl.json (title, description, columns, filters, detail, dialog, actions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced branches management with advanced list view featuring filtering, sorting, and pagination capabilities
  * Added full internationalization support for branches management interface in English and Polish

* **Tests**
  * Refactored branches client tests with improved testing utilities and expanded permission-based access coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->