### PR TITLE
Add Locations V2 migrations: entity cleanup, visual nodes, split nodes, backfill, mapping/archive functions and verification

### DIFF
--- a/apps/web/supabase/migrations/20260507130000_locations_v2_entity_cleanup.sql
+++ b/apps/web/supabase/migrations/20260507130000_locations_v2_entity_cleanup.sql
@@ -1,0 +1,87 @@
+-- Locations V2 Phase 1.1: entity cleanup (additive)
+
+ALTER TABLE public.warehouse_locations
+  ADD COLUMN IF NOT EXISTS can_store_inventory BOOLEAN,
+  ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'archived')),
+  ADD COLUMN IF NOT EXISTS location_category TEXT,
+  ADD COLUMN IF NOT EXISTS width_mm INTEGER,
+  ADD COLUMN IF NOT EXISTS height_mm INTEGER,
+  ADD COLUMN IF NOT EXISTS depth_mm INTEGER;
+
+ALTER TABLE public.warehouse_locations
+  DROP CONSTRAINT IF EXISTS warehouse_locations_dimensions_non_negative;
+
+ALTER TABLE public.warehouse_locations
+  ADD CONSTRAINT warehouse_locations_dimensions_non_negative
+  CHECK (
+    (width_mm IS NULL OR width_mm > 0) AND
+    (height_mm IS NULL OR height_mm > 0) AND
+    (depth_mm IS NULL OR depth_mm > 0)
+  );
+
+-- Conservative backfill from legacy meter fields when present.
+UPDATE public.warehouse_locations
+SET
+  width_mm = COALESCE(width_mm, CASE WHEN physical_width_m IS NOT NULL AND physical_width_m > 0 THEN (physical_width_m * 1000)::INTEGER END),
+  height_mm = COALESCE(height_mm, CASE WHEN physical_height_m IS NOT NULL AND physical_height_m > 0 THEN (physical_height_m * 1000)::INTEGER END),
+  depth_mm = COALESCE(depth_mm, CASE WHEN physical_depth_m IS NOT NULL AND physical_depth_m > 0 THEN (physical_depth_m * 1000)::INTEGER END)
+WHERE true;
+
+-- Controlled V2 categories only.
+UPDATE public.warehouse_locations
+SET location_category = CASE
+  WHEN map_role = 'top_down_unit' THEN 'rack'
+  WHEN map_role = 'front_segment' THEN 'shelf'
+  WHEN map_role = 'top_storage_segment' THEN 'bin'
+  WHEN map_role = 'layout_root' THEN 'area'
+  WHEN map_role = 'logical' THEN 'custom'
+  ELSE 'custom'
+END
+WHERE location_category IS NULL
+   OR location_category NOT IN (
+     'area','zone','room','cabinet','rack','shelf_unit','workbench',
+     'shelf','drawer','bin','box','pallet_position','wall_storage',
+     'receiving','dispatch','quarantine','temporary','custom'
+   );
+
+ALTER TABLE public.warehouse_locations
+  DROP CONSTRAINT IF EXISTS warehouse_locations_location_category_valid;
+
+ALTER TABLE public.warehouse_locations
+  ADD CONSTRAINT warehouse_locations_location_category_valid
+  CHECK (
+    location_category IN (
+      'area','zone','room','cabinet','rack','shelf_unit','workbench',
+      'shelf','drawer','bin','box','pallet_position','wall_storage',
+      'receiving','dispatch','quarantine','temporary','custom'
+    )
+  );
+
+-- Conservative can_store_inventory backfill.
+UPDATE public.warehouse_locations wl
+SET can_store_inventory = true
+WHERE wl.deleted_at IS NULL
+  AND wl.can_store_inventory IS NULL
+  AND wl.map_role IN ('front_segment', 'top_storage_segment')
+  AND NOT EXISTS (
+    SELECT 1
+    FROM public.warehouse_locations child
+    WHERE child.parent_id = wl.id
+      AND child.deleted_at IS NULL
+  );
+
+UPDATE public.warehouse_locations wl
+SET can_store_inventory = false
+WHERE wl.can_store_inventory IS NULL;
+
+CREATE INDEX IF NOT EXISTS wl_status_active_idx
+  ON public.warehouse_locations (organization_id, branch_id, status)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS wl_category_active_idx
+  ON public.warehouse_locations (organization_id, branch_id, location_category)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS wl_can_store_inventory_active_idx
+  ON public.warehouse_locations (organization_id, branch_id, can_store_inventory)
+  WHERE deleted_at IS NULL;

