### PR TITLE
Add Locations V2 Phase 1 migrations: entities, visual & split nodes, mapping/archive functions, backfill and verification

### DIFF
--- a/apps/web/supabase/migrations/20260507130000_locations_v2_entity_cleanup.sql
+++ b/apps/web/supabase/migrations/20260507130000_locations_v2_entity_cleanup.sql
@@ -2,7 +2,7 @@
 
 ALTER TABLE public.warehouse_locations
   ADD COLUMN IF NOT EXISTS can_store_inventory BOOLEAN,
-  ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'archived')),
+  ADD COLUMN IF NOT EXISTS status TEXT,
   ADD COLUMN IF NOT EXISTS location_category TEXT,
   ADD COLUMN IF NOT EXISTS width_mm INTEGER,
   ADD COLUMN IF NOT EXISTS height_mm INTEGER,
@@ -19,7 +19,6 @@ ALTER TABLE public.warehouse_locations
     (depth_mm IS NULL OR depth_mm > 0)
   );
 
--- Conservative backfill from legacy meter fields when present.
 UPDATE public.warehouse_locations
 SET
   width_mm = COALESCE(width_mm, CASE WHEN physical_width_m IS NOT NULL AND physical_width_m > 0 THEN (physical_width_m * 1000)::INTEGER END),
@@ -27,14 +26,13 @@ SET
   depth_mm = COALESCE(depth_mm, CASE WHEN physical_depth_m IS NOT NULL AND physical_depth_m > 0 THEN (physical_depth_m * 1000)::INTEGER END)
 WHERE true;
 
--- Controlled V2 categories only.
+-- Controlled categories only.
 UPDATE public.warehouse_locations
 SET location_category = CASE
   WHEN map_role = 'top_down_unit' THEN 'rack'
   WHEN map_role = 'front_segment' THEN 'shelf'
   WHEN map_role = 'top_storage_segment' THEN 'bin'
   WHEN map_role = 'layout_root' THEN 'area'
-  WHEN map_role = 'logical' THEN 'custom'
   ELSE 'custom'
 END
 WHERE location_category IS NULL
@@ -44,44 +42,56 @@ WHERE location_category IS NULL
      'receiving','dispatch','quarantine','temporary','custom'
    );
 
-ALTER TABLE public.warehouse_locations
-  DROP CONSTRAINT IF EXISTS warehouse_locations_location_category_valid;
-
+ALTER TABLE public.warehouse_locations DROP CONSTRAINT IF EXISTS warehouse_locations_location_category_valid;
 ALTER TABLE public.warehouse_locations
   ADD CONSTRAINT warehouse_locations_location_category_valid
-  CHECK (
-    location_category IN (
-      'area','zone','room','cabinet','rack','shelf_unit','workbench',
-      'shelf','drawer','bin','box','pallet_position','wall_storage',
-      'receiving','dispatch','quarantine','temporary','custom'
-    )
-  );
+  CHECK (location_category IN ('area','zone','room','cabinet','rack','shelf_unit','workbench','shelf','drawer','bin','box','pallet_position','wall_storage','receiving','dispatch','quarantine','temporary','custom'));
 
--- Conservative can_store_inventory backfill.
+ALTER TABLE public.warehouse_locations
+  ALTER COLUMN location_category SET DEFAULT 'custom';
+UPDATE public.warehouse_locations SET location_category = 'custom' WHERE location_category IS NULL;
+ALTER TABLE public.warehouse_locations
+  ALTER COLUMN location_category SET NOT NULL;
+
+-- Conservative can_store_inventory backfill (leaf-only storage-like nodes).
 UPDATE public.warehouse_locations wl
 SET can_store_inventory = true
 WHERE wl.deleted_at IS NULL
   AND wl.can_store_inventory IS NULL
   AND wl.map_role IN ('front_segment', 'top_storage_segment')
   AND NOT EXISTS (
-    SELECT 1
-    FROM public.warehouse_locations child
-    WHERE child.parent_id = wl.id
-      AND child.deleted_at IS NULL
+    SELECT 1 FROM public.warehouse_locations child
+    WHERE child.parent_id = wl.id AND child.deleted_at IS NULL
   );
 
 UPDATE public.warehouse_locations wl
 SET can_store_inventory = false
 WHERE wl.can_store_inventory IS NULL;
 
+ALTER TABLE public.warehouse_locations
+  ALTER COLUMN can_store_inventory SET DEFAULT false;
+ALTER TABLE public.warehouse_locations
+  ALTER COLUMN can_store_inventory SET NOT NULL;
+
+-- location status normalization and constraint (active|inactive|archived)
+UPDATE public.warehouse_locations
+SET status = 'active'
+WHERE status IS NULL OR status NOT IN ('active', 'inactive', 'archived');
+
+ALTER TABLE public.warehouse_locations DROP CONSTRAINT IF EXISTS warehouse_locations_status_valid;
+ALTER TABLE public.warehouse_locations
+  ADD CONSTRAINT warehouse_locations_status_valid CHECK (status IN ('active', 'inactive', 'archived'));
+ALTER TABLE public.warehouse_locations
+  ALTER COLUMN status SET DEFAULT 'active';
+ALTER TABLE public.warehouse_locations
+  ALTER COLUMN status SET NOT NULL;
+
 CREATE INDEX IF NOT EXISTS wl_status_active_idx
   ON public.warehouse_locations (organization_id, branch_id, status)
   WHERE deleted_at IS NULL;
-
 CREATE INDEX IF NOT EXISTS wl_category_active_idx
   ON public.warehouse_locations (organization_id, branch_id, location_category)
   WHERE deleted_at IS NULL;
-
 CREATE INDEX IF NOT EXISTS wl_can_store_inventory_active_idx
   ON public.warehouse_locations (organization_id, branch_id, can_store_inventory)
   WHERE deleted_at IS NULL;

