### PR TITLE
feat(sidebar): group nav items with visual separators between groups

### DIFF
--- a/apps/web/src/app/[locale]/dashboard/_components/dashboard-shell.tsx
+++ b/apps/web/src/app/[locale]/dashboard/_components/dashboard-shell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useCallback, useState, useEffect, useRef } from "react";
+import { useMemo, useCallback, useState, useEffect, useRef, Fragment } from "react";
 import { ChevronRight } from "lucide-react";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import {
@@ -888,6 +888,28 @@ function AppSidebar({
         avatar: "",
       };
 
+  // Split main nav into display groups, preserving item order.
+  // Consecutive items sharing the same `group` key are bundled together.
+  // Items with no group each form their own implicit group.
+  const itemGroups = useMemo(() => {
+    const groups: (typeof model.main)[] = [];
+    let currentGroup: typeof model.main = [];
+    let currentKey: string | undefined;
+
+    for (const item of model.main) {
+      const key = item.group ?? `__solo__${item.id}`;
+      if (key !== currentKey) {
+        if (currentGroup.length > 0) groups.push(currentGroup);
+        currentGroup = [item];
+        currentKey = key;
+      } else {
+        currentGroup.push(item);
+      }
+    }
+    if (currentGroup.length > 0) groups.push(currentGroup);
+    return groups;
+  }, [model.main]);
+
   return (
     <Sidebar collapsible="icon" {...props}>
       <SidebarHeader className="bg-muted border-b">
@@ -895,7 +917,12 @@ function AppSidebar({
         <SidebarBranchSwitcher branches={accessibleBranches} activeBranchId={activeBranchId} />
       </SidebarHeader>
       <SidebarContent>
-        <NavSection items={model.main} pathname={pathname} getLabel={getItemLabel} />
+        {itemGroups.map((groupItems, i) => (
+          <Fragment key={groupItems[0]?.id ?? i}>
+            {i > 0 && <div className="mx-2 h-px shrink-0 bg-border/50" />}
+            <NavSection items={groupItems} pathname={pathname} getLabel={getItemLabel} />
+          </Fragment>
+        ))}
         <NavSection items={model.footer} pathname={pathname} getLabel={getItemLabel} />
       </SidebarContent>
       <SidebarFooter className="bg-muted border-t">

--- a/apps/web/src/lib/sidebar/v2/registry.ts
+++ b/apps/web/src/lib/sidebar/v2/registry.ts
@@ -49,9 +49,136 @@ import {
  * Main navigation sections
  */
 export const MAIN_NAV_ITEMS: SidebarItem[] = [
+  // ── Group: workspace (Warehouse + Tools) ────────────────────────────────
+
+  // Warehouse (plan-gated: MODULE_WAREHOUSE must be in enabled_modules,
+  // user-gated: MODULE_WAREHOUSE_ACCESS permission required)
+  {
+    id: "warehouse",
+    group: "workspace",
+    title: "Warehouse",
+    titleKey: "modules.warehouse.titleSidebar",
+    iconKey: "warehouse",
+    visibility: {
+      requiresModules: [MODULE_WAREHOUSE],
+      requiresPermissions: [MODULE_WAREHOUSE_ACCESS],
+    },
+    children: [
+      {
+        id: "warehouse.inventory",
+        title: "Inventory",
+        titleKey: "modules.warehouse.items.inventory.title",
+        iconKey: "warehouse",
+        href: "/dashboard/warehouse/inventory",
+        match: { startsWith: "/dashboard/warehouse/inventory" },
+        visibility: {
+          requiresPermissions: [WAREHOUSE_INVENTORY_READ],
+        },
+        children: [
+          {
+            id: "warehouse.inventory.movements",
+            title: "Stock Movements",
+            titleKey: "modules.warehouse.items.inventory.movements",
+            iconKey: "warehouse",
+            href: "/dashboard/warehouse/inventory/movements",
+            match: { startsWith: "/dashboard/warehouse/inventory/movements" },
+            visibility: {
+              requiresPermissions: [WAREHOUSE_INVENTORY_READ],
+            },
+          },
+          {
+            id: "warehouse.inventory.transfers",
+            title: "Branch Transfers",
+            titleKey: "modules.warehouse.items.inventory.transfers",
+            iconKey: "warehouse",
+            href: "/dashboard/warehouse/inventory/transfers",
+            match: { startsWith: "/dashboard/warehouse/inventory/transfers" },
+            visibility: {
+              requiresPermissions: [WAREHOUSE_INVENTORY_READ],
+            },
+          },
+          {
+            id: "warehouse.items",
+            title: "Items",
+            titleKey: "modules.warehouse.items.products.title",
+            iconKey: "products",
+            href: "/dashboard/warehouse/items",
+            match: { startsWith: "/dashboard/warehouse/items" },
+            visibility: {
+              requiresPermissions: [WAREHOUSE_PRODUCTS_READ],
+            },
+          },
+        ],
+      },
+
+      {
+        id: "warehouse.purchases",
+        title: "Purchases",
+        titleKey: "modules.warehouse.items.purchases.title",
+        iconKey: "warehouse",
+        href: "/dashboard/warehouse/purchases",
+        match: { startsWith: "/dashboard/warehouse/purchases" },
+        children: [
+          {
+            id: "warehouse.deliveries",
+            title: "Deliveries",
+            titleKey: "modules.warehouse.items.deliveries.title",
+            iconKey: "warehouse",
+            href: "/dashboard/warehouse/deliveries",
+            match: { startsWith: "/dashboard/warehouse/deliveries" },
+          },
+          {
+            id: "warehouse.suppliers",
+            title: "Suppliers",
+            titleKey: "modules.warehouse.items.suppliers.title",
+            iconKey: "users",
+            href: "/dashboard/warehouse/suppliers",
+            match: { startsWith: "/dashboard/warehouse/suppliers" },
+          },
+        ],
+      },
+      {
+        id: "warehouse.locations",
+        title: "Locations",
+        titleKey: "modules.warehouse.items.locations",
+        iconKey: "locations",
+        href: "/dashboard/warehouse/locations",
+        match: { startsWith: "/dashboard/warehouse/locations" },
+        visibility: {
+          requiresPermissions: [WAREHOUSE_LOCATIONS_READ],
+        },
+      },
+      {
+        id: "warehouse.settings",
+        title: "Settings",
+        titleKey: "modules.warehouse.items.settings.title",
+        iconKey: "settings",
+        href: "/dashboard/warehouse/settings",
+        match: { startsWith: "/dashboard/warehouse/settings" },
+      },
+    ],
+  },
+
+  // Tools (always available — no requiresModules gate)
+  {
+    id: "tools",
+    group: "workspace",
+    title: "Tools",
+    titleKey: "modules.tools.titleSidebar",
+    iconKey: "tools",
+    href: "/dashboard/tools",
+    match: { startsWith: "/dashboard/tools" },
+    visibility: {
+      requiresPermissions: [PERMISSION_TOOLS_READ],
+    },
+  },
+
+  // ── Group: admin (Organization Management) ──────────────────────────────
+
   // Organization Management
   {
     id: "organization",
+    group: "admin",
     title: "Organization",
     titleKey: "modules.organizationManagement.titleSidebar",
     iconKey: "users",
@@ -107,10 +234,13 @@ export const MAIN_NAV_ITEMS: SidebarItem[] = [
     ],
   },
 
+  // ── Group: analytics ────────────────────────────────────────────────────
+
   // Analytics & Reports (plan-gated: MODULE_ANALYTICS must be in enabled_modules,
   // user-gated: MODULE_ANALYTICS_ACCESS permission required)
   {
     id: "analytics",
+    group: "analytics",
     title: "Analytics & Reports",
     titleKey: "modules.analytics.titleSidebar",
     iconKey: "barChart",
@@ -153,223 +283,6 @@ export const MAIN_NAV_ITEMS: SidebarItem[] = [
         },
       },
     ],
-  },
-
-  // Warehouse (plan-gated: MODULE_WAREHOUSE must be in enabled_modules,
-  // user-gated: MODULE_WAREHOUSE_ACCESS permission required)
-  {
-    id: "warehouse",
-    title: "Warehouse",
-    titleKey: "modules.warehouse.titleSidebar",
-    iconKey: "warehouse",
-    visibility: {
-      requiresModules: [MODULE_WAREHOUSE],
-      requiresPermissions: [MODULE_WAREHOUSE_ACCESS],
-    },
-    children: [
-      {
-        id: "warehouse.inventory",
-        title: "Inventory",
-        titleKey: "modules.warehouse.items.inventory.title",
-        iconKey: "warehouse",
-        href: "/dashboard/warehouse/inventory",
-        match: { startsWith: "/dashboard/warehouse/inventory" },
-        visibility: {
-          requiresPermissions: [WAREHOUSE_INVENTORY_READ],
-        },
-        children: [
-          {
-            id: "warehouse.inventory.movements",
-            title: "Stock Movements",
-            titleKey: "modules.warehouse.items.inventory.movements",
-            iconKey: "warehouse",
-            href: "/dashboard/warehouse/inventory/movements",
-            match: { startsWith: "/dashboard/warehouse/inventory/movements" },
-            visibility: {
-              requiresPermissions: [WAREHOUSE_INVENTORY_READ],
-            },
-          },
-          {
-            id: "warehouse.inventory.transfers",
-            title: "Branch Transfers",
-            titleKey: "modules.warehouse.items.inventory.transfers",
-            iconKey: "warehouse",
-            href: "/dashboard/warehouse/inventory/transfers",
-            match: { startsWith: "/dashboard/warehouse/inventory/transfers" },
-            visibility: {
-              requiresPermissions: [WAREHOUSE_INVENTORY_READ],
-            },
-          },
-          {
-            id: "warehouse.items",
-            title: "Items",
-            titleKey: "modules.warehouse.items.products.title",
-            iconKey: "products",
-            href: "/dashboard/warehouse/items",
-            match: { startsWith: "/dashboard/warehouse/items" },
-            visibility: {
-              requiresPermissions: [WAREHOUSE_PRODUCTS_READ],
-            },
-          },
-
-          /* NOT YET IMPLEMENTED — etykiety i kody
-          {
-            id: "warehouse.labels",
-            title: "Labels & QR",
-            titleKey: "modules.warehouse.items.labels.title",
-            iconKey: "products",
-            href: "/dashboard/warehouse/labels",
-            match: { startsWith: "/dashboard/warehouse/labels" },
-          },
-          */
-          /* NOT YET IMPLEMENTED — alerty stanów
-          {
-            id: "warehouse.alerts",
-            title: "Stock Alerts",
-            titleKey: "modules.warehouse.items.alerts.title",
-            iconKey: "warehouse",
-            href: "/dashboard/warehouse/alerts",
-            match: { startsWith: "/dashboard/warehouse/alerts" },
-          },
-          */
-          /* NOT YET IMPLEMENTED — korekty stanów
-          {
-            id: "warehouse.inventory.adjustments",
-            title: "Stock Adjustments",
-            titleKey: "modules.warehouse.items.inventory.adjustments.title",
-            iconKey: "settings",
-            href: "/dashboard/warehouse/inventory/adjustments",
-            match: { startsWith: "/dashboard/warehouse/inventory/adjustments" },
-            children: [
-              {
-                id: "warehouse.audits",
-                title: "Audits",
-                titleKey: "modules.warehouse.items.audits.title",
-                iconKey: "settings",
-                href: "/dashboard/warehouse/audits",
-                match: { startsWith: "/dashboard/warehouse/audits" },
-              },
-              {
-                id: "warehouse.adjustments",
-                title: "Single Adjustment",
-                titleKey: "modules.warehouse.items.inventory.adjustments.single",
-                iconKey: "settings",
-                href: "/dashboard/warehouse/inventory/adjustments",
-                match: { exact: "/dashboard/warehouse/inventory/adjustments" },
-              },
-            ],
-          },
-          */
-        ],
-      },
-
-      /* NOT YET IMPLEMENTED — sprzedaż (cała sekcja)
-      {
-        id: "warehouse.sales",
-        title: "Sales",
-        titleKey: "modules.warehouse.items.sales.title",
-        iconKey: "users",
-        href: "/dashboard/warehouse/sales",
-        match: { startsWith: "/dashboard/warehouse/sales" },
-        children: [
-          {
-            id: "warehouse.sales-orders",
-            title: "Sales Orders",
-            titleKey: "modules.warehouse.items.sales.orders",
-            iconKey: "products",
-            href: "/dashboard/warehouse/sales-orders",
-            match: { startsWith: "/dashboard/warehouse/sales-orders" },
-          },
-          {
-            id: "warehouse.clients",
-            title: "Clients",
-            titleKey: "modules.warehouse.items.sales.clients",
-            iconKey: "users",
-            href: "/dashboard/warehouse/clients",
-            match: { startsWith: "/dashboard/warehouse/clients" },
-          },
-        ],
-      },
-      */
-      {
-        id: "warehouse.purchases",
-        title: "Purchases",
-        titleKey: "modules.warehouse.items.purchases.title",
-        iconKey: "warehouse",
-        href: "/dashboard/warehouse/purchases",
-        match: { startsWith: "/dashboard/warehouse/purchases" },
-        children: [
-          /* NOT YET IMPLEMENTED — zamówienia zakupu
-          {
-            id: "warehouse.purchase-orders",
-            title: "Purchase Orders",
-            titleKey: "modules.warehouse.items.purchases.orders",
-            iconKey: "products",
-            href: "/dashboard/warehouse/purchase-orders",
-            match: { startsWith: "/dashboard/warehouse/purchase-orders" },
-          },
-          */
-          {
-            id: "warehouse.deliveries",
-            title: "Deliveries",
-            titleKey: "modules.warehouse.items.deliveries.title",
-            iconKey: "warehouse",
-            href: "/dashboard/warehouse/deliveries",
-            match: { startsWith: "/dashboard/warehouse/deliveries" },
-          },
-          {
-            id: "warehouse.suppliers",
-            title: "Suppliers",
-            titleKey: "modules.warehouse.items.suppliers.title",
-            iconKey: "users",
-            href: "/dashboard/warehouse/suppliers",
-            match: { startsWith: "/dashboard/warehouse/suppliers" },
-          },
-          /* NOT YET IMPLEMENTED — skanowanie dostawy
-          {
-            id: "warehouse.scanning.delivery",
-            title: "Delivery Scanning",
-            titleKey: "modules.warehouse.items.scanning.delivery",
-            iconKey: "warehouse",
-            href: "/dashboard/warehouse/scanning/delivery",
-            match: { startsWith: "/dashboard/warehouse/scanning/delivery" },
-          },
-          */
-        ],
-      },
-      {
-        id: "warehouse.locations",
-        title: "Locations",
-        titleKey: "modules.warehouse.items.locations",
-        iconKey: "locations",
-        href: "/dashboard/warehouse/locations",
-        match: { startsWith: "/dashboard/warehouse/locations" },
-        visibility: {
-          requiresPermissions: [WAREHOUSE_LOCATIONS_READ],
-        },
-      },
-      {
-        id: "warehouse.settings",
-        title: "Settings",
-        titleKey: "modules.warehouse.items.settings.title",
-        iconKey: "settings",
-        href: "/dashboard/warehouse/settings",
-        match: { startsWith: "/dashboard/warehouse/settings" },
-      },
-    ],
-  },
-
-  // Tools (always available — no requiresModules gate, last in main nav)
-  {
-    id: "tools",
-    title: "Tools",
-    titleKey: "modules.tools.titleSidebar",
-    iconKey: "tools",
-    href: "/dashboard/tools",
-    match: { startsWith: "/dashboard/tools" },
-    visibility: {
-      requiresPermissions: [PERMISSION_TOOLS_READ],
-    },
   },
 ];
 

--- a/apps/web/src/lib/types/v2/sidebar.ts
+++ b/apps/web/src/lib/types/v2/sidebar.ts
@@ -123,6 +123,13 @@ export interface SidebarItem {
   badge?: string;
 
   /**
+   * Visual grouping key. Items sharing the same group are rendered together;
+   * a separator is drawn between consecutive groups.
+   * Items with no group form their own implicit group.
+   */
+  group?: string;
+
+  /**
    * IMPORTANT: Active state is NOT in this model.
    * Active highlighting is a CLIENT-SIDE concern computed using router pathname.
    * Server-side model only contains VISIBILITY data (permissions/entitlements).


### PR DESCRIPTION
Introduces a `group` field to SidebarItem so registry items can be tagged into logical groups (workspace, admin, analytics). AppSidebar splits resolved items by consecutive group key and renders a thin separator line between groups — applies to both expanded and collapsed icon-only sidebar states.

Registry reordered: warehouse + tools (workspace) → organization (admin) → analytics (analytics).