--- a/apps/web/supabase/migrations/20260507131000_locations_v2_visual_nodes.sql
+++ b/apps/web/supabase/migrations/20260507131000_locations_v2_visual_nodes.sql
@@ -1,0 +1,76 @@
+-- Locations V2 Phase 1.2: visual nodes table (separate from inventory entities)
+
+CREATE TABLE IF NOT EXISTS public.warehouse_location_visual_nodes (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  layout_id UUID NOT NULL REFERENCES public.warehouse_layouts(id) ON DELETE CASCADE,
+  organization_id UUID NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  branch_id UUID NOT NULL REFERENCES public.branches(id) ON DELETE CASCADE,
+
+  location_id UUID NOT NULL REFERENCES public.warehouse_locations(id) ON DELETE RESTRICT,
+  view_type TEXT NOT NULL CHECK (view_type IN ('top_down', 'front', 'interior')),
+  view_context_location_id UUID NULL REFERENCES public.warehouse_locations(id) ON DELETE SET NULL,
+  visualization_type TEXT NOT NULL DEFAULT 'rectangle' CHECK (visualization_type IN ('rectangle','cabinet','rack','grid','drawer','bin','zone','custom')),
+  visual_role TEXT NOT NULL DEFAULT 'primary' CHECK (visual_role IN ('primary','label','reference','aggregate')),
+  status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'hidden', 'historical')),
+
+  x_mm INTEGER NOT NULL DEFAULT 0,
+  y_mm INTEGER NOT NULL DEFAULT 0,
+  z_mm INTEGER NOT NULL DEFAULT 0,
+  width_mm INTEGER NOT NULL CHECK (width_mm > 0),
+  height_mm INTEGER NOT NULL CHECK (height_mm > 0),
+  depth_mm INTEGER NOT NULL CHECK (depth_mm > 0),
+
+  rotation_deg NUMERIC(8,2) NOT NULL DEFAULT 0,
+  style JSONB,
+  z_index INTEGER NOT NULL DEFAULT 0,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+
+  created_by UUID NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  updated_by UUID NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  deleted_at TIMESTAMPTZ NULL
+);
+
+-- NOTE: uniqueness applies to active PRIMARY nodes only.
+CREATE UNIQUE INDEX IF NOT EXISTS wlvn_primary_unique_idx
+  ON public.warehouse_location_visual_nodes (
+    location_id,
+    view_type,
+    COALESCE(layout_id, '00000000-0000-0000-0000-000000000000'::uuid),
+    COALESCE(view_context_location_id, '00000000-0000-0000-0000-000000000000'::uuid)
+  )
+  WHERE deleted_at IS NULL
+    AND status = 'active'
+    AND visual_role = 'primary';
+
+CREATE INDEX IF NOT EXISTS wlvn_scope_active_idx
+  ON public.warehouse_location_visual_nodes (layout_id, view_type, view_context_location_id)
+  WHERE deleted_at IS NULL;
+
+ALTER TABLE public.warehouse_location_visual_nodes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.warehouse_location_visual_nodes FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS wlvn_select_layout_read ON public.warehouse_location_visual_nodes;
+CREATE POLICY wlvn_select_layout_read
+  ON public.warehouse_location_visual_nodes FOR SELECT
+  USING (
+    public.has_branch_permission(organization_id, branch_id, 'warehouse.layouts.read')
+    AND deleted_at IS NULL
+  );
+
+DROP POLICY IF EXISTS wlvn_insert_layout_manage ON public.warehouse_location_visual_nodes;
+CREATE POLICY wlvn_insert_layout_manage
+  ON public.warehouse_location_visual_nodes FOR INSERT
+  WITH CHECK (public.has_branch_permission(organization_id, branch_id, 'warehouse.layouts.manage'));
+
+DROP POLICY IF EXISTS wlvn_update_layout_manage ON public.warehouse_location_visual_nodes;
+CREATE POLICY wlvn_update_layout_manage
+  ON public.warehouse_location_visual_nodes FOR UPDATE
+  USING (public.has_branch_permission(organization_id, branch_id, 'warehouse.layouts.manage'))
+  WITH CHECK (public.has_branch_permission(organization_id, branch_id, 'warehouse.layouts.manage'));
+
+DROP POLICY IF EXISTS wlvn_delete_deny ON public.warehouse_location_visual_nodes;
+CREATE POLICY wlvn_delete_deny
+  ON public.warehouse_location_visual_nodes FOR DELETE
+  USING (false);