--- a/apps/web/supabase/migrations/20260507130000_locations_v2_entity_cleanup.sql
+++ b/apps/web/supabase/migrations/20260507130000_locations_v2_entity_cleanup.sql
@@ -1,0 +1,87 @@
+-- Locations V2 Phase 1.1: entity cleanup (additive)
+
+ALTER TABLE public.warehouse_locations
+  ADD COLUMN IF NOT EXISTS can_store_inventory BOOLEAN,
+  ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'archived')),
+  ADD COLUMN IF NOT EXISTS location_category TEXT,
+  ADD COLUMN IF NOT EXISTS width_mm INTEGER,
+  ADD COLUMN IF NOT EXISTS height_mm INTEGER,
+  ADD COLUMN IF NOT EXISTS depth_mm INTEGER;
+
+ALTER TABLE public.warehouse_locations
+  DROP CONSTRAINT IF EXISTS warehouse_locations_dimensions_non_negative;
+
+ALTER TABLE public.warehouse_locations
+  ADD CONSTRAINT warehouse_locations_dimensions_non_negative
+  CHECK (
+    (width_mm IS NULL OR width_mm > 0) AND
+    (height_mm IS NULL OR height_mm > 0) AND
+    (depth_mm IS NULL OR depth_mm > 0)
+  );
+
+-- Conservative backfill from legacy meter fields when present.
+UPDATE public.warehouse_locations
+SET
+  width_mm = COALESCE(width_mm, CASE WHEN physical_width_m IS NOT NULL AND physical_width_m > 0 THEN (physical_width_m * 1000)::INTEGER END),
+  height_mm = COALESCE(height_mm, CASE WHEN physical_height_m IS NOT NULL AND physical_height_m > 0 THEN (physical_height_m * 1000)::INTEGER END),
+  depth_mm = COALESCE(depth_mm, CASE WHEN physical_depth_m IS NOT NULL AND physical_depth_m > 0 THEN (physical_depth_m * 1000)::INTEGER END)
+WHERE true;
+
+-- Controlled V2 categories only.
+UPDATE public.warehouse_locations
+SET location_category = CASE
+  WHEN map_role = 'top_down_unit' THEN 'rack'
+  WHEN map_role = 'front_segment' THEN 'shelf'
+  WHEN map_role = 'top_storage_segment' THEN 'bin'
+  WHEN map_role = 'layout_root' THEN 'area'
+  WHEN map_role = 'logical' THEN 'custom'
+  ELSE 'custom'
+END
+WHERE location_category IS NULL
+   OR location_category NOT IN (
+     'area','zone','room','cabinet','rack','shelf_unit','workbench',
+     'shelf','drawer','bin','box','pallet_position','wall_storage',
+     'receiving','dispatch','quarantine','temporary','custom'
+   );
+
+ALTER TABLE public.warehouse_locations
+  DROP CONSTRAINT IF EXISTS warehouse_locations_location_category_valid;
+
+ALTER TABLE public.warehouse_locations
+  ADD CONSTRAINT warehouse_locations_location_category_valid
+  CHECK (
+    location_category IN (
+      'area','zone','room','cabinet','rack','shelf_unit','workbench',
+      'shelf','drawer','bin','box','pallet_position','wall_storage',
+      'receiving','dispatch','quarantine','temporary','custom'
+    )
+  );
+
+-- Conservative can_store_inventory backfill.
+UPDATE public.warehouse_locations wl
+SET can_store_inventory = true
+WHERE wl.deleted_at IS NULL
+  AND wl.can_store_inventory IS NULL
+  AND wl.map_role IN ('front_segment', 'top_storage_segment')
+  AND NOT EXISTS (
+    SELECT 1
+    FROM public.warehouse_locations child
+    WHERE child.parent_id = wl.id
+      AND child.deleted_at IS NULL
+  );
+
+UPDATE public.warehouse_locations wl
+SET can_store_inventory = false
+WHERE wl.can_store_inventory IS NULL;
+
+CREATE INDEX IF NOT EXISTS wl_status_active_idx
+  ON public.warehouse_locations (organization_id, branch_id, status)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS wl_category_active_idx
+  ON public.warehouse_locations (organization_id, branch_id, location_category)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS wl_can_store_inventory_active_idx
+  ON public.warehouse_locations (organization_id, branch_id, can_store_inventory)
+  WHERE deleted_at IS NULL;

--- a/apps/web/supabase/migrations/20260507131000_locations_v2_visual_nodes.sql
+++ b/apps/web/supabase/migrations/20260507131000_locations_v2_visual_nodes.sql
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS public.warehouse_location_visual_nodes (
   z_mm INTEGER NOT NULL DEFAULT 0,
   width_mm INTEGER NOT NULL CHECK (width_mm > 0),
   height_mm INTEGER NOT NULL CHECK (height_mm > 0),
-  depth_mm INTEGER NOT NULL CHECK (depth_mm > 0),
+  depth_mm INTEGER CHECK (depth_mm IS NULL OR depth_mm > 0),
 
   rotation_deg NUMERIC(8,2) NOT NULL DEFAULT 0,
   style JSONB,
@@ -74,3 +74,14 @@ DROP POLICY IF EXISTS wlvn_delete_deny ON public.warehouse_location_visual_nodes
 CREATE POLICY wlvn_delete_deny
   ON public.warehouse_location_visual_nodes FOR DELETE
   USING (false);
+
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.routines WHERE routine_schema='public' AND routine_name='set_updated_at') THEN
+    DROP TRIGGER IF EXISTS warehouse_location_visual_nodes_updated_at ON public.warehouse_location_visual_nodes;
+    CREATE TRIGGER warehouse_location_visual_nodes_updated_at
+      BEFORE UPDATE ON public.warehouse_location_visual_nodes
+      FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+  END IF;
+END $$;

--- a/apps/web/supabase/migrations/20260507131000_locations_v2_visual_nodes.sql
+++ b/apps/web/supabase/migrations/20260507131000_locations_v2_visual_nodes.sql
@@ -1,0 +1,76 @@
+-- Locations V2 Phase 1.2: visual nodes table (separate from inventory entities)
+
+CREATE TABLE IF NOT EXISTS public.warehouse_location_visual_nodes (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  layout_id UUID NOT NULL REFERENCES public.warehouse_layouts(id) ON DELETE CASCADE,
+  organization_id UUID NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  branch_id UUID NOT NULL REFERENCES public.branches(id) ON DELETE CASCADE,
+
+  location_id UUID NOT NULL REFERENCES public.warehouse_locations(id) ON DELETE RESTRICT,
+  view_type TEXT NOT NULL CHECK (view_type IN ('top_down', 'front', 'interior')),
+  view_context_location_id UUID NULL REFERENCES public.warehouse_locations(id) ON DELETE SET NULL,
+  visualization_type TEXT NOT NULL DEFAULT 'rectangle' CHECK (visualization_type IN ('rectangle','cabinet','rack','grid','drawer','bin','zone','custom')),
+  visual_role TEXT NOT NULL DEFAULT 'primary' CHECK (visual_role IN ('primary','label','reference','aggregate')),
+  status TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'hidden', 'historical')),
+
+  x_mm INTEGER NOT NULL DEFAULT 0,
+  y_mm INTEGER NOT NULL DEFAULT 0,
+  z_mm INTEGER NOT NULL DEFAULT 0,
+  width_mm INTEGER NOT NULL CHECK (width_mm > 0),
+  height_mm INTEGER NOT NULL CHECK (height_mm > 0),
+  depth_mm INTEGER NOT NULL CHECK (depth_mm > 0),
+
+  rotation_deg NUMERIC(8,2) NOT NULL DEFAULT 0,
+  style JSONB,
+  z_index INTEGER NOT NULL DEFAULT 0,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+
+  created_by UUID NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  updated_by UUID NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  deleted_at TIMESTAMPTZ NULL
+);
+
+-- NOTE: uniqueness applies to active PRIMARY nodes only.
+CREATE UNIQUE INDEX IF NOT EXISTS wlvn_primary_unique_idx
+  ON public.warehouse_location_visual_nodes (
+    location_id,
+    view_type,
+    COALESCE(layout_id, '00000000-0000-0000-0000-000000000000'::uuid),
+    COALESCE(view_context_location_id, '00000000-0000-0000-0000-000000000000'::uuid)
+  )
+  WHERE deleted_at IS NULL
+    AND status = 'active'
+    AND visual_role = 'primary';
+
+CREATE INDEX IF NOT EXISTS wlvn_scope_active_idx
+  ON public.warehouse_location_visual_nodes (layout_id, view_type, view_context_location_id)
+  WHERE deleted_at IS NULL;
+
+ALTER TABLE public.warehouse_location_visual_nodes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.warehouse_location_visual_nodes FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS wlvn_select_layout_read ON public.warehouse_location_visual_nodes;
+CREATE POLICY wlvn_select_layout_read
+  ON public.warehouse_location_visual_nodes FOR SELECT
+  USING (
+    public.has_branch_permission(organization_id, branch_id, 'warehouse.layouts.read')
+    AND deleted_at IS NULL
+  );
+
+DROP POLICY IF EXISTS wlvn_insert_layout_manage ON public.warehouse_location_visual_nodes;
+CREATE POLICY wlvn_insert_layout_manage
+  ON public.warehouse_location_visual_nodes FOR INSERT
+  WITH CHECK (public.has_branch_permission(organization_id, branch_id, 'warehouse.layouts.manage'));
+
+DROP POLICY IF EXISTS wlvn_update_layout_manage ON public.warehouse_location_visual_nodes;
+CREATE POLICY wlvn_update_layout_manage
+  ON public.warehouse_location_visual_nodes FOR UPDATE
+  USING (public.has_branch_permission(organization_id, branch_id, 'warehouse.layouts.manage'))
+  WITH CHECK (public.has_branch_permission(organization_id, branch_id, 'warehouse.layouts.manage'));
+
+DROP POLICY IF EXISTS wlvn_delete_deny ON public.warehouse_location_visual_nodes;
+CREATE POLICY wlvn_delete_deny
+  ON public.warehouse_location_visual_nodes FOR DELETE
+  USING (false);

