### PR TITLE
feat(warehouse): implement Locations V2 phase 0/1 DB foundation

### DIFF
--- a/apps/web/supabase/migrations/20260507130000_locations_v2_entity_cleanup.sql
+++ b/apps/web/supabase/migrations/20260507130000_locations_v2_entity_cleanup.sql
@@ -1,0 +1,65 @@
+-- Locations V2 Phase 1.1: entity cleanup (additive)
+
+ALTER TABLE public.warehouse_locations
+  ADD COLUMN IF NOT EXISTS can_store_inventory BOOLEAN,
+  ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'archived')),
+  ADD COLUMN IF NOT EXISTS location_category TEXT,
+  ADD COLUMN IF NOT EXISTS width_mm INTEGER,
+  ADD COLUMN IF NOT EXISTS height_mm INTEGER,
+  ADD COLUMN IF NOT EXISTS depth_mm INTEGER;
+
+ALTER TABLE public.warehouse_locations
+  DROP CONSTRAINT IF EXISTS warehouse_locations_dimensions_non_negative;
+
+ALTER TABLE public.warehouse_locations
+  ADD CONSTRAINT warehouse_locations_dimensions_non_negative
+  CHECK (
+    (width_mm IS NULL OR width_mm > 0) AND
+    (height_mm IS NULL OR height_mm > 0) AND
+    (depth_mm IS NULL OR depth_mm > 0)
+  );
+
+-- Conservative backfill from legacy meter fields when present.
+UPDATE public.warehouse_locations
+SET
+  width_mm = COALESCE(width_mm, CASE WHEN physical_width_m IS NOT NULL AND physical_width_m > 0 THEN (physical_width_m * 1000)::INTEGER END),
+  height_mm = COALESCE(height_mm, CASE WHEN physical_height_m IS NOT NULL AND physical_height_m > 0 THEN (physical_height_m * 1000)::INTEGER END),
+  depth_mm = COALESCE(depth_mm, CASE WHEN physical_depth_m IS NOT NULL AND physical_depth_m > 0 THEN (physical_depth_m * 1000)::INTEGER END)
+WHERE true;
+
+-- Conservative category backfill (do not expose deprecated concepts in new UI).
+UPDATE public.warehouse_locations
+SET location_category = COALESCE(
+  location_category,
+  CASE
+    WHEN top_storage_segment IS NOT NULL THEN 'storage'
+    WHEN map_role IN ('storage', 'rack', 'shelf', 'bin') THEN 'storage'
+    WHEN map_role IN ('receiving', 'dispatch') THEN map_role
+    WHEN map_role IS NOT NULL THEN 'general'
+    ELSE NULL
+  END
+)
+WHERE location_category IS NULL;
+
+-- Safe default for can_store_inventory only when old role is strongly storage-like.
+UPDATE public.warehouse_locations
+SET can_store_inventory = true
+WHERE can_store_inventory IS NULL
+  AND map_role IN ('storage', 'rack', 'shelf', 'bin', 'slot');
+
+-- For remaining rows keep explicit false until manually classified.
+UPDATE public.warehouse_locations
+SET can_store_inventory = false
+WHERE can_store_inventory IS NULL;
+
+CREATE INDEX IF NOT EXISTS wl_status_active_idx
+  ON public.warehouse_locations (organization_id, branch_id, status)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS wl_category_active_idx
+  ON public.warehouse_locations (organization_id, branch_id, location_category)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS wl_can_store_inventory_active_idx
+  ON public.warehouse_locations (organization_id, branch_id, can_store_inventory)
+  WHERE deleted_at IS NULL;