--- a/apps/web/supabase/migrations/20260507132000_locations_v2_split_nodes.sql
+++ b/apps/web/supabase/migrations/20260507132000_locations_v2_split_nodes.sql
@@ -1,0 +1,61 @@
+-- Locations V2 Phase 1.3: split nodes for front/interior structural editors
+
+CREATE TABLE IF NOT EXISTS public.warehouse_layout_split_nodes (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  layout_id UUID NOT NULL REFERENCES public.warehouse_layouts(id) ON DELETE CASCADE,
+  organization_id UUID NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  branch_id UUID NOT NULL REFERENCES public.branches(id) ON DELETE CASCADE,
+  view_context_location_id UUID NULL REFERENCES public.warehouse_locations(id) ON DELETE SET NULL,
+
+  parent_node_id UUID NULL REFERENCES public.warehouse_layout_split_nodes(id) ON DELETE CASCADE,
+  node_kind TEXT NOT NULL CHECK (node_kind IN ('container', 'cell')),
+  split_direction TEXT NULL CHECK (split_direction IN ('horizontal', 'vertical')),
+  size_mode TEXT NOT NULL DEFAULT 'equal' CHECK (size_mode IN ('equal', 'ratio', 'fixed', 'auto')),
+  size_value NUMERIC(10,3) NULL,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  linked_location_id UUID NULL REFERENCES public.warehouse_locations(id) ON DELETE SET NULL,
+
+  calc_x_mm INTEGER,
+  calc_y_mm INTEGER,
+  calc_width_mm INTEGER,
+  calc_height_mm INTEGER,
+  calc_depth_mm INTEGER,
+  cache_valid BOOLEAN NOT NULL DEFAULT false,
+
+  created_by UUID NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  updated_by UUID NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  deleted_at TIMESTAMPTZ NULL
+);
+
+CREATE INDEX IF NOT EXISTS wlsn_scope_active_idx
+  ON public.warehouse_layout_split_nodes (layout_id, view_context_location_id)
+  WHERE deleted_at IS NULL;
+
+ALTER TABLE public.warehouse_layout_split_nodes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.warehouse_layout_split_nodes FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS wlsn_select_layout_read ON public.warehouse_layout_split_nodes;
+CREATE POLICY wlsn_select_layout_read
+  ON public.warehouse_layout_split_nodes FOR SELECT
+  USING (
+    public.has_branch_permission(organization_id, branch_id, 'warehouse.layouts.read')
+    AND deleted_at IS NULL
+  );
+
+DROP POLICY IF EXISTS wlsn_insert_layout_manage ON public.warehouse_layout_split_nodes;
+CREATE POLICY wlsn_insert_layout_manage
+  ON public.warehouse_layout_split_nodes FOR INSERT
+  WITH CHECK (public.has_branch_permission(organization_id, branch_id, 'warehouse.layouts.manage'));
+
+DROP POLICY IF EXISTS wlsn_update_layout_manage ON public.warehouse_layout_split_nodes;
+CREATE POLICY wlsn_update_layout_manage
+  ON public.warehouse_layout_split_nodes FOR UPDATE
+  USING (public.has_branch_permission(organization_id, branch_id, 'warehouse.layouts.manage'))
+  WITH CHECK (public.has_branch_permission(organization_id, branch_id, 'warehouse.layouts.manage'));
+
+DROP POLICY IF EXISTS wlsn_delete_deny ON public.warehouse_layout_split_nodes;
+CREATE POLICY wlsn_delete_deny
+  ON public.warehouse_layout_split_nodes FOR DELETE
+  USING (false);