--- a/apps/web/supabase/migrations/20260507132000_locations_v2_split_nodes.sql
+++ b/apps/web/supabase/migrations/20260507132000_locations_v2_split_nodes.sql
@@ -1,0 +1,61 @@
+-- Locations V2 Phase 1.3: split nodes for front/interior structural editors
+
+CREATE TABLE IF NOT EXISTS public.warehouse_layout_split_nodes (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  layout_id UUID NOT NULL REFERENCES public.warehouse_layouts(id) ON DELETE CASCADE,
+  organization_id UUID NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  branch_id UUID NOT NULL REFERENCES public.branches(id) ON DELETE CASCADE,
+  view_context_location_id UUID NULL REFERENCES public.warehouse_locations(id) ON DELETE SET NULL,
+
+  parent_node_id UUID NULL REFERENCES public.warehouse_layout_split_nodes(id) ON DELETE CASCADE,
+  node_kind TEXT NOT NULL CHECK (node_kind IN ('container', 'cell')),
+  split_direction TEXT NULL CHECK (split_direction IN ('horizontal', 'vertical')),
+  size_mode TEXT NOT NULL DEFAULT 'equal' CHECK (size_mode IN ('equal', 'ratio', 'fixed', 'auto')),
+  size_value NUMERIC(10,3) NULL,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  linked_location_id UUID NULL REFERENCES public.warehouse_locations(id) ON DELETE SET NULL,
+
+  calc_x_mm INTEGER,
+  calc_y_mm INTEGER,
+  calc_width_mm INTEGER,
+  calc_height_mm INTEGER,
+  calc_depth_mm INTEGER,
+  cache_valid BOOLEAN NOT NULL DEFAULT false,
+
+  created_by UUID NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  updated_by UUID NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  deleted_at TIMESTAMPTZ NULL
+);
+
+CREATE INDEX IF NOT EXISTS wlsn_scope_active_idx
+  ON public.warehouse_layout_split_nodes (layout_id, view_context_location_id)
+  WHERE deleted_at IS NULL;
+
+ALTER TABLE public.warehouse_layout_split_nodes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.warehouse_layout_split_nodes FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS wlsn_select_layout_read ON public.warehouse_layout_split_nodes;
+CREATE POLICY wlsn_select_layout_read
+  ON public.warehouse_layout_split_nodes FOR SELECT
+  USING (
+    public.has_branch_permission(organization_id, branch_id, 'warehouse.layouts.read')
+    AND deleted_at IS NULL
+  );
+
+DROP POLICY IF EXISTS wlsn_insert_layout_manage ON public.warehouse_layout_split_nodes;
+CREATE POLICY wlsn_insert_layout_manage
+  ON public.warehouse_layout_split_nodes FOR INSERT
+  WITH CHECK (public.has_branch_permission(organization_id, branch_id, 'warehouse.layouts.manage'));
+
+DROP POLICY IF EXISTS wlsn_update_layout_manage ON public.warehouse_layout_split_nodes;
+CREATE POLICY wlsn_update_layout_manage
+  ON public.warehouse_layout_split_nodes FOR UPDATE
+  USING (public.has_branch_permission(organization_id, branch_id, 'warehouse.layouts.manage'))
+  WITH CHECK (public.has_branch_permission(organization_id, branch_id, 'warehouse.layouts.manage'));
+
+DROP POLICY IF EXISTS wlsn_delete_deny ON public.warehouse_layout_split_nodes;
+CREATE POLICY wlsn_delete_deny
+  ON public.warehouse_layout_split_nodes FOR DELETE
+  USING (false);

--- a/apps/web/supabase/migrations/20260507132000_locations_v2_split_nodes.sql
+++ b/apps/web/supabase/migrations/20260507132000_locations_v2_split_nodes.sql
@@ -1,4 +1,8 @@
 -- Locations V2 Phase 1.3: split nodes for front/interior structural editors