--- a/apps/web/supabase/migrations/20260507131000_locations_v2_visual_nodes.sql
+++ b/apps/web/supabase/migrations/20260507131000_locations_v2_visual_nodes.sql
@@ -1,0 +1,67 @@
+-- Locations V2 Phase 1.2: visual nodes table (separate from inventory entities)
+
+CREATE TABLE IF NOT EXISTS public.warehouse_location_visual_nodes (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  layout_id UUID NOT NULL REFERENCES public.warehouse_layouts(id) ON DELETE CASCADE,
+  organization_id UUID NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  branch_id UUID NOT NULL REFERENCES public.branches(id) ON DELETE CASCADE,
+
+  location_id UUID NOT NULL REFERENCES public.warehouse_locations(id) ON DELETE RESTRICT,
+  view_type TEXT NOT NULL CHECK (view_type IN ('top_down', 'front', 'interior')),
+  view_context_location_id UUID NULL REFERENCES public.warehouse_locations(id) ON DELETE CASCADE,
+  visual_role TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'archived')),
+
+  x_mm INTEGER NOT NULL DEFAULT 0,
+  y_mm INTEGER NOT NULL DEFAULT 0,
+  z_mm INTEGER NOT NULL DEFAULT 0,
+  width_mm INTEGER NOT NULL CHECK (width_mm > 0),
+  height_mm INTEGER NOT NULL CHECK (height_mm > 0),
+  depth_mm INTEGER NOT NULL CHECK (depth_mm > 0),
+
+  rotation_deg NUMERIC(8,2) NOT NULL DEFAULT 0,
+  style JSONB,
+  z_index INTEGER NOT NULL DEFAULT 0,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+
+  created_by UUID NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  updated_by UUID NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  deleted_at TIMESTAMPTZ NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS wlvn_active_primary_per_scope_uidx
+  ON public.warehouse_location_visual_nodes (layout_id, view_type, COALESCE(view_context_location_id, '00000000-0000-0000-0000-000000000000'::uuid), location_id)
+  WHERE deleted_at IS NULL AND status = 'active';
+
+CREATE INDEX IF NOT EXISTS wlvn_scope_active_idx
+  ON public.warehouse_location_visual_nodes (layout_id, view_type, view_context_location_id)
+  WHERE deleted_at IS NULL;
+
+ALTER TABLE public.warehouse_location_visual_nodes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.warehouse_location_visual_nodes FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS wlvn_select_layout_read ON public.warehouse_location_visual_nodes;
+CREATE POLICY wlvn_select_layout_read
+  ON public.warehouse_location_visual_nodes FOR SELECT
+  USING (
+    public.has_branch_permission(organization_id, branch_id, 'warehouse.layouts.read')
+    AND deleted_at IS NULL
+  );
+
+DROP POLICY IF EXISTS wlvn_insert_layout_manage ON public.warehouse_location_visual_nodes;
+CREATE POLICY wlvn_insert_layout_manage
+  ON public.warehouse_location_visual_nodes FOR INSERT
+  WITH CHECK (public.has_branch_permission(organization_id, branch_id, 'warehouse.layouts.manage'));
+
+DROP POLICY IF EXISTS wlvn_update_layout_manage ON public.warehouse_location_visual_nodes;
+CREATE POLICY wlvn_update_layout_manage
+  ON public.warehouse_location_visual_nodes FOR UPDATE
+  USING (public.has_branch_permission(organization_id, branch_id, 'warehouse.layouts.manage'))
+  WITH CHECK (public.has_branch_permission(organization_id, branch_id, 'warehouse.layouts.manage'));
+
+DROP POLICY IF EXISTS wlvn_delete_deny ON public.warehouse_location_visual_nodes;
+CREATE POLICY wlvn_delete_deny
+  ON public.warehouse_location_visual_nodes FOR DELETE
+  USING (false);