--- a/apps/web/supabase/migrations/20260507133000_locations_v2_mapping_archive_functions.sql
+++ b/apps/web/supabase/migrations/20260507133000_locations_v2_mapping_archive_functions.sql
@@ -1,0 +1,169 @@
+-- Locations V2 Phase 1.4: mapping status + archive validation
+
+CREATE OR REPLACE FUNCTION public.get_warehouse_location_mapping_status(
+  p_location_id UUID
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+DECLARE
+  v_visual_count INTEGER := 0;
+  v_has_top_down BOOLEAN := false;
+  v_has_front_or_interior BOOLEAN := false;
+  v_active_child_count INTEGER := 0;
+  v_mapped_child_count INTEGER := 0;
+  v_unmapped_child_count INTEGER := 0;
+  v_mapping_status TEXT := 'unmapped';
+BEGIN
+  SELECT COUNT(*) INTO v_visual_count
+  FROM public.warehouse_location_visual_nodes
+  WHERE location_id = p_location_id
+    AND deleted_at IS NULL
+    AND status = 'active';
+
+  SELECT EXISTS (
+    SELECT 1 FROM public.warehouse_location_visual_nodes
+    WHERE location_id = p_location_id
+      AND view_type = 'top_down'
+      AND deleted_at IS NULL
+      AND status = 'active'
+  ) INTO v_has_top_down;
+
+  SELECT EXISTS (
+    SELECT 1 FROM public.warehouse_location_visual_nodes
+    WHERE location_id = p_location_id
+      AND view_type IN ('front', 'interior')
+      AND deleted_at IS NULL
+      AND status = 'active'
+  ) INTO v_has_front_or_interior;
+
+  SELECT COUNT(*) INTO v_active_child_count
+  FROM public.warehouse_locations c
+  WHERE c.parent_id = p_location_id
+    AND c.deleted_at IS NULL
+    AND COALESCE(c.status, 'active') = 'active';
+
+  SELECT COUNT(*) INTO v_mapped_child_count
+  FROM public.warehouse_locations c
+  WHERE c.parent_id = p_location_id
+    AND c.deleted_at IS NULL
+    AND COALESCE(c.status, 'active') = 'active'
+    AND EXISTS (
+      SELECT 1 FROM public.warehouse_location_visual_nodes n
+      WHERE n.location_id = c.id
+        AND n.deleted_at IS NULL
+        AND n.status = 'active'
+    );
+
+  v_unmapped_child_count := GREATEST(v_active_child_count - v_mapped_child_count, 0);
+
+  IF v_visual_count = 0 THEN
+    v_mapping_status := 'unmapped';
+  ELSIF v_unmapped_child_count > 0 THEN
+    v_mapping_status := 'partially_mapped';
+  ELSE
+    v_mapping_status := 'mapped';
+  END IF;
+
+  RETURN jsonb_build_object(
+    'location_id', p_location_id,
+    'mapping_status', v_mapping_status,
+    'is_mapped', v_visual_count > 0,
+    'visual_node_count', v_visual_count,
+    'active_child_count', v_active_child_count,
+    'mapped_child_count', v_mapped_child_count,
+    'unmapped_child_count', v_unmapped_child_count,
+    'has_top_down', v_has_top_down,
+    'has_front_or_interior', v_has_front_or_interior
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.validate_warehouse_location_archive(
+  p_location_id UUID
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+DECLARE
+  v_direct_stock_count BIGINT := 0;
+  v_direct_stock_qty NUMERIC := 0;
+  v_desc_stock_count BIGINT := 0;
+  v_desc_stock_qty NUMERIC := 0;
+  v_active_children_count BIGINT := 0;
+  v_reserved_stock_count BIGINT := 0;
+  v_has_visual_nodes BIGINT := 0;
+  v_blockers JSONB := '[]'::jsonb;
+  v_warnings JSONB := '[]'::jsonb;
+BEGIN
+  SELECT COUNT(*), COALESCE(SUM(pls.quantity), 0)
+    INTO v_direct_stock_count, v_direct_stock_qty
+  FROM public.product_location_stock pls
+  WHERE pls.location_id = p_location_id
+    AND COALESCE(pls.quantity, 0) > 0;
+
+  WITH RECURSIVE descendants AS (
+    SELECT wl.id
+    FROM public.warehouse_locations wl
+    WHERE wl.parent_id = p_location_id AND wl.deleted_at IS NULL
+    UNION ALL
+    SELECT wl2.id
+    FROM public.warehouse_locations wl2
+    JOIN descendants d ON d.id = wl2.parent_id
+    WHERE wl2.deleted_at IS NULL
+  )
+  SELECT COUNT(*), COALESCE(SUM(pls.quantity), 0)
+    INTO v_desc_stock_count, v_desc_stock_qty
+  FROM public.product_location_stock pls
+  JOIN descendants d ON d.id = pls.location_id
+  WHERE COALESCE(pls.quantity, 0) > 0;
+
+  SELECT COUNT(*) INTO v_active_children_count
+  FROM public.warehouse_locations wl
+  WHERE wl.parent_id = p_location_id
+    AND wl.deleted_at IS NULL
+    AND COALESCE(wl.status, 'active') = 'active';
+
+  IF to_regclass('public.stock_reservations') IS NOT NULL
+     AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='stock_reservations' AND column_name='location_id')
+  THEN
+    EXECUTE format('SELECT COUNT(*) FROM public.stock_reservations sr WHERE sr.location_id = $1 %s %s',
+      CASE WHEN EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='stock_reservations' AND column_name='status')
+           THEN 'AND COALESCE(sr.status, ''active'') IN (''active'', ''partially_released'')' ELSE '' END,
+      CASE WHEN EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='stock_reservations' AND column_name='deleted_at')
+           THEN 'AND sr.deleted_at IS NULL' ELSE '' END
+    ) INTO v_reserved_stock_count USING p_location_id;
+  END IF;
+
+  SELECT COUNT(*) INTO v_has_visual_nodes
+  FROM public.warehouse_location_visual_nodes n
+  WHERE n.location_id = p_location_id
+    AND n.deleted_at IS NULL
+    AND n.status = 'active';
+
+  IF v_direct_stock_count > 0 THEN
+    v_blockers := v_blockers || jsonb_build_array(jsonb_build_object('type','direct_stock','message','Location contains active inventory','count',v_direct_stock_count,'quantity',v_direct_stock_qty));
+  END IF;
+  IF v_desc_stock_count > 0 THEN
+    v_blockers := v_blockers || jsonb_build_array(jsonb_build_object('type','descendant_stock','message','Descendant locations contain active inventory','count',v_desc_stock_count,'quantity',v_desc_stock_qty));
+  END IF;
+  IF v_active_children_count > 0 THEN
+    v_blockers := v_blockers || jsonb_build_array(jsonb_build_object('type','active_children','message','Location has active child locations','count',v_active_children_count));
+  END IF;
+  IF v_reserved_stock_count > 0 THEN
+    v_blockers := v_blockers || jsonb_build_array(jsonb_build_object('type','reserved_stock','message','Location has active stock reservations','count',v_reserved_stock_count));
+  END IF;
+  IF v_has_visual_nodes > 0 THEN
+    v_warnings := v_warnings || jsonb_build_array(jsonb_build_object('type','has_visual_nodes','message','Location has visual map representations','count',v_has_visual_nodes));
+  END IF;
+
+  RETURN jsonb_build_object(
+    'location_id', p_location_id,
+    'can_archive', jsonb_array_length(v_blockers) = 0,
+    'blockers', v_blockers,
+    'warnings', v_warnings
+  );
+END;
+$$;