+-- FK behavior:
+-- - parent_node_id cascades within split-tree hierarchy.
+-- - parent_visual_node_id cascades when removing the owning visual container.
+-- - view_context_location_id / linked_location_id are SET NULL to preserve split history.
 
 CREATE TABLE IF NOT EXISTS public.warehouse_layout_split_nodes (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -6,6 +10,7 @@ CREATE TABLE IF NOT EXISTS public.warehouse_layout_split_nodes (
   organization_id UUID NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
   branch_id UUID NOT NULL REFERENCES public.branches(id) ON DELETE CASCADE,
   view_context_location_id UUID NULL REFERENCES public.warehouse_locations(id) ON DELETE SET NULL,
+  parent_visual_node_id UUID NULL REFERENCES public.warehouse_location_visual_nodes(id) ON DELETE CASCADE,
 
   parent_node_id UUID NULL REFERENCES public.warehouse_layout_split_nodes(id) ON DELETE CASCADE,
   node_kind TEXT NOT NULL CHECK (node_kind IN ('container', 'cell')),
@@ -17,6 +22,7 @@ CREATE TABLE IF NOT EXISTS public.warehouse_layout_split_nodes (
 
   calc_x_mm INTEGER,
   calc_y_mm INTEGER,
+  calc_z_mm INTEGER,
   calc_width_mm INTEGER,
   calc_height_mm INTEGER,
   calc_depth_mm INTEGER,
@@ -31,6 +37,10 @@ CREATE TABLE IF NOT EXISTS public.warehouse_layout_split_nodes (
 
 CREATE INDEX IF NOT EXISTS wlsn_scope_active_idx
   ON public.warehouse_layout_split_nodes (layout_id, view_context_location_id)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS wlsn_parent_visual_node_idx
+  ON public.warehouse_layout_split_nodes(parent_visual_node_id)
   WHERE deleted_at IS NULL;
 
 ALTER TABLE public.warehouse_layout_split_nodes ENABLE ROW LEVEL SECURITY;
@@ -59,3 +69,13 @@ DROP POLICY IF EXISTS wlsn_delete_deny ON public.warehouse_layout_split_nodes;
 CREATE POLICY wlsn_delete_deny
   ON public.warehouse_layout_split_nodes FOR DELETE
   USING (false);
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.routines WHERE routine_schema='public' AND routine_name='set_updated_at') THEN
+    DROP TRIGGER IF EXISTS warehouse_layout_split_nodes_updated_at ON public.warehouse_layout_split_nodes;
+    CREATE TRIGGER warehouse_layout_split_nodes_updated_at
+      BEFORE UPDATE ON public.warehouse_layout_split_nodes
+      FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+  END IF;
+END $$;

--- a/apps/web/supabase/migrations/20260507133000_locations_v2_mapping_archive_functions.sql
+++ b/apps/web/supabase/migrations/20260507133000_locations_v2_mapping_archive_functions.sql
@@ -16,6 +16,8 @@ DECLARE
   v_unmapped_child_count INTEGER := 0;
   v_mapping_status TEXT := 'unmapped';
 BEGIN
+  -- Phase 1 scope: mapping_status is direct-child aware only.
+  -- Descendant-aware storage mapping can be added in a later phase if required.
   SELECT COUNT(*) INTO v_visual_count
   FROM public.warehouse_location_visual_nodes
   WHERE location_id = p_location_id
@@ -98,13 +100,14 @@ DECLARE
   v_blockers JSONB := '[]'::jsonb;
   v_warnings JSONB := '[]'::jsonb;
 BEGIN
-  SELECT COUNT(*), COALESCE(SUM(pls.quantity), 0)
-    INTO v_direct_stock_count, v_direct_stock_qty
-  FROM public.product_location_stock pls
-  WHERE pls.location_id = p_location_id
-    AND COALESCE(pls.quantity, 0) > 0;
+  IF to_regclass('public.product_location_stock') IS NOT NULL
+     AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='product_location_stock' AND column_name='location_id')
+     AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='product_location_stock' AND column_name='quantity')
+  THEN
+    EXECUTE 'SELECT COUNT(*), COALESCE(SUM(quantity), 0) FROM public.product_location_stock WHERE location_id = $1 AND COALESCE(quantity, 0) > 0'
+      INTO v_direct_stock_count, v_direct_stock_qty USING p_location_id;
 
-  WITH RECURSIVE descendants AS (
+    WITH RECURSIVE descendants AS (
     SELECT wl.id
     FROM public.warehouse_locations wl
     WHERE wl.parent_id = p_location_id AND wl.deleted_at IS NULL
@@ -114,11 +117,12 @@ BEGIN
     JOIN descendants d ON d.id = wl2.parent_id
     WHERE wl2.deleted_at IS NULL
   )
-  SELECT COUNT(*), COALESCE(SUM(pls.quantity), 0)
-    INTO v_desc_stock_count, v_desc_stock_qty
-  FROM public.product_location_stock pls
-  JOIN descendants d ON d.id = pls.location_id
-  WHERE COALESCE(pls.quantity, 0) > 0;
+    SELECT COUNT(*), COALESCE(SUM(pls.quantity), 0)
+      INTO v_desc_stock_count, v_desc_stock_qty
+    FROM public.product_location_stock pls
+    JOIN descendants d ON d.id = pls.location_id
+    WHERE COALESCE(pls.quantity, 0) > 0;
+  END IF;
 
   SELECT COUNT(*) INTO v_active_children_count
   FROM public.warehouse_locations wl

--- a/apps/web/supabase/migrations/20260507133000_locations_v2_mapping_archive_functions.sql
+++ b/apps/web/supabase/migrations/20260507133000_locations_v2_mapping_archive_functions.sql
@@ -1,0 +1,169 @@
+-- Locations V2 Phase 1.4: mapping status + archive validation
+
+CREATE OR REPLACE FUNCTION public.get_warehouse_location_mapping_status(
+  p_location_id UUID
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+DECLARE
+  v_visual_count INTEGER := 0;
+  v_has_top_down BOOLEAN := false;
+  v_has_front_or_interior BOOLEAN := false;
+  v_active_child_count INTEGER := 0;
+  v_mapped_child_count INTEGER := 0;
+  v_unmapped_child_count INTEGER := 0;
+  v_mapping_status TEXT := 'unmapped';
+BEGIN
+  SELECT COUNT(*) INTO v_visual_count
+  FROM public.warehouse_location_visual_nodes
+  WHERE location_id = p_location_id
+    AND deleted_at IS NULL
+    AND status = 'active';
+
+  SELECT EXISTS (
+    SELECT 1 FROM public.warehouse_location_visual_nodes
+    WHERE location_id = p_location_id
+      AND view_type = 'top_down'
+      AND deleted_at IS NULL
+      AND status = 'active'
+  ) INTO v_has_top_down;
+
+  SELECT EXISTS (
+    SELECT 1 FROM public.warehouse_location_visual_nodes
+    WHERE location_id = p_location_id
+      AND view_type IN ('front', 'interior')
+      AND deleted_at IS NULL
+      AND status = 'active'
+  ) INTO v_has_front_or_interior;
+
+  SELECT COUNT(*) INTO v_active_child_count
+  FROM public.warehouse_locations c
+  WHERE c.parent_id = p_location_id
+    AND c.deleted_at IS NULL
+    AND COALESCE(c.status, 'active') = 'active';
+
+  SELECT COUNT(*) INTO v_mapped_child_count
+  FROM public.warehouse_locations c
+  WHERE c.parent_id = p_location_id
+    AND c.deleted_at IS NULL
+    AND COALESCE(c.status, 'active') = 'active'
+    AND EXISTS (
+      SELECT 1 FROM public.warehouse_location_visual_nodes n
+      WHERE n.location_id = c.id
+        AND n.deleted_at IS NULL
+        AND n.status = 'active'
+    );
+
+  v_unmapped_child_count := GREATEST(v_active_child_count - v_mapped_child_count, 0);
+
+  IF v_visual_count = 0 THEN
+    v_mapping_status := 'unmapped';
+  ELSIF v_unmapped_child_count > 0 THEN
+    v_mapping_status := 'partially_mapped';
+  ELSE
+    v_mapping_status := 'mapped';
+  END IF;
+
+  RETURN jsonb_build_object(
+    'location_id', p_location_id,
+    'mapping_status', v_mapping_status,
+    'is_mapped', v_visual_count > 0,
+    'visual_node_count', v_visual_count,
+    'active_child_count', v_active_child_count,
+    'mapped_child_count', v_mapped_child_count,
+    'unmapped_child_count', v_unmapped_child_count,
+    'has_top_down', v_has_top_down,
+    'has_front_or_interior', v_has_front_or_interior
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.validate_warehouse_location_archive(
+  p_location_id UUID
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+DECLARE
+  v_direct_stock_count BIGINT := 0;
+  v_direct_stock_qty NUMERIC := 0;
+  v_desc_stock_count BIGINT := 0;
+  v_desc_stock_qty NUMERIC := 0;
+  v_active_children_count BIGINT := 0;
+  v_reserved_stock_count BIGINT := 0;
+  v_has_visual_nodes BIGINT := 0;
+  v_blockers JSONB := '[]'::jsonb;
+  v_warnings JSONB := '[]'::jsonb;
+BEGIN
+  SELECT COUNT(*), COALESCE(SUM(pls.quantity), 0)
+    INTO v_direct_stock_count, v_direct_stock_qty
+  FROM public.product_location_stock pls
+  WHERE pls.location_id = p_location_id
+    AND COALESCE(pls.quantity, 0) > 0;
+
+  WITH RECURSIVE descendants AS (
+    SELECT wl.id
+    FROM public.warehouse_locations wl
+    WHERE wl.parent_id = p_location_id AND wl.deleted_at IS NULL
+    UNION ALL
+    SELECT wl2.id
+    FROM public.warehouse_locations wl2
+    JOIN descendants d ON d.id = wl2.parent_id
+    WHERE wl2.deleted_at IS NULL
+  )
+  SELECT COUNT(*), COALESCE(SUM(pls.quantity), 0)
+    INTO v_desc_stock_count, v_desc_stock_qty
+  FROM public.product_location_stock pls
+  JOIN descendants d ON d.id = pls.location_id
+  WHERE COALESCE(pls.quantity, 0) > 0;
+
+  SELECT COUNT(*) INTO v_active_children_count
+  FROM public.warehouse_locations wl
+  WHERE wl.parent_id = p_location_id
+    AND wl.deleted_at IS NULL
+    AND COALESCE(wl.status, 'active') = 'active';
+
+  IF to_regclass('public.stock_reservations') IS NOT NULL
+     AND EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='stock_reservations' AND column_name='location_id')
+  THEN
+    EXECUTE format('SELECT COUNT(*) FROM public.stock_reservations sr WHERE sr.location_id = $1 %s %s',
+      CASE WHEN EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='stock_reservations' AND column_name='status')
+           THEN 'AND COALESCE(sr.status, ''active'') IN (''active'', ''partially_released'')' ELSE '' END,
+      CASE WHEN EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='stock_reservations' AND column_name='deleted_at')
+           THEN 'AND sr.deleted_at IS NULL' ELSE '' END
+    ) INTO v_reserved_stock_count USING p_location_id;
+  END IF;
+
+  SELECT COUNT(*) INTO v_has_visual_nodes
+  FROM public.warehouse_location_visual_nodes n
+  WHERE n.location_id = p_location_id
+    AND n.deleted_at IS NULL
+    AND n.status = 'active';
+
+  IF v_direct_stock_count > 0 THEN
+    v_blockers := v_blockers || jsonb_build_array(jsonb_build_object('type','direct_stock','message','Location contains active inventory','count',v_direct_stock_count,'quantity',v_direct_stock_qty));
+  END IF;
+  IF v_desc_stock_count > 0 THEN
+    v_blockers := v_blockers || jsonb_build_array(jsonb_build_object('type','descendant_stock','message','Descendant locations contain active inventory','count',v_desc_stock_count,'quantity',v_desc_stock_qty));
+  END IF;
+  IF v_active_children_count > 0 THEN
+    v_blockers := v_blockers || jsonb_build_array(jsonb_build_object('type','active_children','message','Location has active child locations','count',v_active_children_count));
+  END IF;
+  IF v_reserved_stock_count > 0 THEN
+    v_blockers := v_blockers || jsonb_build_array(jsonb_build_object('type','reserved_stock','message','Location has active stock reservations','count',v_reserved_stock_count));
+  END IF;
+  IF v_has_visual_nodes > 0 THEN
+    v_warnings := v_warnings || jsonb_build_array(jsonb_build_object('type','has_visual_nodes','message','Location has visual map representations','count',v_has_visual_nodes));
+  END IF;
+
+  RETURN jsonb_build_object(
+    'location_id', p_location_id,
+    'can_archive', jsonb_array_length(v_blockers) = 0,
+    'blockers', v_blockers,
+    'warnings', v_warnings
+  );
+END;
+$$;

--- a/apps/web/supabase/migrations/20260507134000_locations_v2_backfill_visual_nodes.sql
+++ b/apps/web/supabase/migrations/20260507134000_locations_v2_backfill_visual_nodes.sql
@@ -1,0 +1,79 @@
+-- Locations V2 Phase 1.5: backfill legacy location shapes into visual nodes
+-- NOTE:
+-- - `warehouse_layout_shapes` remains for legacy/decorative shapes and old editor compatibility.
+-- - V2 location visuals should read from `warehouse_location_visual_nodes`.
+
+INSERT INTO public.warehouse_location_visual_nodes (
+  layout_id,
+  organization_id,
+  branch_id,
+  location_id,
+  view_type,
+  view_context_location_id,
+  visualization_type,
+  visual_role,
+  status,
+  x_mm,
+  y_mm,
+  z_mm,
+  width_mm,
+  height_mm,
+  depth_mm,
+  rotation_deg,
+  style,
+  z_index,
+  sort_order,
+  created_by,
+  updated_by,
+  created_at,
+  updated_at
+)
+SELECT
+  s.layout_id,
+  s.organization_id,
+  s.branch_id,
+  s.location_id,
+  CASE
+    WHEN COALESCE(s.projection, 'top_down') = 'front_elevation' THEN 'front'
+    ELSE 'top_down'
+  END::TEXT,
+  COALESCE(s.anchor_location_id, l.root_location_id),
+  CASE
+    WHEN wl.map_role = 'top_down_unit' THEN 'rack'
+    WHEN wl.map_role = 'front_segment' THEN 'grid'
+    WHEN wl.map_role = 'top_storage_segment' THEN 'bin'
+    ELSE 'rectangle'
+  END::TEXT,
+  'primary'::TEXT,
+  'active'::TEXT,
+  GREATEST((s.x * 1000)::INTEGER, 0),
+  GREATEST((s.y * 1000)::INTEGER, 0),
+  0,
+  GREATEST((s.width * 1000)::INTEGER, 1),
+  GREATEST((COALESCE(wl.physical_height_m, s.height) * 1000)::INTEGER, 1),
+  GREATEST((COALESCE(wl.physical_depth_m, s.height) * 1000)::INTEGER, 1),
+  s.rotation,
+  s.style,
+  s.z_index,
+  s.sort_order,
+  s.created_by,
+  s.created_by,
+  s.created_at,
+  s.updated_at
+FROM public.warehouse_layout_shapes s
+JOIN public.warehouse_layouts l ON l.id = s.layout_id
+JOIN public.warehouse_locations wl ON wl.id = s.location_id
+WHERE s.deleted_at IS NULL
+  AND s.shape_type = 'location'
+  AND s.location_id IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1
+    FROM public.warehouse_location_visual_nodes n
+    WHERE n.location_id = s.location_id
+      AND n.layout_id = s.layout_id
+      AND n.view_type = (CASE WHEN COALESCE(s.projection, 'top_down') = 'front_elevation' THEN 'front' ELSE 'top_down' END)
+      AND COALESCE(n.view_context_location_id, '00000000-0000-0000-0000-000000000000'::uuid) = COALESCE(COALESCE(s.anchor_location_id, l.root_location_id), '00000000-0000-0000-0000-000000000000'::uuid)
+      AND n.visual_role = 'primary'
+      AND n.deleted_at IS NULL
+      AND n.status = 'active'
+  );

--- a/apps/web/supabase/migrations/20260507134000_locations_v2_backfill_visual_nodes.sql
+++ b/apps/web/supabase/migrations/20260507134000_locations_v2_backfill_visual_nodes.sql
@@ -51,7 +51,11 @@ SELECT
   0,
   GREATEST((s.width * 1000)::INTEGER, 1),
   GREATEST((COALESCE(wl.physical_height_m, s.height) * 1000)::INTEGER, 1),
-  GREATEST((COALESCE(wl.physical_depth_m, s.height) * 1000)::INTEGER, 1),
+  CASE
+    WHEN wl.physical_depth_m IS NOT NULL AND wl.physical_depth_m > 0 THEN ROUND(wl.physical_depth_m * 1000)::INTEGER
+    WHEN wl.depth_mm IS NOT NULL AND wl.depth_mm > 0 THEN wl.depth_mm
+    ELSE NULL
+  END,
   s.rotation,
   s.style,
   s.z_index,

--- a/apps/web/supabase/migrations/20260507135000_locations_v2_verification_queries.sql
+++ b/apps/web/supabase/migrations/20260507135000_locations_v2_verification_queries.sql
@@ -1,0 +1,100 @@
+-- Locations V2 Phase 1.6: reusable verification function
+
+CREATE OR REPLACE FUNCTION public.verify_locations_v2_migration()
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+DECLARE
+  v_old_location_shape_count BIGINT := 0;
+  v_new_visual_node_count BIGINT := 0;
+  v_unmapped_stock_holding_locations BIGINT := 0;
+  v_stock_on_non_storable_locations BIGINT := 0;
+  v_storage_capable_parents_with_children BIGINT := 0;
+  v_duplicate_active_primary_visual_nodes BIGINT := 0;
+  v_invalid_location_categories BIGINT := 0;
+  v_invalid_visual_roles BIGINT := 0;
+  v_invalid_visual_statuses BIGINT := 0;
+  v_invalid_split_size_modes BIGINT := 0;
+BEGIN
+  SELECT COUNT(*) INTO v_old_location_shape_count
+  FROM public.warehouse_layout_shapes s
+  WHERE s.deleted_at IS NULL AND s.shape_type = 'location' AND s.location_id IS NOT NULL;
+
+  SELECT COUNT(*) INTO v_new_visual_node_count
+  FROM public.warehouse_location_visual_nodes n
+  WHERE n.deleted_at IS NULL AND n.status = 'active';
+
+  SELECT COUNT(*) INTO v_unmapped_stock_holding_locations
+  FROM (
+    SELECT wl.id
+    FROM public.warehouse_locations wl
+    JOIN public.product_location_stock pls ON pls.location_id = wl.id AND COALESCE(pls.quantity, 0) > 0
+    LEFT JOIN public.warehouse_location_visual_nodes n
+      ON n.location_id = wl.id AND n.deleted_at IS NULL AND n.status = 'active'
+    WHERE wl.deleted_at IS NULL
+    GROUP BY wl.id
+    HAVING COUNT(n.id) = 0
+  ) q;
+
+  SELECT COUNT(*) INTO v_stock_on_non_storable_locations
+  FROM (
+    SELECT wl.id
+    FROM public.warehouse_locations wl
+    JOIN public.product_location_stock pls ON pls.location_id = wl.id
+    WHERE wl.deleted_at IS NULL AND wl.can_store_inventory = false
+    GROUP BY wl.id
+    HAVING COALESCE(SUM(pls.quantity), 0) > 0
+  ) q;
+
+  SELECT COUNT(*) INTO v_storage_capable_parents_with_children
+  FROM (
+    SELECT p.id
+    FROM public.warehouse_locations p
+    JOIN public.warehouse_locations c ON c.parent_id = p.id AND c.deleted_at IS NULL AND COALESCE(c.status,'active')='active'
+    WHERE p.deleted_at IS NULL AND p.can_store_inventory = true
+    GROUP BY p.id
+  ) q;
+
+  SELECT COUNT(*) INTO v_duplicate_active_primary_visual_nodes
+  FROM (
+    SELECT n.location_id, n.view_type,
+      COALESCE(n.layout_id, '00000000-0000-0000-0000-000000000000'::uuid),
+      COALESCE(n.view_context_location_id, '00000000-0000-0000-0000-000000000000'::uuid)
+    FROM public.warehouse_location_visual_nodes n
+    WHERE n.deleted_at IS NULL AND n.status = 'active' AND n.visual_role = 'primary'
+    GROUP BY 1,2,3,4
+    HAVING COUNT(*) > 1
+  ) q;
+
+  SELECT COUNT(*) INTO v_invalid_location_categories
+  FROM public.warehouse_locations wl
+  WHERE wl.location_category IS NULL
+    OR wl.location_category NOT IN ('area','zone','room','cabinet','rack','shelf_unit','workbench','shelf','drawer','bin','box','pallet_position','wall_storage','receiving','dispatch','quarantine','temporary','custom');
+
+  SELECT COUNT(*) INTO v_invalid_visual_roles
+  FROM public.warehouse_location_visual_nodes n
+  WHERE n.visual_role NOT IN ('primary','label','reference','aggregate');
+
+  SELECT COUNT(*) INTO v_invalid_visual_statuses
+  FROM public.warehouse_location_visual_nodes n
+  WHERE n.status NOT IN ('active','hidden','historical');
+
+  SELECT COUNT(*) INTO v_invalid_split_size_modes
+  FROM public.warehouse_layout_split_nodes sn
+  WHERE sn.size_mode NOT IN ('equal','ratio','fixed','auto');
+
+  RETURN jsonb_build_object(
+    'old_location_shape_count', v_old_location_shape_count,
+    'new_visual_node_count', v_new_visual_node_count,
+    'unmapped_stock_holding_locations', v_unmapped_stock_holding_locations,
+    'stock_on_non_storable_locations', v_stock_on_non_storable_locations,
+    'storage_capable_parents_with_children', v_storage_capable_parents_with_children,
+    'duplicate_active_primary_visual_nodes', v_duplicate_active_primary_visual_nodes,
+    'invalid_location_categories', v_invalid_location_categories,
+    'invalid_visual_roles', v_invalid_visual_roles,
+    'invalid_visual_statuses', v_invalid_visual_statuses,
+    'invalid_split_size_modes', v_invalid_split_size_modes
+  );
+END;
+$$;

--- a/docs/locations-v2-implementation-progress.md
+++ b/docs/locations-v2-implementation-progress.md
@@ -81,3 +81,34 @@
 
 - manual verification SQL path: `docs/sql/locations-v2-verification.sql`
 - Phase 1 completion status: **not yet complete** until migrations are applied and verification function passes in dev/shared DB.
+
+## Migration Review Fix Pass (2026-05-07)
+
+- Fixed verification function syntax/return shape in `public.verify_locations_v2_migration()` and ensured JSONB return compiles.
+- Enforced `warehouse_locations.can_store_inventory` as `NOT NULL DEFAULT false` after normalization.
+- Enforced `warehouse_locations.location_category` as `NOT NULL DEFAULT 'custom'` with controlled value constraint.
+- Expanded `warehouse_locations.status` to `active|inactive|archived`, normalized invalid/null to `active`, and enforced NOT NULL + default.
+- Added `updated_at` triggers for:
+  - `warehouse_location_visual_nodes`
+  - `warehouse_layout_split_nodes`
+- Made visual node `depth_mm` nullable with positive check only when provided.
+- Corrected backfill depth logic to use real depth fields only; removed shape-height-as-depth fallback.
+- Added split-node anchoring and geometry support:
+  - `parent_visual_node_id` (ON DELETE CASCADE)
+  - index `wlsn_parent_visual_node_idx`
+  - `calc_z_mm`
+- Hardened archive validation against missing `product_location_stock` table/columns using table+column guards.
+- Added note that mapping-status logic is direct-child aware in Phase 1 (descendant-aware later if needed).
+- Updated manual verification SQL with null/invalid checks for location/visual/split fields.
+
+### Verification assets
+
+- Function: `public.verify_locations_v2_migration()`
+- Manual SQL: `docs/sql/locations-v2-verification.sql`
+
+### Remaining blockers before Phase 1 completion
+
+- Run migrations on dev/shared DB successfully.
+- Execute `SELECT public.verify_locations_v2_migration();` on dev DB and review metrics.
+- Validate optional dependency behavior of archive validation in target schema.
+- Confirm duplicate primary-node handling with real data (no silent delete/remap).

--- a/docs/locations-v2-implementation-progress.md
+++ b/docs/locations-v2-implementation-progress.md
@@ -1,0 +1,83 @@
+# Locations V2 Implementation Progress
+
+## Plan source / mismatch note
+
+- Requested plan file: `/mnt/data/ambra-locations-v2-refactor-implementation-plan.md`.
+- Actual environment does not contain `/mnt/data` and the plan file is not present, so implementation is based on the user-provided phase checklist in the prompt.
+
+## Phase 0 — Preflight
+
+- [x] Review current `warehouse_locations` migrations.
+- [x] Review current `warehouse_layouts` migrations.
+- [x] Review current `warehouse_layout_shapes` migrations.
+- [x] Review location services.
+- [x] Review layout services.
+- [x] Review shape services.
+- [x] Review warehouse server actions.
+- [x] Review React Query hooks for warehouse locations/maps.
+- [x] Review `/dashboard/warehouse/locations` and `/dashboard/warehouse/map` routes.
+- [x] Confirm current table and column names before migration work.
+- [x] Confirm inventory stock table name (`product_location_stock`).
+- [x] Confirm locale route structure (`app/[locale]/dashboard/...`).
+- [x] Document repo/plan mismatches.
+
+### Phase 0 mismatch details
+
+1. Plan references an external markdown file path not available in this container.
+2. Existing schema already includes v1 map concepts (`map_role`, `front_segment`, `top_down_unit`, `top_storage_segment`) and shape RPCs with replace-all semantics that must be preserved for legacy UI during transition.
+3. Inventory table for location stock exists as `product_location_stock` (not just a hypothetical table name).
+
+## Phase 1 — Database foundation (additive only)
+
+- [x] `locations_v2_entity_cleanup` migration created.
+- [x] `locations_v2_visual_nodes` migration created.
+- [x] `locations_v2_split_nodes` migration created.
+- [x] `locations_v2_mapping_archive_functions` migration created.
+- [x] `locations_v2_backfill_visual_nodes` migration created.
+- [x] `locations_v2_verification_queries` migration created.
+- [ ] Apply migrations to target database.
+- [ ] Regenerate Supabase types (if/when connected workflow is executed).
+- [ ] Run post-apply verification queries against live data.
+
+## Phase 2+
+
+- [ ] Not started (intentionally deferred per instruction: start with Phase 0 and Phase 1 only).
+
+## Migration Hardening Pass (2026-05-07)
+
+- Strategy: amended original Phase 1 local migrations directly (assumed not applied to shared DB yet).
+- Fixed `location_category` to controlled enum-like set with normalization + CHECK.
+- Removed invalid `top_storage_segment` column usage; now uses `map_role` value mapping only.
+- Hardened `can_store_inventory` backfill to conservative leaf-only role logic.
+- Updated visual nodes schema:
+  - added `visualization_type`
+  - enforced controlled `visual_role`
+  - changed status set to `active|hidden|historical`
+  - changed `view_context_location_id` FK to `ON DELETE SET NULL`
+  - primary-node unique index now scoped to active `visual_role='primary'`.
+- Updated split nodes schema:
+  - added `cache_valid`
+  - aligned `size_mode` to `equal|ratio|fixed|auto`
+  - `view_context_location_id` changed to nullable + `ON DELETE SET NULL`.
+- Reworked RPCs:
+  - `get_warehouse_location_mapping_status()` now returns `mapping_status` + child mapped counts.
+  - `validate_warehouse_location_archive()` now returns UI-friendly `blockers[]` and `warnings[]`, and optional-table checks validate table+column presence before dynamic SQL references.
+- Backfill migration corrected:
+  - sets `visualization_type`
+  - sets `visual_role='primary'`
+  - maps `front_elevation -> front`
+  - uses `anchor_location_id`/root for `view_context_location_id`
+  - avoids duplicates via scoped `NOT EXISTS`
+  - keeps legacy shapes intact.
+- Verification migration converted into rerunnable function:
+  - `public.verify_locations_v2_migration()`
+
+### Remaining before Phase 2
+
+- Apply amended migrations to Supabase target environment.
+- Execute `public.verify_locations_v2_migration()` in dev/staging.
+- Confirm zero duplicates/invalid categories/invalid visual roles on real data.
+- Confirm `validate_warehouse_location_archive()` behavior against environments with optional dependency tables.
+
+- manual verification SQL path: `docs/sql/locations-v2-verification.sql`
+- Phase 1 completion status: **not yet complete** until migrations are applied and verification function passes in dev/shared DB.

--- a/docs/sql/locations-v2-verification.sql
+++ b/docs/sql/locations-v2-verification.sql
@@ -1,38 +1,38 @@
 -- Locations V2 manual verification queries
 
--- 1) shape parity (legacy location shapes vs v2 visual nodes)
+-- 1) shape parity
 SELECT
   (SELECT COUNT(*) FROM public.warehouse_layout_shapes s WHERE s.deleted_at IS NULL AND s.shape_type = 'location' AND s.location_id IS NOT NULL) AS old_location_shape_count,
   (SELECT COUNT(*) FROM public.warehouse_location_visual_nodes n WHERE n.deleted_at IS NULL AND n.status = 'active') AS new_visual_node_count;
 