--- a/apps/web/supabase/migrations/20260507132000_locations_v2_split_nodes.sql
+++ b/apps/web/supabase/migrations/20260507132000_locations_v2_split_nodes.sql
@@ -1,0 +1,56 @@
+-- Locations V2 Phase 1.3: split nodes for front/interior structural editors
+
+CREATE TABLE IF NOT EXISTS public.warehouse_layout_split_nodes (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  layout_id UUID NOT NULL REFERENCES public.warehouse_layouts(id) ON DELETE CASCADE,
+  organization_id UUID NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  branch_id UUID NOT NULL REFERENCES public.branches(id) ON DELETE CASCADE,
+  view_context_location_id UUID NOT NULL REFERENCES public.warehouse_locations(id) ON DELETE CASCADE,
+
+  parent_node_id UUID NULL REFERENCES public.warehouse_layout_split_nodes(id) ON DELETE CASCADE,
+  node_kind TEXT NOT NULL CHECK (node_kind IN ('container', 'cell')),
+  split_direction TEXT NULL CHECK (split_direction IN ('horizontal', 'vertical')),
+  size_mode TEXT NULL CHECK (size_mode IN ('fraction', 'fixed_mm', 'auto')),
+  size_value NUMERIC(10,3) NULL,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  linked_location_id UUID NULL REFERENCES public.warehouse_locations(id) ON DELETE SET NULL,
+
+  calc_x_mm INTEGER,
+  calc_y_mm INTEGER,
+  calc_width_mm INTEGER,
+  calc_height_mm INTEGER,
+  calc_depth_mm INTEGER,
+
+  created_by UUID NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  updated_by UUID NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  deleted_at TIMESTAMPTZ NULL
+);
+
+CREATE INDEX IF NOT EXISTS wlsn_scope_active_idx
+  ON public.warehouse_layout_split_nodes (layout_id, view_context_location_id)
+  WHERE deleted_at IS NULL;
+
+ALTER TABLE public.warehouse_layout_split_nodes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.warehouse_layout_split_nodes FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY wlsn_select_layout_read
+  ON public.warehouse_layout_split_nodes FOR SELECT
+  USING (
+    public.has_branch_permission(organization_id, branch_id, 'warehouse.layouts.read')
+    AND deleted_at IS NULL
+  );
+
+CREATE POLICY wlsn_insert_layout_manage
+  ON public.warehouse_layout_split_nodes FOR INSERT
+  WITH CHECK (public.has_branch_permission(organization_id, branch_id, 'warehouse.layouts.manage'));
+
+CREATE POLICY wlsn_update_layout_manage
+  ON public.warehouse_layout_split_nodes FOR UPDATE
+  USING (public.has_branch_permission(organization_id, branch_id, 'warehouse.layouts.manage'))
+  WITH CHECK (public.has_branch_permission(organization_id, branch_id, 'warehouse.layouts.manage'));
+
+CREATE POLICY wlsn_delete_deny
+  ON public.warehouse_layout_split_nodes FOR DELETE
+  USING (false);