--- a/apps/web/supabase/migrations/20260507134000_locations_v2_backfill_visual_nodes.sql
+++ b/apps/web/supabase/migrations/20260507134000_locations_v2_backfill_visual_nodes.sql
@@ -1,0 +1,79 @@
+-- Locations V2 Phase 1.5: backfill legacy location shapes into visual nodes
+-- NOTE:
+-- - `warehouse_layout_shapes` remains for legacy/decorative shapes and old editor compatibility.
+-- - V2 location visuals should read from `warehouse_location_visual_nodes`.
+
+INSERT INTO public.warehouse_location_visual_nodes (
+  layout_id,
+  organization_id,
+  branch_id,
+  location_id,
+  view_type,
+  view_context_location_id,
+  visualization_type,
+  visual_role,
+  status,
+  x_mm,
+  y_mm,
+  z_mm,
+  width_mm,
+  height_mm,
+  depth_mm,
+  rotation_deg,
+  style,
+  z_index,
+  sort_order,
+  created_by,
+  updated_by,
+  created_at,
+  updated_at
+)
+SELECT
+  s.layout_id,
+  s.organization_id,
+  s.branch_id,
+  s.location_id,
+  CASE
+    WHEN COALESCE(s.projection, 'top_down') = 'front_elevation' THEN 'front'
+    ELSE 'top_down'
+  END::TEXT,
+  COALESCE(s.anchor_location_id, l.root_location_id),
+  CASE
+    WHEN wl.map_role = 'top_down_unit' THEN 'rack'
+    WHEN wl.map_role = 'front_segment' THEN 'grid'
+    WHEN wl.map_role = 'top_storage_segment' THEN 'bin'
+    ELSE 'rectangle'
+  END::TEXT,
+  'primary'::TEXT,
+  'active'::TEXT,
+  GREATEST((s.x * 1000)::INTEGER, 0),
+  GREATEST((s.y * 1000)::INTEGER, 0),
+  0,
+  GREATEST((s.width * 1000)::INTEGER, 1),
+  GREATEST((COALESCE(wl.physical_height_m, s.height) * 1000)::INTEGER, 1),
+  GREATEST((COALESCE(wl.physical_depth_m, s.height) * 1000)::INTEGER, 1),
+  s.rotation,
+  s.style,
+  s.z_index,
+  s.sort_order,
+  s.created_by,
+  s.created_by,
+  s.created_at,
+  s.updated_at
+FROM public.warehouse_layout_shapes s
+JOIN public.warehouse_layouts l ON l.id = s.layout_id
+JOIN public.warehouse_locations wl ON wl.id = s.location_id
+WHERE s.deleted_at IS NULL
+  AND s.shape_type = 'location'
+  AND s.location_id IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1
+    FROM public.warehouse_location_visual_nodes n
+    WHERE n.location_id = s.location_id
+      AND n.layout_id = s.layout_id
+      AND n.view_type = (CASE WHEN COALESCE(s.projection, 'top_down') = 'front_elevation' THEN 'front' ELSE 'top_down' END)
+      AND COALESCE(n.view_context_location_id, '00000000-0000-0000-0000-000000000000'::uuid) = COALESCE(COALESCE(s.anchor_location_id, l.root_location_id), '00000000-0000-0000-0000-000000000000'::uuid)
+      AND n.visual_role = 'primary'
+      AND n.deleted_at IS NULL
+      AND n.status = 'active'
+  );