--- 2) stock-holding unmapped locations
-SELECT wl.id, wl.organization_id, wl.branch_id, wl.name
-FROM public.warehouse_locations wl
-JOIN public.product_location_stock pls ON pls.location_id = wl.id AND COALESCE(pls.quantity, 0) > 0
-LEFT JOIN public.warehouse_location_visual_nodes n
-  ON n.location_id = wl.id AND n.deleted_at IS NULL AND n.status = 'active'
-WHERE wl.deleted_at IS NULL
-GROUP BY wl.id
-HAVING COUNT(n.id) = 0;
+-- 2) null / invalid warehouse location flags
+SELECT COUNT(*) AS null_can_store_inventory
+FROM public.warehouse_locations
+WHERE can_store_inventory IS NULL;
 
--- 3) stock on non-storable locations
-SELECT wl.id, wl.name, COALESCE(SUM(pls.quantity), 0) AS qty
-FROM public.warehouse_locations wl
-JOIN public.product_location_stock pls ON pls.location_id = wl.id
-WHERE wl.deleted_at IS NULL
-  AND wl.can_store_inventory = false
-GROUP BY wl.id, wl.name
-HAVING COALESCE(SUM(pls.quantity), 0) > 0;
+SELECT COUNT(*) AS null_location_category
+FROM public.warehouse_locations
+WHERE location_category IS NULL;
 