--- a/apps/web/supabase/migrations/20260507133000_locations_v2_mapping_archive_functions.sql
+++ b/apps/web/supabase/migrations/20260507133000_locations_v2_mapping_archive_functions.sql
@@ -1,0 +1,128 @@
+-- Locations V2 Phase 1.4: mapping status + archive validation
+
+CREATE OR REPLACE FUNCTION public.get_warehouse_location_mapping_status(
+  p_location_id UUID
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+DECLARE
+  v_has_top_down BOOLEAN;
+  v_has_front_or_interior BOOLEAN;
+  v_visual_count INTEGER;
+BEGIN
+  SELECT COUNT(*) INTO v_visual_count
+  FROM public.warehouse_location_visual_nodes
+  WHERE location_id = p_location_id
+    AND deleted_at IS NULL
+    AND status = 'active';
+
+  SELECT EXISTS (
+    SELECT 1 FROM public.warehouse_location_visual_nodes
+    WHERE location_id = p_location_id
+      AND view_type = 'top_down'
+      AND deleted_at IS NULL
+      AND status = 'active'
+  ) INTO v_has_top_down;
+
+  SELECT EXISTS (
+    SELECT 1 FROM public.warehouse_location_visual_nodes
+    WHERE location_id = p_location_id
+      AND view_type IN ('front', 'interior')
+      AND deleted_at IS NULL
+      AND status = 'active'
+  ) INTO v_has_front_or_interior;
+
+  RETURN jsonb_build_object(
+    'location_id', p_location_id,
+    'is_mapped', v_visual_count > 0,
+    'visual_node_count', v_visual_count,
+    'has_top_down', v_has_top_down,
+    'has_front_or_interior', v_has_front_or_interior
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.validate_warehouse_location_archive(
+  p_location_id UUID
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+DECLARE
+  v_direct_stock_count BIGINT := 0;
+  v_descendant_stock_count BIGINT := 0;
+  v_active_children_count BIGINT := 0;
+  v_reserved_stock_count BIGINT := 0;
+  v_open_assignment_count BIGINT := 0;
+  v_has_sku_rules BOOLEAN := false;
+BEGIN
+  -- direct stock
+  SELECT COUNT(*) INTO v_direct_stock_count
+  FROM public.product_location_stock pls
+  WHERE pls.location_id = p_location_id
+    AND COALESCE(pls.quantity, 0) > 0;
+
+  -- descendant stock
+  WITH RECURSIVE descendants AS (
+    SELECT wl.id
+    FROM public.warehouse_locations wl
+    WHERE wl.parent_id = p_location_id AND wl.deleted_at IS NULL
+    UNION ALL
+    SELECT wl2.id
+    FROM public.warehouse_locations wl2
+    JOIN descendants d ON d.id = wl2.parent_id
+    WHERE wl2.deleted_at IS NULL
+  )
+  SELECT COUNT(*) INTO v_descendant_stock_count
+  FROM public.product_location_stock pls
+  JOIN descendants d ON d.id = pls.location_id
+  WHERE COALESCE(pls.quantity, 0) > 0;
+
+  -- active children
+  SELECT COUNT(*) INTO v_active_children_count
+  FROM public.warehouse_locations wl
+  WHERE wl.parent_id = p_location_id
+    AND wl.deleted_at IS NULL
+    AND wl.status = 'active';
+
+  -- reserved stock if table exists
+  IF to_regclass('public.stock_reservations') IS NOT NULL THEN
+    EXECUTE $$
+      SELECT COUNT(*)
+      FROM public.stock_reservations sr
+      WHERE sr.location_id = $1
+        AND COALESCE(sr.status, 'active') IN ('active', 'partially_released')
+        AND COALESCE(sr.deleted_at, NULL) IS NULL
+    $$ INTO v_reserved_stock_count USING p_location_id;
+  END IF;
+
+  -- open inbound/outbound assignments safe stub (TODO: wire to concrete assignment tables when available)
+  v_open_assignment_count := 0;
+
+  -- SKU rules safe stub (TODO: wire to concrete SKU-location rule table when available)
+  v_has_sku_rules := false;
+
+  RETURN jsonb_build_object(
+    'location_id', p_location_id,
+    'can_archive', (
+      v_direct_stock_count = 0
+      AND v_descendant_stock_count = 0
+      AND v_active_children_count = 0
+      AND v_reserved_stock_count = 0
+      AND v_open_assignment_count = 0
+      AND v_has_sku_rules = false
+    ),
+    'blockers', jsonb_build_object(
+      'direct_stock_count', v_direct_stock_count,
+      'descendant_stock_count', v_descendant_stock_count,
+      'active_children_count', v_active_children_count,
+      'reserved_stock_count', v_reserved_stock_count,
+      'open_assignment_count', v_open_assignment_count,
+      'has_sku_rules', v_has_sku_rules
+    )
+  );
+END;
+$$;

--- a/apps/web/supabase/migrations/20260507134000_locations_v2_backfill_visual_nodes.sql
+++ b/apps/web/supabase/migrations/20260507134000_locations_v2_backfill_visual_nodes.sql
@@ -1,0 +1,56 @@
+-- Locations V2 Phase 1.5: backfill legacy location shapes into visual nodes
+
+INSERT INTO public.warehouse_location_visual_nodes (
+  layout_id,
+  organization_id,
+  branch_id,
+  location_id,
+  view_type,
+  view_context_location_id,
+  visual_role,
+  status,
+  x_mm,
+  y_mm,
+  z_mm,
+  width_mm,
+  height_mm,
+  depth_mm,
+  rotation_deg,
+  style,
+  z_index,
+  sort_order,
+  created_by,
+  updated_by,
+  created_at,
+  updated_at
+)
+SELECT
+  s.layout_id,
+  s.organization_id,
+  s.branch_id,
+  s.location_id,
+  'top_down'::TEXT,
+  l.root_location_id,
+  COALESCE(wl.map_role, 'legacy_location_shape')::TEXT,
+  'active'::TEXT,
+  GREATEST((s.x * 1000)::INTEGER, 0),
+  GREATEST((s.y * 1000)::INTEGER, 0),
+  0,
+  GREATEST((s.width * 1000)::INTEGER, 1),
+  GREATEST((COALESCE(wl.physical_height_m, s.height) * 1000)::INTEGER, 1),
+  GREATEST((COALESCE(wl.physical_depth_m, s.height) * 1000)::INTEGER, 1),
+  s.rotation,
+  s.style,
+  s.z_index,
+  s.sort_order,
+  s.created_by,
+  s.created_by,
+  s.created_at,
+  s.updated_at
+FROM public.warehouse_layout_shapes s
+JOIN public.warehouse_layouts l ON l.id = s.layout_id
+JOIN public.warehouse_locations wl ON wl.id = s.location_id
+WHERE s.deleted_at IS NULL
+  AND s.shape_type = 'location'
+  AND s.location_id IS NOT NULL
+ON CONFLICT DO NOTHING;

--- a/apps/web/supabase/migrations/20260507135000_locations_v2_verification_queries.sql
+++ b/apps/web/supabase/migrations/20260507135000_locations_v2_verification_queries.sql
@@ -1,0 +1,40 @@
+-- Locations V2 Phase 1.6: verification queries (run manually after apply)
+
+-- 1) old location shapes vs new visual nodes counts
+SELECT
+  (SELECT COUNT(*) FROM public.warehouse_layout_shapes s WHERE s.deleted_at IS NULL AND s.shape_type = 'location' AND s.location_id IS NOT NULL) AS old_location_shapes_count,
+  (SELECT COUNT(*) FROM public.warehouse_location_visual_nodes n WHERE n.deleted_at IS NULL AND n.status = 'active') AS new_visual_nodes_count;
+
+-- 2) stock-holding unmapped locations
+SELECT wl.id, wl.organization_id, wl.branch_id, wl.name
+FROM public.warehouse_locations wl
+JOIN public.product_location_stock pls ON pls.location_id = wl.id AND COALESCE(pls.quantity, 0) > 0
+LEFT JOIN public.warehouse_location_visual_nodes n
+  ON n.location_id = wl.id AND n.deleted_at IS NULL AND n.status = 'active'
+WHERE wl.deleted_at IS NULL
+GROUP BY wl.id
+HAVING COUNT(n.id) = 0;
+
+-- 3) stock assigned to can_store_inventory=false
+SELECT wl.id, wl.name, COALESCE(SUM(pls.quantity), 0) AS qty
+FROM public.warehouse_locations wl
+JOIN public.product_location_stock pls ON pls.location_id = wl.id
+WHERE wl.deleted_at IS NULL
+  AND wl.can_store_inventory = false
+GROUP BY wl.id, wl.name
+HAVING COALESCE(SUM(pls.quantity), 0) > 0;
+
+-- 4) parent locations with can_store_inventory=true and active children
+SELECT p.id, p.name, COUNT(c.id) AS active_children
+FROM public.warehouse_locations p
+JOIN public.warehouse_locations c ON c.parent_id = p.id AND c.deleted_at IS NULL AND c.status = 'active'
+WHERE p.deleted_at IS NULL
+  AND p.can_store_inventory = true
+GROUP BY p.id, p.name;
+
+-- 5) duplicate active primary visual nodes in same scope
+SELECT layout_id, view_type, COALESCE(view_context_location_id, '00000000-0000-0000-0000-000000000000'::uuid) AS view_context_location_id, location_id, COUNT(*)
+FROM public.warehouse_location_visual_nodes
+WHERE deleted_at IS NULL AND status = 'active'
+GROUP BY layout_id, view_type, COALESCE(view_context_location_id, '00000000-0000-0000-0000-000000000000'::uuid), location_id
+HAVING COUNT(*) > 1;