--- a/apps/web/supabase/migrations/20260507135000_locations_v2_verification_queries.sql
+++ b/apps/web/supabase/migrations/20260507135000_locations_v2_verification_queries.sql
@@ -1,0 +1,88 @@
+-- Locations V2 Phase 1.6: reusable verification function
+
+CREATE OR REPLACE FUNCTION public.verify_locations_v2_migration()
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+DECLARE
+  v_old_location_shape_count BIGINT := 0;
+  v_new_visual_node_count BIGINT := 0;
+  v_unmapped_stock_holding_locations BIGINT := 0;
+  v_stock_on_non_storable_locations BIGINT := 0;
+  v_storage_capable_parents_with_children BIGINT := 0;
+  v_duplicate_active_primary_visual_nodes BIGINT := 0;
+  v_invalid_location_categories BIGINT := 0;
+  v_invalid_visual_roles BIGINT := 0;
+BEGIN
+  SELECT COUNT(*) INTO v_old_location_shape_count
+  FROM public.warehouse_layout_shapes s
+  WHERE s.deleted_at IS NULL AND s.shape_type = 'location' AND s.location_id IS NOT NULL;
+
+  SELECT COUNT(*) INTO v_new_visual_node_count
+  FROM public.warehouse_location_visual_nodes n
+  WHERE n.deleted_at IS NULL AND n.status = 'active';
+
+  SELECT COUNT(*) INTO v_unmapped_stock_holding_locations
+  FROM (
+    SELECT wl.id
+    FROM public.warehouse_locations wl
+    JOIN public.product_location_stock pls ON pls.location_id = wl.id AND COALESCE(pls.quantity, 0) > 0
+    LEFT JOIN public.warehouse_location_visual_nodes n
+      ON n.location_id = wl.id AND n.deleted_at IS NULL AND n.status = 'active'
+    WHERE wl.deleted_at IS NULL
+    GROUP BY wl.id
+    HAVING COUNT(n.id) = 0
+  ) q;
+
+  SELECT COUNT(*) INTO v_stock_on_non_storable_locations
+  FROM (
+    SELECT wl.id
+    FROM public.warehouse_locations wl
+    JOIN public.product_location_stock pls ON pls.location_id = wl.id
+    WHERE wl.deleted_at IS NULL AND wl.can_store_inventory = false
+    GROUP BY wl.id
+    HAVING COALESCE(SUM(pls.quantity), 0) > 0
+  ) q;
+
+  SELECT COUNT(*) INTO v_storage_capable_parents_with_children
+  FROM (
+    SELECT p.id
+    FROM public.warehouse_locations p
+    JOIN public.warehouse_locations c ON c.parent_id = p.id AND c.deleted_at IS NULL AND COALESCE(c.status,'active')='active'
+    WHERE p.deleted_at IS NULL AND p.can_store_inventory = true
+    GROUP BY p.id
+  ) q;
+
+  SELECT COUNT(*) INTO v_duplicate_active_primary_visual_nodes
+  FROM (
+    SELECT n.location_id, n.view_type,
+      COALESCE(n.layout_id, '00000000-0000-0000-0000-000000000000'::uuid),
+      COALESCE(n.view_context_location_id, '00000000-0000-0000-0000-000000000000'::uuid)
+    FROM public.warehouse_location_visual_nodes n
+    WHERE n.deleted_at IS NULL AND n.status = 'active' AND n.visual_role = 'primary'
+    GROUP BY 1,2,3,4
+    HAVING COUNT(*) > 1
+  ) q;
+
+  SELECT COUNT(*) INTO v_invalid_location_categories
+  FROM public.warehouse_locations wl
+  WHERE wl.location_category IS NULL
+    OR wl.location_category NOT IN ('area','zone','room','cabinet','rack','shelf_unit','workbench','shelf','drawer','bin','box','pallet_position','wall_storage','receiving','dispatch','quarantine','temporary','custom');
+
+  SELECT COUNT(*) INTO v_invalid_visual_roles
+  FROM public.warehouse_location_visual_nodes n
+  WHERE n.visual_role NOT IN ('primary','label','reference','aggregate');
+
+  RETURN jsonb_build_object(
+    'old_location_shape_count', v_old_location_shape_count,
+    'new_visual_node_count', v_new_visual_node_count,
+    'unmapped_stock_holding_locations', v_unmapped_stock_holding_locations,
+    'stock_on_non_storable_locations', v_stock_on_non_storable_locations,
+    'storage_capable_parents_with_children', v_storage_capable_parents_with_children,
+    'duplicate_active_primary_visual_nodes', v_duplicate_active_primary_visual_nodes,
+    'invalid_location_categories', v_invalid_location_categories,
+    'invalid_visual_roles', v_invalid_visual_roles
+  );
+END;
+$$;