--- 4) storable parents with active children
-SELECT p.id, p.name, COUNT(c.id) AS active_children
-FROM public.warehouse_locations p
-JOIN public.warehouse_locations c ON c.parent_id = p.id AND c.deleted_at IS NULL AND COALESCE(c.status, 'active') = 'active'
-WHERE p.deleted_at IS NULL
-  AND p.can_store_inventory = true
-GROUP BY p.id, p.name;
+SELECT COUNT(*) AS invalid_location_status
+FROM public.warehouse_locations
+WHERE status IS NULL OR status NOT IN ('active','inactive','archived');
 
--- 5) duplicate active primary visual nodes in same scope
+-- 3) null / invalid visual flags
+SELECT COUNT(*) AS invalid_visual_role
+FROM public.warehouse_location_visual_nodes
+WHERE visual_role IS NULL OR visual_role NOT IN ('primary','label','reference','aggregate');
+
+SELECT COUNT(*) AS invalid_visual_status
+FROM public.warehouse_location_visual_nodes
+WHERE status IS NULL OR status NOT IN ('active','hidden','historical');
+
+-- 4) invalid split size_mode
+SELECT COUNT(*) AS invalid_split_size_mode
+FROM public.warehouse_layout_split_nodes
+WHERE size_mode IS NULL OR size_mode NOT IN ('equal','ratio','fixed','auto');
+
+-- 5) duplicate active primary nodes
 SELECT location_id, view_type,
   COALESCE(layout_id, '00000000-0000-0000-0000-000000000000'::uuid) AS layout_id,
   COALESCE(view_context_location_id, '00000000-0000-0000-0000-000000000000'::uuid) AS view_context_location_id,