--- a/docs/locations-v2-implementation-progress.md
+++ b/docs/locations-v2-implementation-progress.md
@@ -1,0 +1,44 @@
+# Locations V2 Implementation Progress
+
+## Plan source / mismatch note
+
+- Requested plan file: `/mnt/data/ambra-locations-v2-refactor-implementation-plan.md`.
+- Actual environment does not contain `/mnt/data` and the plan file is not present, so implementation is based on the user-provided phase checklist in the prompt.
+
+## Phase 0 — Preflight
+
+- [x] Review current `warehouse_locations` migrations.
+- [x] Review current `warehouse_layouts` migrations.
+- [x] Review current `warehouse_layout_shapes` migrations.
+- [x] Review location services.
+- [x] Review layout services.
+- [x] Review shape services.
+- [x] Review warehouse server actions.
+- [x] Review React Query hooks for warehouse locations/maps.
+- [x] Review `/dashboard/warehouse/locations` and `/dashboard/warehouse/map` routes.
+- [x] Confirm current table and column names before migration work.
+- [x] Confirm inventory stock table name (`product_location_stock`).
+- [x] Confirm locale route structure (`app/[locale]/dashboard/...`).
+- [x] Document repo/plan mismatches.
+
+### Phase 0 mismatch details
+
+1. Plan references an external markdown file path not available in this container.
+2. Existing schema already includes v1 map concepts (`map_role`, `front_segment`, `top_down_unit`, `top_storage_segment`) and shape RPCs with replace-all semantics that must be preserved for legacy UI during transition.
+3. Inventory table for location stock exists as `product_location_stock` (not just a hypothetical table name).
+
+## Phase 1 — Database foundation (additive only)
+
+- [x] `locations_v2_entity_cleanup` migration created.
+- [x] `locations_v2_visual_nodes` migration created.
+- [x] `locations_v2_split_nodes` migration created.
+- [x] `locations_v2_mapping_archive_functions` migration created.
+- [x] `locations_v2_backfill_visual_nodes` migration created.
+- [x] `locations_v2_verification_queries` migration created.
+- [ ] Apply migrations to target database.
+- [ ] Regenerate Supabase types (if/when connected workflow is executed).
+- [ ] Run post-apply verification queries against live data.
+
+## Phase 2+
+
+- [ ] Not started (intentionally deferred per instruction: start with Phase 0 and Phase 1 only).