--- a/docs/locations-v2-implementation-progress.md
+++ b/docs/locations-v2-implementation-progress.md
@@ -1,0 +1,80 @@
+# Locations V2 Implementation Progress
+
+## Plan source / mismatch note
+
+- Requested plan file: `/mnt/data/ambra-locations-v2-refactor-implementation-plan.md`.
+- Actual environment does not contain `/mnt/data` and the plan file is not present, so implementation is based on the user-provided phase checklist in the prompt.
+
+## Phase 0 — Preflight
+
+- [x] Review current `warehouse_locations` migrations.
+- [x] Review current `warehouse_layouts` migrations.
+- [x] Review current `warehouse_layout_shapes` migrations.
+- [x] Review location services.
+- [x] Review layout services.
+- [x] Review shape services.
+- [x] Review warehouse server actions.
+- [x] Review React Query hooks for warehouse locations/maps.
+- [x] Review `/dashboard/warehouse/locations` and `/dashboard/warehouse/map` routes.
+- [x] Confirm current table and column names before migration work.
+- [x] Confirm inventory stock table name (`product_location_stock`).
+- [x] Confirm locale route structure (`app/[locale]/dashboard/...`).
+- [x] Document repo/plan mismatches.
+
+### Phase 0 mismatch details
+
+1. Plan references an external markdown file path not available in this container.
+2. Existing schema already includes v1 map concepts (`map_role`, `front_segment`, `top_down_unit`, `top_storage_segment`) and shape RPCs with replace-all semantics that must be preserved for legacy UI during transition.
+3. Inventory table for location stock exists as `product_location_stock` (not just a hypothetical table name).
+
+## Phase 1 — Database foundation (additive only)
+
+- [x] `locations_v2_entity_cleanup` migration created.
+- [x] `locations_v2_visual_nodes` migration created.
+- [x] `locations_v2_split_nodes` migration created.
+- [x] `locations_v2_mapping_archive_functions` migration created.
+- [x] `locations_v2_backfill_visual_nodes` migration created.
+- [x] `locations_v2_verification_queries` migration created.
+- [ ] Apply migrations to target database.
+- [ ] Regenerate Supabase types (if/when connected workflow is executed).
+- [ ] Run post-apply verification queries against live data.
+
+## Phase 2+
+
+- [ ] Not started (intentionally deferred per instruction: start with Phase 0 and Phase 1 only).
+
+## Migration Fix Pass (2026-05-07)
+
+- Strategy: amended original Phase 1 local migrations directly (assumed not applied to shared DB yet).
+- Fixed `location_category` to controlled enum-like set with normalization + CHECK.
+- Removed invalid `top_storage_segment` column usage; now uses `map_role` value mapping only.
+- Hardened `can_store_inventory` backfill to conservative leaf-only role logic.
+- Updated visual nodes schema:
+  - added `visualization_type`
+  - enforced controlled `visual_role`
+  - changed status set to `active|hidden|historical`
+  - changed `view_context_location_id` FK to `ON DELETE SET NULL`
+  - primary-node unique index now scoped to active `visual_role='primary'`.
+- Updated split nodes schema:
+  - added `cache_valid`
+  - aligned `size_mode` to `equal|ratio|fixed|auto`
+  - `view_context_location_id` changed to nullable + `ON DELETE SET NULL`.
+- Reworked RPCs:
+  - `get_warehouse_location_mapping_status()` now returns `mapping_status` + child mapped counts.
+  - `validate_warehouse_location_archive()` now returns UI-friendly `blockers[]` and `warnings[]`, and optional-table checks validate table+column presence before dynamic SQL references.
+- Backfill migration corrected:
+  - sets `visualization_type`
+  - sets `visual_role='primary'`
+  - maps `front_elevation -> front`
+  - uses `anchor_location_id`/root for `view_context_location_id`
+  - avoids duplicates via scoped `NOT EXISTS`
+  - keeps legacy shapes intact.
+- Verification migration converted into rerunnable function:
+  - `public.verify_locations_v2_migration()`
+
+### Remaining before Phase 2
+
+- Apply amended migrations to Supabase target environment.
+- Execute `public.verify_locations_v2_migration()` in dev/staging.
+- Confirm zero duplicates/invalid categories/invalid visual roles on real data.
+- Confirm `validate_warehouse_location_archive()` behavior against environments with optional dependency tables.