@@ -41,3 +41,20 @@ FROM public.warehouse_location_visual_nodes
 WHERE deleted_at IS NULL AND status = 'active' AND visual_role = 'primary'
 GROUP BY 1,2,3,4
 HAVING COUNT(*) > 1;
+
+-- 6) storage-capable parents with active children
+SELECT p.id, p.name, COUNT(c.id) AS active_children
+FROM public.warehouse_locations p
+JOIN public.warehouse_locations c ON c.parent_id = p.id AND c.deleted_at IS NULL AND COALESCE(c.status, 'active') = 'active'
+WHERE p.deleted_at IS NULL AND p.can_store_inventory = true
+GROUP BY p.id, p.name;
+
+-- 7) stock-holding unmapped locations
+SELECT wl.id, wl.organization_id, wl.branch_id, wl.name
+FROM public.warehouse_locations wl
+JOIN public.product_location_stock pls ON pls.location_id = wl.id AND COALESCE(pls.quantity, 0) > 0
+LEFT JOIN public.warehouse_location_visual_nodes n
+  ON n.location_id = wl.id AND n.deleted_at IS NULL AND n.status = 'active'
+WHERE wl.deleted_at IS NULL
+GROUP BY wl.id
+HAVING COUNT(n.id) = 0;

--- a/docs/sql/locations-v2-verification.sql
+++ b/docs/sql/locations-v2-verification.sql
@@ -1,0 +1,43 @@
+-- Locations V2 manual verification queries
+
+-- 1) shape parity (legacy location shapes vs v2 visual nodes)
+SELECT
+  (SELECT COUNT(*) FROM public.warehouse_layout_shapes s WHERE s.deleted_at IS NULL AND s.shape_type = 'location' AND s.location_id IS NOT NULL) AS old_location_shape_count,
+  (SELECT COUNT(*) FROM public.warehouse_location_visual_nodes n WHERE n.deleted_at IS NULL AND n.status = 'active') AS new_visual_node_count;
+
+-- 2) stock-holding unmapped locations
+SELECT wl.id, wl.organization_id, wl.branch_id, wl.name
+FROM public.warehouse_locations wl
+JOIN public.product_location_stock pls ON pls.location_id = wl.id AND COALESCE(pls.quantity, 0) > 0
+LEFT JOIN public.warehouse_location_visual_nodes n
+  ON n.location_id = wl.id AND n.deleted_at IS NULL AND n.status = 'active'
+WHERE wl.deleted_at IS NULL
+GROUP BY wl.id
+HAVING COUNT(n.id) = 0;
+
+-- 3) stock on non-storable locations
+SELECT wl.id, wl.name, COALESCE(SUM(pls.quantity), 0) AS qty
+FROM public.warehouse_locations wl
+JOIN public.product_location_stock pls ON pls.location_id = wl.id
+WHERE wl.deleted_at IS NULL
+  AND wl.can_store_inventory = false
+GROUP BY wl.id, wl.name
+HAVING COALESCE(SUM(pls.quantity), 0) > 0;
+
+-- 4) storable parents with active children
+SELECT p.id, p.name, COUNT(c.id) AS active_children
+FROM public.warehouse_locations p
+JOIN public.warehouse_locations c ON c.parent_id = p.id AND c.deleted_at IS NULL AND COALESCE(c.status, 'active') = 'active'
+WHERE p.deleted_at IS NULL
+  AND p.can_store_inventory = true
+GROUP BY p.id, p.name;
+
+-- 5) duplicate active primary visual nodes in same scope
+SELECT location_id, view_type,
+  COALESCE(layout_id, '00000000-0000-0000-0000-000000000000'::uuid) AS layout_id,
+  COALESCE(view_context_location_id, '00000000-0000-0000-0000-000000000000'::uuid) AS view_context_location_id,
+  COUNT(*)
+FROM public.warehouse_location_visual_nodes
+WHERE deleted_at IS NULL AND status = 'active' AND visual_role = 'primary'
+GROUP BY 1,2,3,4
+HAVING COUNT(*) > 1;


