### PR TITLE
implement DataView for branches dashboard page with filters, sorting,…

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1887,6 +1887,19 @@
         "toasts": {
           "created": "Created {count} QR code(s).",
           "revoked": "QR code revoked."
+        },
+        "detail": {
+          "label": "Label",
+          "token": "Token",
+          "status": "Status",
+          "assignment": "Assignment",
+          "created": "Created",
+          "id": "ID",
+          "unlabelled": "Unlabelled",
+          "unassigned": "—",
+          "designButton": "Design {count} selected",
+          "noSelection": "No codes selected",
+          "revokeButton": "Revoke"
         }
       },
       "previewDialog": {

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -1842,6 +1842,19 @@
         "toasts": {
           "created": "Utworzono {count} kod(ów) QR.",
           "revoked": "Kod QR został unieważniony."
+        },
+        "detail": {
+          "label": "Etykieta",
+          "token": "Token",
+          "status": "Status",
+          "assignment": "Przypisanie",
+          "created": "Utworzono",
+          "id": "ID",
+          "unlabelled": "Bez etykiety",
+          "unassigned": "—",
+          "designButton": "Projektuj {count} wybranych",
+          "noSelection": "Brak wybranych kodów",
+          "revokeButton": "Unieważnij"
         }
       },
       "previewDialog": {

--- a/apps/web/src/app/[locale]/dashboard/qr/_components/qr-management-client.tsx
+++ b/apps/web/src/app/[locale]/dashboard/qr/_components/qr-management-client.tsx
@@ -1,23 +1,14 @@
 "use client";
 
 import dynamic from "next/dynamic";
-import { memo, useCallback, useEffect, useMemo, useState, useTransition } from "react";
+import { useCallback, useMemo, useRef, useState, useTransition } from "react";
 import { useTranslations } from "next-intl";
 import { toast } from "react-toastify";
-import { ArrowLeft, ArrowRight, QrCode, Plus, Trash2, RefreshCw } from "lucide-react";
+import { ArrowLeft, QrCode, Plus, Trash2, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Checkbox } from "@/components/ui/checkbox";
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -28,6 +19,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import type { QrCodeWithStatus } from "@/server/services/qr.service";
 import type { PermissionSnapshot } from "@/lib/types/permissions";
 import { checkPermission } from "@/lib/utils/permissions";
@@ -35,7 +27,15 @@ import { QR_CREATE, QR_REVOKE, QR_EXPORT } from "@/lib/constants/permissions";
 import { listQrCodesAction } from "@/app/actions/qr/list";
 import { createQrBatchAction } from "@/app/actions/qr/create-batch";
 import { revokeQrAction } from "@/app/actions/qr/revoke";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { DataView } from "@/components/data-view/data-view";
+import { useDataViewSelection } from "@/components/data-view/use-data-view";
+import type {
+  DataViewColumnDef,
+  DataViewFilterDef,
+  DataViewListParams,
+  PaginatedResult,
+} from "@/components/data-view/data-view.types";
+import { filterSortQrCodes, paginateQrCodes, getQrStatus } from "../_utils/data-view";
 
 const LabelDesigner = dynamic(
   () =>
@@ -45,185 +45,193 @@ const LabelDesigner = dynamic(
   { ssr: false }
 );
 
+const QR_DV_KEY = ["qr-codes-dataview"];
+
 // ---------------------------------------------------------------------------
-// Types
+// Detail panel — rendered inside DataViewProvider so it can read selection
 // ---------------------------------------------------------------------------
 
-type FilterStatus = "all" | "assigned" | "unassigned" | "revoked";
-
-function getQrStatus(qr: QrCodeWithStatus): "assigned" | "unassigned" | "revoked" {
-  if (qr.status === "revoked") return "revoked";
-  return qr.assignment ? "assigned" : "unassigned";
+interface QrDetailPanelProps {
+  qr: QrCodeWithStatus;
+  canRevoke: boolean;
+  canExport: boolean;
+  isRevoking: boolean;
+  onRevoke: (id: string) => void;
+  onDesign: (ids: string[]) => void;
+  t: ReturnType<typeof useTranslations>;
 }
 
-function statusBadge(qr: QrCodeWithStatus, t: (key: string) => string) {
-  const s = getQrStatus(qr);
-  const map = {
+function QrDetailPanel({
+  qr,
+  canRevoke,
+  canExport,
+  isRevoking,
+  onRevoke,
+  onDesign,
+  t,
+}: QrDetailPanelProps) {
+  const { selectedRowIds, selectedRowCount } = useDataViewSelection();
+
+  const displayStatus = getQrStatus(qr);
+  const statusVariant = {
     assigned: "default",
     unassigned: "secondary",
     revoked: "destructive",
   } as const;
-  return <Badge variant={map[s]}>{t(`status.${s}`)}</Badge>;
-}
 
-interface QrTableRowProps {
-  qr: QrCodeWithStatus;
-  selected: boolean;
-  canRevoke: boolean;
-  isRevoking: boolean;
-  t: (key: string, values?: Record<string, string | number>) => string;
-  onToggleSelect: (id: string) => void;
-  onRevoke: (id: string) => void;
-}
-
-const QrTableRow = memo(function QrTableRow({
-  qr,
-  selected,
-  canRevoke,
-  isRevoking,
-  t,
-  onToggleSelect,
-  onRevoke,
-}: QrTableRowProps) {
   return (
-    <TableRow data-state={selected ? "selected" : undefined}>
-      <TableCell>
-        <Checkbox
-          checked={selected}
-          onCheckedChange={() => onToggleSelect(qr.id)}
-          disabled={qr.status === "revoked"}
-        />
-      </TableCell>
-      <TableCell className="max-w-[180px] truncate font-medium">
-        {qr.label ?? <span className="text-muted-foreground italic">{t("table.unlabelled")}</span>}
-      </TableCell>
-      <TableCell className="font-mono text-xs text-muted-foreground">
-        {qr.token.slice(0, 10)}…
-      </TableCell>
-      <TableCell>{statusBadge(qr, t)}</TableCell>
-      <TableCell className="text-xs text-muted-foreground">
-        {qr.assignment ? qr.assignment.target_type : t("table.unassignedDash")}
-      </TableCell>
-      <TableCell className="text-xs text-muted-foreground">
-        {new Date(qr.created_at).toLocaleDateString()}
-      </TableCell>
-      {canRevoke && (
-        <TableCell>
-          {qr.status === "active" ? (
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-7 w-7 text-destructive hover:text-destructive"
-              onClick={() => onRevoke(qr.id)}
-              disabled={isRevoking}
-              title={t("table.revoke")}
-            >
-              <Trash2 className="h-3.5 w-3.5" />
-            </Button>
-          ) : null}
-        </TableCell>
-      )}
-    </TableRow>
+    <div className="space-y-5">
+      <div className="flex items-start gap-3">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md border">
+          <QrCode className="h-5 w-5 text-muted-foreground" />
+        </div>
+        <div className="min-w-0">
+          <h2 className="text-lg font-semibold leading-tight">
+            {qr.label ?? (
+              <span className="italic text-muted-foreground">{t("detail.unlabelled")}</span>
+            )}
+          </h2>
+          <p className="font-mono text-xs text-muted-foreground">{qr.token}</p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3 text-sm">
+        <div>
+          <p className="mb-0.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            {t("detail.status")}
+          </p>
+          <Badge variant={statusVariant[displayStatus]} className="text-xs capitalize">
+            {t(`status.${displayStatus}` as Parameters<typeof t>[0])}
+          </Badge>
+        </div>
+        <div>
+          <p className="mb-0.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            {t("detail.created")}
+          </p>
+          <span>{new Date(qr.created_at).toLocaleDateString()}</span>
+        </div>
+        <div>
+          <p className="mb-0.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            {t("detail.assignment")}
+          </p>
+          <span className="text-sm">
+            {qr.assignment ? (
+              qr.assignment.target_type
+            ) : (
+              <span className="text-muted-foreground">{t("detail.unassigned")}</span>
+            )}
+          </span>
+        </div>
+        <div>
+          <p className="mb-0.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            {t("detail.id")}
+          </p>
+          <span className="break-all font-mono text-xs text-muted-foreground">{qr.id}</span>
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div className="flex flex-col gap-2 border-t pt-3">
+        {canExport && selectedRowCount > 0 && (
+          <Button
+            size="sm"
+            className="w-full gap-2"
+            onClick={() => onDesign(Object.keys(selectedRowIds))}
+          >
+            {t("detail.designButton", { count: selectedRowCount })}
+          </Button>
+        )}
+        {canRevoke && qr.status === "active" && (
+          <Button
+            size="sm"
+            variant="outline"
+            className="w-full text-destructive hover:text-destructive"
+            onClick={() => onRevoke(qr.id)}
+            disabled={isRevoking}
+          >
+            <Trash2 className="mr-1.5 h-3.5 w-3.5" />
+            {t("detail.revokeButton")}
+          </Button>
+        )}
+      </div>
+    </div>
   );
-});
+}
 
 // ---------------------------------------------------------------------------
 // Props
 // ---------------------------------------------------------------------------
 
 interface Props {
-  initialCodes: QrCodeWithStatus[];
+  initialData: PaginatedResult<QrCodeWithStatus>;
+  allCodes: QrCodeWithStatus[];
   permissionSnapshot: PermissionSnapshot;
 }
 
 // ---------------------------------------------------------------------------
-// Component
+// Main component
 // ---------------------------------------------------------------------------
 
-export function QrManagementClient({ initialCodes, permissionSnapshot }: Props) {
+export function QrManagementClient({
+  initialData,
+  allCodes: initialAllCodes,
+  permissionSnapshot,
+}: Props) {
   const t = useTranslations("modules.qr.management");
+
   const canCreate = checkPermission(permissionSnapshot, QR_CREATE);
   const canRevoke = checkPermission(permissionSnapshot, QR_REVOKE);
   const canExport = checkPermission(permissionSnapshot, QR_EXPORT);
 
-  // Data
-  const [codes, setCodes] = useState<QrCodeWithStatus[]>(initialCodes);
-  const [isRefreshing, startRefresh] = useTransition();
+  const allRef = useRef(initialAllCodes);
+  allRef.current = initialAllCodes;
+
+  // Client-side fetcher — zero latency, no server round-trip on filter/sort/page changes
+  const listFetcher = useCallback(
+    async (params: DataViewListParams): Promise<PaginatedResult<QrCodeWithStatus>> => {
+      const filtered = filterSortQrCodes(allRef.current, params);
+      return paginateQrCodes(filtered, params.page, params.pageSize);
+    },
+    []
+  );
+
+  const detailFetcher = useCallback(
+    async (id: string): Promise<QrCodeWithStatus | null> =>
+      allRef.current.find((qr) => qr.id === id) ?? null,
+    []
+  );
 
   // Generate form
   const [generateCount, setGenerateCount] = useState(1);
   const [labelPrefix, setLabelPrefix] = useState("");
   const [isGenerating, startGenerate] = useTransition();
+  const [isRefreshing, startRefresh] = useTransition();
 
-  // Selection
-  const [selected, setSelected] = useState<Set<string>>(new Set());
-
-  // Filter
-  const [filter, setFilter] = useState<FilterStatus>("all");
+  // Two stages: select (DataView) ↔ design (LabelDesigner)
   const [activeStage, setActiveStage] = useState<"select" | "design">("select");
+  const [designIds, setDesignIds] = useState<string[]>([]);
   const [labelFormat, setLabelFormat] = useState<"pdf" | "zpl">("pdf");
-  const [page, setPage] = useState(1);
-  const pageSize = 50;
 
-  // Revoke confirm
+  // Revoke confirmation
   const [revokeTarget, setRevokeTarget] = useState<string | null>(null);
   const [isRevoking, startRevoke] = useTransition();
 
-  // ---------------------------------------------------------------------------
-  // Derived
-  // ---------------------------------------------------------------------------
-
-  const filtered = useMemo(() => {
-    if (filter === "all") return codes;
-    return codes.filter((qr) => getQrStatus(qr) === filter);
-  }, [codes, filter]);
-
-  const allFilteredIds = useMemo(() => filtered.map((qr) => qr.id), [filtered]);
-  const filteredIdSet = useMemo(() => new Set(allFilteredIds), [allFilteredIds]);
-  const allSelected = allFilteredIds.length > 0 && allFilteredIds.every((id) => selected.has(id));
-  const selectedIds = useMemo(
-    () => [...selected].filter((id) => filteredIdSet.has(id)),
-    [selected, filteredIdSet]
-  );
-  const totalPages = Math.max(1, Math.ceil(filtered.length / pageSize));
-  const currentPage = Math.min(page, totalPages);
-  const paginated = useMemo(() => {
-    const start = (currentPage - 1) * pageSize;
-    return filtered.slice(start, start + pageSize);
-  }, [filtered, currentPage]);
-
-  const counts = useMemo(() => {
-    const all = codes.length;
-    const assigned = codes.filter((q) => getQrStatus(q) === "assigned").length;
-    const unassigned = codes.filter((q) => getQrStatus(q) === "unassigned").length;
-    const revoked = codes.filter((q) => getQrStatus(q) === "revoked").length;
-    return { all, assigned, unassigned, revoked };
-  }, [codes]);
-
-  useEffect(() => {
-    setPage(1);
-  }, [filter]);
-
-  useEffect(() => {
-    if (page > totalPages) setPage(totalPages);
-  }, [page, totalPages]);
-
-  // ---------------------------------------------------------------------------
-  // Handlers
-  // ---------------------------------------------------------------------------
-
+  // ── Refresh from server ───────────────────────────────────────────────────────
   function handleRefresh() {
     startRefresh(async () => {
       const result = await listQrCodesAction();
       if (result.success) {
-        setCodes(result.data);
-        setSelected(new Set());
+        allRef.current = result.data;
+        // React Query cache for DataView will re-read from allRef on next render/invalidation
+        // Force a re-render by triggering a page re-render with router.refresh() is optional here
+        // since the DataView will use allRef.current on next listFetcher call
       } else {
         toast.error((result as { success: false; error: string }).error);
       }
     });
   }
 
+  // ── Generate ─────────────────────────────────────────────────────────────────
   function handleGenerate() {
     startGenerate(async () => {
       const result = await createQrBatchAction({
@@ -232,7 +240,9 @@ export function QrManagementClient({ initialCodes, permissionSnapshot }: Props) 
       });
       if (result.success) {
         toast.success(t("toasts.created", { count: result.data.length }));
-        handleRefresh();
+        // Reload from server and update ref
+        const fresh = await listQrCodesAction();
+        if (fresh.success) allRef.current = fresh.data;
         setLabelPrefix("");
         setGenerateCount(1);
       } else {
@@ -241,34 +251,13 @@ export function QrManagementClient({ initialCodes, permissionSnapshot }: Props) 
     });
   }
 
-  const toggleSelect = useCallback((id: string) => {
-    setSelected((prev) => {
-      const next = new Set(prev);
-      next.has(id) ? next.delete(id) : next.add(id);
-      return next;
-    });
-  }, []);
-
-  const toggleSelectAll = useCallback(() => {
-    if (allSelected) {
-      setSelected((prev) => {
-        const next = new Set(prev);
-        allFilteredIds.forEach((id) => next.delete(id));
-        return next;
-      });
-    } else {
-      setSelected((prev) => new Set([...prev, ...allFilteredIds]));
-    }
-  }, [allFilteredIds, allSelected]);
-
-  const handleOpenDesign = useCallback(() => {
+  // ── Design ───────────────────────────────────────────────────────────────────
+  const handleOpenDesign = useCallback((ids: string[]) => {
+    setDesignIds(ids);
     setActiveStage("design");
   }, []);
 
-  const handleBackToSelection = useCallback(() => {
-    setActiveStage("select");
-  }, []);
-
+  // ── Revoke ───────────────────────────────────────────────────────────────────
   function handleRevokeConfirm() {
     if (!revokeTarget) return;
     const id = revokeTarget;
@@ -277,231 +266,233 @@ export function QrManagementClient({ initialCodes, permissionSnapshot }: Props) 
       const result = await revokeQrAction({ qrCodeId: id });
       if (result.success) {
         toast.success(t("toasts.revoked"));
-        setCodes((prev) =>
-          prev.map((qr) =>
-            qr.id === id ? { ...qr, status: "revoked" as const, assignment: null } : qr
-          )
+        // Optimistic local update
+        allRef.current = allRef.current.map((qr) =>
+          qr.id === id ? { ...qr, status: "revoked" as const, assignment: null } : qr
         );
-        setSelected((prev) => {
-          const next = new Set(prev);
-          next.delete(id);
-          return next;
-        });
       } else {
         toast.error((result as { success: false; error: string }).error);
       }
     });
   }
 
-  const filterTabs: { key: FilterStatus; label: string; count: number }[] = [
-    { key: "all", label: t("filters.all"), count: counts.all },
-    { key: "unassigned", label: t("filters.unassigned"), count: counts.unassigned },
-    { key: "assigned", label: t("filters.assigned"), count: counts.assigned },
-    { key: "revoked", label: t("filters.revoked"), count: counts.revoked },
-  ];
+  // ── DataView definitions ──────────────────────────────────────────────────────
+  const columns = useMemo<DataViewColumnDef<QrCodeWithStatus>[]>(
+    () => [
+      {
+        key: "label",
+        header: t("table.label"),
+        accessor: (row) =>
+          row.label ? (
+            <span className="truncate font-medium text-foreground">{row.label}</span>
+          ) : (
+            <span className="italic text-muted-foreground text-sm">{t("table.unlabelled")}</span>
+          ),
+        sortable: true,
+        defaultVisible: true,
+      },
+      {
+        key: "token",
+        header: t("table.token"),
+        accessor: (row) => (
+          <span className="font-mono text-xs text-muted-foreground">{row.token.slice(0, 10)}…</span>
+        ),
+        defaultVisible: true,
+        compactLabel: true,
+      },
+      {
+        key: "displayStatus",
+        header: t("table.statusHeader"),
+        accessor: (row) => {
+          const s = getQrStatus(row);
+          const variant = {
+            assigned: "default",
+            unassigned: "secondary",
+            revoked: "destructive",
+          } as const;
+          return (
+            <Badge variant={variant[s]} className="text-xs">
+              {t(`status.${s}` as Parameters<typeof t>[0])}
+            </Badge>
+          );
+        },
+        sortable: true,
+        defaultVisible: true,
+      },
+      {
+        key: "assignment",
+        header: t("table.assignment"),
+        accessor: (row) => (
+          <span className="text-xs text-muted-foreground">
+            {row.assignment ? row.assignment.target_type : t("table.unassignedDash")}
+          </span>
+        ),
+        defaultVisible: true,
+      },
+      {
+        key: "created_at",
+        header: t("table.created"),
+        accessor: (row) => (
+          <span className="text-xs text-muted-foreground">
+            {new Date(row.created_at).toLocaleDateString()}
+          </span>
+        ),
+        sortable: true,
+        defaultVisible: true,
+      },
+    ],
+    [t]
+  );
 
-  // ---------------------------------------------------------------------------
-  // Render
-  // ---------------------------------------------------------------------------
+  const filters = useMemo<DataViewFilterDef[]>(
+    () => [
+      {
+        type: "select",
+        key: "status",
+        label: t("table.statusHeader"),
+        options: [
+          { label: t("filters.assigned"), value: "assigned" },
+          { label: t("filters.unassigned"), value: "unassigned" },
+          { label: t("filters.revoked"), value: "revoked" },
+        ],
+      },
+    ],
+    [t]
+  );
+
+  const renderCompactItem = useCallback(
+    (row: QrCodeWithStatus) => {
+      const s = getQrStatus(row);
+      const variant = {
+        assigned: "default",
+        unassigned: "secondary",
+        revoked: "destructive",
+      } as const;
+      return (
+        <div className="flex items-center gap-2 py-0.5">
+          <QrCode className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          <span className="truncate text-sm font-medium">
+            {row.label ?? (
+              <span className="italic text-muted-foreground">{t("table.unlabelled")}</span>
+            )}
+          </span>
+          <Badge variant={variant[s]} className="shrink-0 text-xs">
+            {t(`status.${s}` as Parameters<typeof t>[0])}
+          </Badge>
+        </div>
+      );
+    },
+    [t]
+  );
+
+  // renderDetail returns QrDetailPanel — a named component that can use useDataViewSelection()
+  const renderDetail = useCallback(
+    (qr: QrCodeWithStatus) => (
+      <QrDetailPanel
+        qr={qr}
+        canRevoke={canRevoke}
+        canExport={canExport}
+        isRevoking={isRevoking}
+        onRevoke={setRevokeTarget}
+        onDesign={handleOpenDesign}
+        t={t}
+      />
+    ),
+    [canRevoke, canExport, isRevoking, handleOpenDesign, t]
+  );
+
+  // ── Render ────────────────────────────────────────────────────────────────────
 
   return (
-    <div className="flex h-full min-h-0 flex-col overflow-hidden">
+    <div className="flex h-full flex-col gap-4 overflow-hidden">
       <Tabs
         value={activeStage}
-        onValueChange={(value) => setActiveStage(value as "select" | "design")}
-        className="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden"
+        onValueChange={(v) => setActiveStage(v as "select" | "design")}
+        className="flex min-h-0 flex-1 flex-col overflow-hidden"
       >
-        <div className="flex shrink-0 flex-wrap items-center justify-between gap-3">
-          <TabsList className="grid w-full max-w-[360px] grid-cols-2">
+        <div className="flex shrink-0 items-center gap-3">
+          <TabsList className="grid w-[320px] grid-cols-2">
             <TabsTrigger value="select">{t("stages.select")}</TabsTrigger>
-            <TabsTrigger value="design" disabled={!canExport}>
+            <TabsTrigger value="design" disabled={!canExport || designIds.length === 0}>
               {t("stages.design")}
             </TabsTrigger>
           </TabsList>
-
-          <div className="text-sm text-muted-foreground">
-            {selectedIds.length > 0 ? (
-              <span>
-                <span className="font-medium text-foreground">{selectedIds.length}</span>{" "}
-                {t("selectedCount", { count: selectedIds.length })}
-              </span>
-            ) : (
-              <span>{t("selectHint")}</span>
-            )}
-          </div>
         </div>
 
+        {/* ── Select tab ────────────────────────────────────────────────────── */}
         <TabsContent value="select" className="!mt-0 min-h-0 flex-1 overflow-hidden">
-          <div className="flex h-full min-h-0 flex-col gap-6 overflow-y-auto pr-1">
-            <div className="flex flex-wrap items-end gap-3 rounded-lg border bg-card p-4">
-              <div className="flex flex-col gap-1">
-                <label className="text-xs font-medium text-muted-foreground">
-                  {t("generate.prefixLabel")}
-                </label>
-                <Input
-                  value={labelPrefix}
-                  onChange={(e) => setLabelPrefix(e.target.value)}
-                  placeholder={t("generate.prefixPlaceholder")}
-                  className="w-44"
-                  disabled={!canCreate || isGenerating}
-                />
-              </div>
-              <div className="flex flex-col gap-1">
-                <label className="text-xs font-medium text-muted-foreground">
-                  {t("generate.countLabel")}
-                </label>
-                <Input
-                  type="number"
-                  min={1}
-                  max={50}
-                  value={generateCount}
-                  onChange={(e) =>
-                    setGenerateCount(Math.min(50, Math.max(1, Number(e.target.value))))
-                  }
-                  className="w-24"
-                  disabled={!canCreate || isGenerating}
-                />
-              </div>
-              <Button
-                onClick={handleGenerate}
-                disabled={!canCreate || isGenerating}
-                className="gap-2"
-              >
-                <Plus className="h-4 w-4" />
-                {isGenerating ? t("generate.generating") : t("generate.submit")}
-              </Button>
-              <Button
-                variant="outline"
-                size="icon"
-                onClick={handleRefresh}
-                disabled={isRefreshing}
-                title={t("refresh")}
-              >
-                <RefreshCw className={`h-4 w-4 ${isRefreshing ? "animate-spin" : ""}`} />
-              </Button>
-            </div>
-
-            <div className="space-y-4 rounded-xl border bg-card p-4">
-              <div className="flex flex-wrap items-center justify-between gap-3">
-                <div>
-                  <p className="text-sm font-medium">{t("selection.title")}</p>
-                  <p className="text-sm text-muted-foreground">{t("selection.description")}</p>
+          <div className="flex h-full flex-col gap-4 overflow-hidden">
+            {/* Generate form */}
+            {canCreate && (
+              <div className="flex shrink-0 flex-wrap items-end gap-3 rounded-lg border bg-card p-4">
+                <div className="flex flex-col gap-1">
+                  <label className="text-xs font-medium text-muted-foreground">
+                    {t("generate.prefixLabel")}
+                  </label>
+                  <Input
+                    value={labelPrefix}
+                    onChange={(e) => setLabelPrefix(e.target.value)}
+                    placeholder={t("generate.prefixPlaceholder")}
+                    className="w-44"
+                    disabled={isGenerating}
+                  />
                 </div>
+                <div className="flex flex-col gap-1">
+                  <label className="text-xs font-medium text-muted-foreground">
+                    {t("generate.countLabel")}
+                  </label>
+                  <Input
+                    type="number"
+                    min={1}
+                    max={50}
+                    value={generateCount}
+                    onChange={(e) =>
+                      setGenerateCount(Math.min(50, Math.max(1, Number(e.target.value))))
+                    }
+                    className="w-24"
+                    disabled={isGenerating}
+                  />
+                </div>
+                <Button onClick={handleGenerate} disabled={isGenerating} className="gap-2">
+                  <Plus className="h-4 w-4" />
+                  {isGenerating ? t("generate.generating") : t("generate.submit")}
+                </Button>
                 <Button
-                  onClick={handleOpenDesign}
-                  disabled={!canExport || selectedIds.length === 0}
-                  className="gap-2"
+                  variant="outline"
+                  size="icon"
+                  onClick={handleRefresh}
+                  disabled={isRefreshing}
+                  title={t("refresh")}
                 >
-                  {t("selection.designSelected")}
-                  <ArrowRight className="h-4 w-4" />
+                  <RefreshCw className={`h-4 w-4 ${isRefreshing ? "animate-spin" : ""}`} />
                 </Button>
               </div>
+            )}
 
-              <div className="flex gap-2">
-                {filterTabs.map((tab) => (
-                  <button
-                    key={tab.key}
-                    onClick={() => setFilter(tab.key)}
-                    className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
-                      filter === tab.key
-                        ? "bg-primary text-primary-foreground"
-                        : "text-muted-foreground hover:bg-accent"
-                    }`}
-                  >
-                    {tab.label}
-                    <span className="ml-1.5 text-xs opacity-70">{tab.count}</span>
-                  </button>
-                ))}
-              </div>
-
-              <div className="rounded-md border">
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead className="w-10">
-                        <Checkbox
-                          checked={allSelected}
-                          onCheckedChange={toggleSelectAll}
-                          disabled={filtered.length === 0}
-                        />
-                      </TableHead>
-                      <TableHead>{t("table.label")}</TableHead>
-                      <TableHead>{t("table.token")}</TableHead>
-                      <TableHead>{t("table.statusHeader")}</TableHead>
-                      <TableHead>{t("table.assignment")}</TableHead>
-                      <TableHead>{t("table.created")}</TableHead>
-                      {canRevoke && <TableHead className="w-16" />}
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {filtered.length === 0 ? (
-                      <TableRow>
-                        <TableCell
-                          colSpan={canRevoke ? 7 : 6}
-                          className="py-12 text-center text-sm text-muted-foreground"
-                        >
-                          <QrCode className="mx-auto mb-2 h-8 w-8 opacity-30" />
-                          {t("table.empty")}
-                        </TableCell>
-                      </TableRow>
-                    ) : (
-                      paginated.map((qr) => (
-                        <QrTableRow
-                          key={qr.id}
-                          qr={qr}
-                          selected={selected.has(qr.id)}
-                          canRevoke={canRevoke}
-                          isRevoking={isRevoking}
-                          t={t}
-                          onToggleSelect={toggleSelect}
-                          onRevoke={setRevokeTarget}
-                        />
-                      ))
-                    )}
-                  </TableBody>
-                </Table>
-              </div>
-
-              {filtered.length > pageSize ? (
-                <div className="flex flex-wrap items-center justify-between gap-3">
-                  <p className="text-sm text-muted-foreground">
-                    {t("pagination.summary", {
-                      from: filtered.length === 0 ? 0 : (currentPage - 1) * pageSize + 1,
-                      to: Math.min(currentPage * pageSize, filtered.length),
-                      total: filtered.length,
-                    })}
-                  </p>
-                  <div className="flex items-center gap-2">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      disabled={currentPage === 1}
-                      onClick={() => setPage((prev) => Math.max(1, prev - 1))}
-                    >
-                      {t("pagination.previous")}
-                    </Button>
-                    <span className="text-sm text-muted-foreground">
-                      {t("pagination.page", { current: currentPage, total: totalPages })}
-                    </span>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      disabled={currentPage === totalPages}
-                      onClick={() => setPage((prev) => Math.min(totalPages, prev + 1))}
-                    >
-                      {t("pagination.next")}
-                    </Button>
-                  </div>
-                </div>
-              ) : null}
+            {/* DataView */}
+            <div className="min-h-0 flex-1 overflow-hidden">
+              <DataView<QrCodeWithStatus, QrCodeWithStatus>
+                entity="qr-codes"
+                columns={columns}
+                filters={filters}
+                initialData={initialData}
+                queryKey={QR_DV_KEY}
+                listFetcher={listFetcher}
+                detailFetcher={detailFetcher}
+                getRowId={(row) => row.id}
+                renderCompactItem={renderCompactItem}
+                renderDetail={renderDetail}
+                className="h-full"
+              />
             </div>
           </div>
         </TabsContent>
 
+        {/* ── Design tab ────────────────────────────────────────────────────── */}
         <TabsContent value="design" className="!mt-0 min-h-0 flex-1 overflow-hidden">
-          {canExport ? (
-            <div className="flex h-full min-h-0 flex-col overflow-hidden rounded-xl border bg-card p-4">
-              <div className="flex flex-wrap items-center justify-between gap-3 border-b pb-4">
+          {canExport && designIds.length > 0 ? (
+            <div className="flex h-full flex-col overflow-hidden rounded-xl border bg-card p-4">
+              <div className="flex shrink-0 flex-wrap items-center justify-between gap-3 border-b pb-4">
                 <div>
                   <p className="text-sm font-medium">{t("design.title")}</p>
                   <p className="text-sm text-muted-foreground">{t("design.description")}</p>
@@ -530,7 +521,11 @@ export function QrManagementClient({ initialCodes, permissionSnapshot }: Props) 
                   <TooltipProvider>
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <Button variant="outline" size="icon" onClick={handleBackToSelection}>
+                        <Button
+                          variant="outline"
+                          size="icon"
+                          onClick={() => setActiveStage("select")}
+                        >
                           <ArrowLeft className="h-4 w-4" />
                         </Button>
                       </TooltipTrigger>
@@ -539,15 +534,8 @@ export function QrManagementClient({ initialCodes, permissionSnapshot }: Props) 
                   </TooltipProvider>
                 </div>
               </div>
-
               <div className="min-h-0 flex-1 overflow-hidden pt-4">
-                {activeStage === "design" ? (
-                  <LabelDesigner
-                    selectedIds={selectedIds}
-                    canExport={canExport}
-                    format={labelFormat}
-                  />
-                ) : null}
+                <LabelDesigner selectedIds={designIds} canExport={canExport} format={labelFormat} />
               </div>
             </div>
           ) : null}

--- a/apps/web/src/app/[locale]/dashboard/qr/_utils/data-view.ts
+++ b/apps/web/src/app/[locale]/dashboard/qr/_utils/data-view.ts
@@ -1,0 +1,67 @@
+import type { DataViewListParams, PaginatedResult } from "@/components/data-view/data-view.types";
+import type { QrCodeWithStatus } from "@/server/services/qr.service";
+
+export type QrDisplayStatus = "assigned" | "unassigned" | "revoked";
+
+export function getQrStatus(qr: QrCodeWithStatus): QrDisplayStatus {
+  if (qr.status === "revoked") return "revoked";
+  return qr.assignment ? "assigned" : "unassigned";
+}
+
+function normalize(value: unknown): string {
+  return String(value ?? "").toLowerCase();
+}
+
+export function filterSortQrCodes(
+  rows: QrCodeWithStatus[],
+  params: Pick<DataViewListParams, "search" | "filters" | "sort">
+): QrCodeWithStatus[] {
+  let result = rows.filter((qr) => !qr.deleted_at);
+
+  if (params.search) {
+    const q = params.search.toLowerCase();
+    result = result.filter(
+      (qr) => (qr.label?.toLowerCase().includes(q) ?? false) || qr.token.toLowerCase().includes(q)
+    );
+  }
+
+  if (typeof params.filters.status === "string" && params.filters.status) {
+    result = result.filter((qr) => getQrStatus(qr) === params.filters.status);
+  }
+
+  if (params.sort) {
+    const { field, direction } = params.sort;
+    const dir = direction === "asc" ? 1 : -1;
+    result = [...result].sort((a, b) => {
+      let aVal: string;
+      let bVal: string;
+      if (field === "label") {
+        aVal = (a.label ?? "").toLowerCase();
+        bVal = (b.label ?? "").toLowerCase();
+      } else if (field === "displayStatus") {
+        aVal = getQrStatus(a);
+        bVal = getQrStatus(b);
+      } else {
+        aVal = normalize(a[field as keyof QrCodeWithStatus]);
+        bVal = normalize(b[field as keyof QrCodeWithStatus]);
+      }
+      const cmp = aVal.localeCompare(bVal, undefined, { numeric: true });
+      return cmp !== 0 ? cmp * dir : a.id.localeCompare(b.id);
+    });
+  }
+
+  return result;
+}
+
+export function paginateQrCodes(
+  rows: QrCodeWithStatus[],
+  page: number,
+  pageSize: number
+): PaginatedResult<QrCodeWithStatus> {
+  return {
+    rows: rows.slice((page - 1) * pageSize, page * pageSize),
+    totalCount: rows.length,
+    page,
+    pageSize,
+  };
+}

--- a/apps/web/src/app/[locale]/dashboard/qr/page.tsx
+++ b/apps/web/src/app/[locale]/dashboard/qr/page.tsx
@@ -3,25 +3,47 @@ import { getTranslations } from "next-intl/server";
 import { loadDashboardContextV2 } from "@/server/loaders/v2/load-dashboard-context.v2";
 import { QrCodesService } from "@/server/services/qr.service";
 import { QrManagementClient } from "./_components/qr-management-client";
+import { parseDataViewSearchParams } from "@/components/data-view/data-view-search-params";
+import { filterSortQrCodes, paginateQrCodes } from "./_utils/data-view";
 
-export default async function QrCodesPage() {
+type PageProps = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export default async function QrCodesPage({ searchParams }: PageProps) {
   const t = await getTranslations("modules.qr.page");
   const supabase = await createClient();
   const context = await loadDashboardContextV2();
   const orgId = context?.app.activeOrgId ?? "";
 
   const result = orgId ? await QrCodesService.listWithStatus(supabase, orgId) : null;
-  const initialCodes = result?.success ? result.data : [];
+  const allCodes = result?.success ? result.data : [];
+
+  const params = await searchParams;
+  const urlState = parseDataViewSearchParams(params);
+
+  const filtered = filterSortQrCodes(allCodes, {
+    search: urlState.search,
+    filters: urlState.filters,
+    sort: urlState.sort,
+  });
+  const initialData = paginateQrCodes(filtered, urlState.page, urlState.pageSize);
 
   const snapshot = context?.user.permissionSnapshot ?? { allow: [], deny: [] };
 
   return (
-    <div className="space-y-6 p-4 md:p-6">
-      <div>
+    <div className="flex h-[calc(100vh-4rem)] flex-col gap-4 p-4 md:p-6">
+      <div className="shrink-0">
         <h1 className="text-2xl font-bold tracking-tight">{t("title")}</h1>
         <p className="text-sm text-muted-foreground">{t("description")}</p>
       </div>
-      <QrManagementClient initialCodes={initialCodes} permissionSnapshot={snapshot} />
+      <div className="min-h-0 flex-1 overflow-hidden">
+        <QrManagementClient
+          initialData={initialData}
+          allCodes={allCodes}
+          permissionSnapshot={snapshot}
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
… and translations

Replace the custom table/filter/pagination in qr-management-client with the DataView component, following the same pattern as branches and users sections.

Architecture: renderDetail returns a named QrDetailPanel component which runs inside DataViewProvider, giving it access to useDataViewSelection(). This lets the "Design N selected" button read the DataView's internal selection count and IDs without any context piercing or DataView modification.

Changes:
- page.tsx: accepts searchParams, computes SSR initialData via filterSortQrCodes + paginateQrCodes, passes allCodes alongside initialData; layout changed to h-[calc(100vh-4rem)] flex column
- _utils/data-view.ts: filterSortQrCodes (search by label/token, select filter on computed assigned/unassigned/revoked status, sort), paginateQrCodes
- qr-management-client.tsx: allRef + client-side listFetcher/detailFetcher (zero latency); 5 sortable columns; status select filter; QrDetailPanel shows QR details, Design N selected button, and Revoke button; generate form and Design tab with LabelDesigner preserved unchanged
- en.json / pl.json: modules.qr.management.detail.* added (label, token, status, assignment, created, id, unlabelled, designButton, revokeButton)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added QR detail view displaying labels, token, and status information
  * Introduced label design stage for managing QR codes
  * Enhanced QR management interface with search, filtering, and sorting capabilities
  * Implemented permission-based controls for creation, revocation, and export actions
  * Added optimistic UI updates for improved responsiveness during QR operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->