### PR DESCRIPTION
### Motivation

- Introduce additive database migrations to support a Locations V2 refactor that separates visual map nodes from inventory entities and paves the way for new editors and mapping status checks.
- Normalize and harden existing `warehouse_locations` fields (categories, dimensions, can_store_inventory, status) and provide conservative backfills from legacy fields.
- Provide server-side mapping status, archive validation, and a reusable verification query to make the migration runnable and auditable in target environments.

### Description

- Added `locations_v2_entity_cleanup` migration to add `can_store_inventory`, `status`, `location_category`, dimension columns, reworked constraints, conservative backfills from legacy meter fields, and new indexes scoped to active rows.
- Added `warehouse_location_visual_nodes` table via `locations_v2_visual_nodes` migration with controlled enums, geometry fields, uniqueness scoped to active primary nodes, RLS and permissive policies for read/insert/update and denies delete.
- Added `warehouse_layout_split_nodes` table via `locations_v2_split_nodes` migration to model view split/container cells with size modes, cached layout fields, indexes and RLS policies.
- Added `get_warehouse_location_mapping_status` and `validate_warehouse_location_archive` functions in `locations_v2_mapping_archive_functions` to compute mapping status and to return UI-friendly `blockers`/`warnings` with optional-table safety checks.
- Added `locations_v2_backfill_visual_nodes` migration to backfill legacy `warehouse_layout_shapes` into the new `warehouse_location_visual_nodes` table while avoiding duplicates and mapping front/top projections appropriately.
- Added `verify_locations_v2_migration` function in `locations_v2_verification_queries` to produce counts and validation metrics for post-migration verification, and added `docs/locations-v2-implementation-progress.md` documenting the plan and migration checklist.

### Testing

- No automated tests were executed as part of this change; migrations and functions were authored as rerunnable SQL files for application to the target database.
- A verification helper `verify_locations_v2_migration()` was added and should be executed against the target DB after applying migrations to validate counts and detect duplicates or invalid states.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc283c1a188328a2c2a4086d4e9871)