### PR DESCRIPTION
### Motivation

- Introduce an additive Locations V2 database foundation that separates visual representations from inventory entities and provides conservative backfills and validation before switching runtime behaviour.
- Harden and normalize existing `warehouse_locations` columns (`can_store_inventory`, `status`, `location_category`, physical dimensions) and add indexes to support new queries.
- Add first-class visual and layout split node tables with row-level security and scoped uniqueness to support new editors and avoid collisions with legacy shapes.
- Provide server-side helpers to compute mapping status and archive validation plus a rerunnable verification query to validate migration parity before rollout.

### Description

- Altered `public.warehouse_locations` to add columns `can_store_inventory`, `status`, `location_category`, `width_mm`, `height_mm`, `depth_mm`, reworked dimension/check constraints, conservative backfills from legacy meter fields, normalized categories, and added partial indexes (`wl_status_active_idx`, `wl_category_active_idx`, `wl_can_store_inventory_active_idx`).
- Added `public.warehouse_location_visual_nodes` table with RLS, policies, controlled enums for `view_type`/`visualization_type`/`visual_role`/`status`, geometry fields, unique index for active primary nodes (`wlvn_primary_unique_idx`), and scope index (`wlvn_scope_active_idx`).
- Added `public.warehouse_layout_split_nodes` table with RLS, policies, split metadata (`node_kind`, `size_mode`, `size_value`, `cache_valid`), parent-child linkage and scope index (`wlsn_scope_active_idx`).
- Added mapping and archive helper functions `public.get_warehouse_location_mapping_status(p_location_id UUID)` and `public.validate_warehouse_location_archive(p_location_id UUID)` to return JSONB results suitable for UI decisions and to safely check optional tables/columns.
- Added backfill migration `locations_v2_backfill_visual_nodes.sql` that inserts legacy `warehouse_layout_shapes` as scoped `warehouse_location_visual_nodes` while avoiding duplicates and mapping projection/visualization types.
- Added a rerunnable verification function `public.verify_locations_v2_migration()` and a companion manual SQL file at `docs/sql/locations-v2-verification.sql` plus the implementation progress doc `docs/locations-v2-implementation-progress.md`.

### Testing

- No automated CI tests were executed as part of this change because migrations are additive files and have not been applied to a target database in this rollout.
- A verification helper `public.verify_locations_v2_migration()` and manual checks in `docs/sql/locations-v2-verification.sql` were added to run after applying migrations to validate counts, duplicates, unmapped stock, and invalid enums.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc283c1a188328a2c2a4086d4e9871)