### PR DESCRIPTION
### Motivation

- Begin the Locations V2 refactor to separate operational location entities from visual/layout artifacts and introduce safe archive + backfill behavior. 
- Provide an additive, reviewable DB foundation that preserves the legacy map editor while enabling V2 UI and editor work in later phases. 

### Description

- Added a progress tracker at `docs/locations-v2-implementation-progress.md` and documented a missing external plan file plus repo/plan mismatches. 
- Introduced additive-only SQL migrations: `20260507130000_locations_v2_entity_cleanup.sql` (adds `can_store_inventory`, `status`, `location_category`, `*_mm` dimensions, conservative backfills, and indexes), `20260507131000_locations_v2_visual_nodes.sql` (creates `warehouse_location_visual_nodes` with mm geometry, scope constraints, and RLS using `warehouse.layouts.*` gates), `20260507132000_locations_v2_split_nodes.sql` (creates `warehouse_layout_split_nodes` with `node_kind`, split model, geometry cache, and RLS), `20260507133000_locations_v2_mapping_archive_functions.sql` (adds `get_warehouse_location_mapping_status()` and `validate_warehouse_location_archive()` with safe stubs for optional tables), `20260507134000_locations_v2_backfill_visual_nodes.sql` (backfills legacy `warehouse_layout_shapes` location-type shapes into V2 visual nodes), and `20260507135000_locations_v2_verification_queries.sql` (manual verification queries for parity and blockers). 
- All changes are additive only, include safety checks and constraints, avoid coupling inventory to visual nodes, and preserve legacy `warehouse_layout_shapes` behavior for the existing editor. 

### Testing

- Pre-commit pipeline and `lint-staged` formatting ran successfully (prettier via pre-commit tasks completed). 
- Quick repository checks were performed using `rg` to confirm migration files and key SQL symbols are present and to verify references to `product_location_stock` and legacy map-role fields. 
- Verification SQLs were added in `20260507135000_locations_v2_verification_queries.sql` for manual run against the target DB after migrations are applied (not executed in this PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc283c1a188328a2c2a4086d4e9871)