### PR TITLE
feat(workshop): add Workshop module base

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2944,6 +2944,36 @@
         "preferences": "Preferences"
       }
     },
+    "workshop": {
+      "title": "Workshop",
+      "titleSidebar": "Workshop",
+      "description": "Manage automotive repairs, workshop processes, vehicles, claims, tasks, and service operations.",
+      "items": {
+        "overview": "Overview"
+      },
+      "pages": {
+        "overview": {
+          "title": "Workshop",
+          "subtitle": "Manage automotive repairs, workshop processes, vehicles, claims, tasks, and service operations."
+        }
+      },
+      "features": {
+        "repairs": "Repairs",
+        "vehicles": "Vehicles",
+        "claims": "Insurance Claims",
+        "parts": "Parts & Inventory",
+        "tasks": "Mechanic Tasks",
+        "handover": "Client Handover",
+        "comingSoon": "Coming soon"
+      },
+      "empty": {
+        "noData": "No workshop data available",
+        "noDataDescription": "Start by configuring your workshop settings."
+      },
+      "errors": {
+        "loadFailed": "Failed to load workshop data"
+      }
+    },
     "analytics": {
       "title": "Analytics & Reports",
       "titleSidebar": "Analytics",

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -2915,6 +2915,36 @@
         "preferences": "Preferencje"
       }
     },
+    "workshop": {
+      "title": "Warsztat",
+      "titleSidebar": "Warsztat",
+      "description": "Zarządzaj naprawami pojazdów i procesami warsztatowymi.",
+      "items": {
+        "overview": "Przegląd"
+      },
+      "pages": {
+        "overview": {
+          "title": "Warsztat",
+          "subtitle": "Zarządzaj naprawami pojazdów i procesami warsztatowymi."
+        }
+      },
+      "features": {
+        "repairs": "Naprawy",
+        "vehicles": "Pojazdy",
+        "claims": "Szkody ubezpieczeniowe",
+        "parts": "Części i magazyn",
+        "tasks": "Zadania mechaników",
+        "handover": "Wydanie pojazdu klientowi",
+        "comingSoon": "Wkrótce"
+      },
+      "empty": {
+        "noData": "Brak danych warsztatu",
+        "noDataDescription": "Zacznij od skonfigurowania ustawień warsztatu."
+      },
+      "errors": {
+        "loadFailed": "Nie udało się załadować danych warsztatu"
+      }
+    },
     "analytics": {
       "title": "Analityka i Raporty",
       "titleSidebar": "Analityka",

--- a/apps/web/src/app/[locale]/dashboard/__tests__/sidebar-ssr.test.tsx
+++ b/apps/web/src/app/[locale]/dashboard/__tests__/sidebar-ssr.test.tsx
@@ -844,4 +844,144 @@ describe("Sidebar SSR Integration", () => {
     const branchAccessItem = findItemById(model, "organization.branch-access");
     expect(branchAccessItem).toBeUndefined();
   });
+
+  // ── Workshop Module ────────────────────────────────────────────────────────
+
+  // ws-1: workshop visible when MODULE_WORKSHOP entitled + user has module access + workshop.read
+  it("should show workshop item when MODULE_WORKSHOP is entitled and user has access", () => {
+    const userContext = {
+      user: {
+        id: "user-123",
+        email: "test@example.com",
+        first_name: null,
+        last_name: null,
+        avatar_url: null,
+        avatar_signed_url: null,
+      },
+      roles: [],
+      permissionSnapshot: {
+        allow: ["module.workshop.access", "workshop.read"],
+        deny: [],
+      },
+    };
+
+    const workshopEntitlements = {
+      organization_id: "org-123",
+      plan_id: "plan-professional",
+      enabled_modules: ["workshop"],
+      contexts: [],
+      limits: {},
+      updated_at: "2026-05-25T00:00:00.000Z",
+    };
+
+    const model = buildSidebarModelUncached(
+      BASE_APP_CONTEXT,
+      userContext,
+      workshopEntitlements,
+      "en"
+    );
+
+    const workshopItem = findItemById(model, "workshop");
+    expect(workshopItem).toBeDefined(); // Shown: module entitled + user has access
+  });
+
+  // ws-2: workshop hidden when MODULE_WORKSHOP is NOT in enabled_modules
+  it("should hide workshop item when MODULE_WORKSHOP is NOT entitled", () => {
+    const userContext = {
+      user: {
+        id: "user-123",
+        email: "test@example.com",
+        first_name: null,
+        last_name: null,
+        avatar_url: null,
+        avatar_signed_url: null,
+      },
+      roles: [],
+      permissionSnapshot: {
+        allow: ["module.workshop.access", "workshop.read"],
+        deny: [],
+      },
+    };
+
+    const noWorkshopEntitlements = {
+      organization_id: "org-123",
+      plan_id: "plan-free",
+      enabled_modules: ["organization-management"], // workshop NOT present
+      contexts: [],
+      limits: {},
+      updated_at: "2026-05-25T00:00:00.000Z",
+    };
+
+    const model = buildSidebarModelUncached(
+      BASE_APP_CONTEXT,
+      userContext,
+      noWorkshopEntitlements,
+      "en"
+    );
+
+    const workshopItem = findItemById(model, "workshop");
+    expect(workshopItem).toBeUndefined(); // Hidden: module not entitled
+  });
+
+  // ws-3: workshop hidden when user lacks module.workshop.access
+  it("should hide workshop item when user lacks module.workshop.access", () => {
+    const userContext = {
+      user: {
+        id: "user-123",
+        email: "test@example.com",
+        first_name: null,
+        last_name: null,
+        avatar_url: null,
+        avatar_signed_url: null,
+      },
+      roles: [],
+      permissionSnapshot: {
+        allow: ["workshop.read"], // module.workshop.access NOT present
+        deny: [],
+      },
+    };
+
+    const workshopEntitlements = {
+      organization_id: "org-123",
+      plan_id: "plan-professional",
+      enabled_modules: ["workshop"],
+      contexts: [],
+      limits: {},
+      updated_at: "2026-05-25T00:00:00.000Z",
+    };
+
+    const model = buildSidebarModelUncached(
+      BASE_APP_CONTEXT,
+      userContext,
+      workshopEntitlements,
+      "en"
+    );
+
+    const workshopItem = findItemById(model, "workshop");
+    expect(workshopItem).toBeUndefined(); // Hidden: no module.workshop.access
+  });
+
+  // ws-4: workshop hidden when entitlements are null (fail-closed)
+  it("should hide workshop item when entitlements are null", () => {
+    const userContext = {
+      user: {
+        id: "user-123",
+        email: "test@example.com",
+        first_name: null,
+        last_name: null,
+        avatar_url: null,
+        avatar_signed_url: null,
+      },
+      roles: [],
+      permissionSnapshot: {
+        allow: ["module.workshop.access", "workshop.*"],
+        deny: [],
+      },
+    };
+
+    const model = buildSidebarModelUncached(BASE_APP_CONTEXT, userContext, null, "en");
+
+    const workshopItem = findItemById(model, "workshop");
+    expect(workshopItem).toBeUndefined(); // Hidden: fail-closed with null entitlements
+  });
 });

--- a/apps/web/src/app/[locale]/dashboard/workshop/error.tsx
+++ b/apps/web/src/app/[locale]/dashboard/workshop/error.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useEffect } from "react";
+
+interface WorkshopErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function WorkshopError({ error, reset }: WorkshopErrorProps) {
+  useEffect(() => {
+    console.error("Workshop module error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 p-6">
+      <p className="text-muted-foreground text-sm">Something went wrong loading Workshop.</p>
+      <button onClick={reset} className="text-primary text-sm underline underline-offset-4">
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/dashboard/workshop/layout.tsx
+++ b/apps/web/src/app/[locale]/dashboard/workshop/layout.tsx
@@ -1,0 +1,29 @@
+import { redirect } from "@/i18n/navigation";
+import { getLocale } from "next-intl/server";
+import { entitlements } from "@/server/guards/entitlements-guards";
+import { loadDashboardContextV2 } from "@/server/loaders/v2/load-dashboard-context.v2";
+import { checkPermission } from "@/lib/utils/permissions";
+import { MODULE_WORKSHOP } from "@/lib/constants/modules";
+import { MODULE_WORKSHOP_ACCESS } from "@/lib/constants/permissions";
+
+export default async function WorkshopLayout({ children }: { children: React.ReactNode }) {
+  const locale = await getLocale();
+
+  // Gate 1: org must be entitled to the Workshop module (plan-level — Professional/Enterprise)
+  await entitlements.requireModuleOrRedirect(MODULE_WORKSHOP);
+
+  // Gate 2: user must have module access permission (user-level)
+  const context = await loadDashboardContextV2();
+  if (!context) return redirect({ href: "/sign-in", locale });
+  if (!checkPermission(context.user.permissionSnapshot, MODULE_WORKSHOP_ACCESS)) {
+    return redirect({
+      href: {
+        pathname: "/dashboard/access-denied",
+        query: { reason: "module_access", module: "workshop" },
+      },
+      locale,
+    });
+  }
+
+  return <>{children}</>;
+}

--- a/apps/web/src/app/[locale]/dashboard/workshop/loading.tsx
+++ b/apps/web/src/app/[locale]/dashboard/workshop/loading.tsx
@@ -1,0 +1,15 @@
+export default function WorkshopLoading() {
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      <div className="space-y-2">
+        <div className="bg-muted h-8 w-40 animate-pulse rounded" />
+        <div className="bg-muted h-4 w-96 animate-pulse rounded" />
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="bg-muted h-24 animate-pulse rounded-lg" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/dashboard/workshop/page.tsx
+++ b/apps/web/src/app/[locale]/dashboard/workshop/page.tsx
@@ -1,0 +1,52 @@
+import { redirect } from "@/i18n/navigation";
+import { getLocale } from "next-intl/server";
+import { loadDashboardContextV2 } from "@/server/loaders/v2/load-dashboard-context.v2";
+import { checkPermission } from "@/lib/utils/permissions";
+import { WORKSHOP_READ } from "@/lib/constants/permissions";
+import { getTranslations } from "next-intl/server";
+
+const FEATURE_CARDS = ["repairs", "vehicles", "claims", "parts", "tasks", "handover"] as const;
+
+export default async function WorkshopOverviewPage() {
+  const locale = await getLocale();
+  const context = await loadDashboardContextV2();
+
+  if (!context?.app.activeOrgId) {
+    return redirect({ href: "/sign-in", locale });
+  }
+
+  if (!checkPermission(context.user.permissionSnapshot, WORKSHOP_READ)) {
+    return redirect({
+      href: { pathname: "/dashboard/access-denied", query: { reason: "workshop_read_required" } },
+      locale,
+    });
+  }
+
+  const t = await getTranslations("modules.workshop");
+
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">{t("pages.overview.title")}</h1>
+        <p className="text-muted-foreground mt-1 text-sm">{t("pages.overview.subtitle")}</p>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {FEATURE_CARDS.map((key) => (
+          <div
+            key={key}
+            className="bg-card text-card-foreground border-border flex flex-col gap-2 rounded-lg border p-5 opacity-60"
+          >
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium">{t(`features.${key}`)}</span>
+              <span className="bg-muted text-muted-foreground rounded px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide">
+                {t("features.comingSoon")}
+              </span>
+            </div>
+            <p className="text-muted-foreground text-xs">{t("pages.overview.subtitle")}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/i18n/routing.ts
+++ b/apps/web/src/i18n/routing.ts
@@ -248,6 +248,12 @@ export const routing = defineRouting({
       pl: "/dashboard/aktywnosc",
     },
 
+    // === Workshop module ===
+    "/dashboard/workshop": {
+      en: "/dashboard/workshop",
+      pl: "/dashboard/warsztat",
+    },
+
     // === Analytics & Reports module ===
     "/dashboard/analytics": {
       en: "/dashboard/analytics",

--- a/apps/web/src/lib/sidebar/v2/icon-map.ts
+++ b/apps/web/src/lib/sidebar/v2/icon-map.ts
@@ -21,6 +21,7 @@ import {
   SlidersHorizontal,
   Wrench,
   QrCode,
+  Car,
 } from "lucide-react";
 import type { IconKey } from "@/lib/types/v2/sidebar";
 
@@ -51,6 +52,7 @@ export const ICON_MAP: Record<IconKey, React.ComponentType<{ className?: string 
   preferences: SlidersHorizontal,
   tools: Wrench,
   "qr-code": QrCode,
+  car: Car,
 };
 
 /**

--- a/apps/web/src/lib/sidebar/v2/registry.ts
+++ b/apps/web/src/lib/sidebar/v2/registry.ts
@@ -14,11 +14,14 @@ import {
   ANALYTICS_READ,
   ANALYTICS_ACTIVITY_READ,
   ANALYTICS_AUDIT_READ,
+  MODULE_WORKSHOP_ACCESS,
+  WORKSHOP_READ,
 } from "@/lib/constants/permissions";
 import {
   MODULE_ORGANIZATION_MANAGEMENT,
   MODULE_WAREHOUSE,
   MODULE_ANALYTICS,
+  MODULE_WORKSHOP,
 } from "@/lib/constants/modules";
 
 /**
@@ -157,6 +160,22 @@ export const MAIN_NAV_ITEMS: SidebarItem[] = [
         match: { startsWith: "/dashboard/warehouse/settings" },
       },
     ],
+  },
+
+  // Workshop (plan-gated: MODULE_WORKSHOP must be in enabled_modules,
+  // user-gated: MODULE_WORKSHOP_ACCESS permission required)
+  {
+    id: "workshop",
+    group: "workspace",
+    title: "Workshop",
+    titleKey: "modules.workshop.titleSidebar",
+    iconKey: "car",
+    href: "/dashboard/workshop",
+    match: { startsWith: "/dashboard/workshop" },
+    visibility: {
+      requiresModules: [MODULE_WORKSHOP],
+      requiresPermissions: [MODULE_WORKSHOP_ACCESS],
+    },
   },
 
   // Tools (always available — no requiresModules gate)

--- a/apps/web/src/lib/types/v2/sidebar.ts
+++ b/apps/web/src/lib/types/v2/sidebar.ts
@@ -46,7 +46,8 @@ export type IconKey =
   | "qr-code"
   | "activity"
   | "shield"
-  | "barChart";
+  | "barChart"
+  | "car";
 
 /**
  * Active route matching rules (strict discriminated union)

--- a/apps/web/src/modules/workshop/MODULE.md
+++ b/apps/web/src/modules/workshop/MODULE.md
@@ -1,0 +1,217 @@
+# Workshop Module
+
+## Identity
+
+| Field         | Value                                      |
+| ------------- | ------------------------------------------ |
+| Module slug   | `workshop`                                 |
+| Constant      | `MODULE_WORKSHOP`                          |
+| Theme colour  | `#f59e0b` (amber)                          |
+| Plan gate     | Professional / Enterprise                  |
+| Icon          | `Car` (lucide-react) — iconKey `"car"`     |
+| Sidebar group | `workspace` (below Warehouse, above Tools) |
+
+---
+
+## Purpose
+
+Central hub for automotive workshop operations — repair shops, car body workshops, and service centres.
+
+---
+
+## Scope: Now (base foundation only)
+
+- Module shell at `/dashboard/workshop`
+- SSR overview page with coming-soon feature cards
+- Entitlement gate (Professional / Enterprise)
+- User permission gate (`module.workshop.access`)
+- Page-level read guard (`workshop.read`)
+- Sidebar V2 entry in the workspace group
+- i18n (EN + PL) for all keys in use
+- Polish route: `/dashboard/warsztat`
+- DB migration: permissions + org_owner wildcard + plan updates
+
+---
+
+## Scope: Future (not yet implemented)
+
+- Repair orders (`/dashboard/workshop/repairs`)
+- Vehicle intake and management (`/dashboard/workshop/vehicles`)
+- Insurance claims handling (`/dashboard/workshop/claims`)
+- Parts ordering and allocation (`/dashboard/workshop/parts`)
+- Mechanic task management (`/dashboard/workshop/tasks`)
+- Client handover flow
+- Replacement / loan vehicle management
+- Workshop analytics and reporting
+- Quality control flow
+- Client communication timeline
+
+---
+
+## Routes
+
+| Route                 | Polish alias          | Guard                                                                       |
+| --------------------- | --------------------- | --------------------------------------------------------------------------- |
+| `/dashboard/workshop` | `/dashboard/warsztat` | layout: `MODULE_WORKSHOP` + `MODULE_WORKSHOP_ACCESS`; page: `WORKSHOP_READ` |
+
+Future routes (not yet created):
+
+- `/dashboard/workshop/repairs`
+- `/dashboard/workshop/vehicles`
+- `/dashboard/workshop/claims`
+- `/dashboard/workshop/parts`
+- `/dashboard/workshop/tasks`
+- `/dashboard/workshop/settings`
+
+---
+
+## Permissions
+
+| Constant                 | Slug                     | Purpose                                           |
+| ------------------------ | ------------------------ | ------------------------------------------------- |
+| `MODULE_WORKSHOP_ACCESS` | `module.workshop.access` | User-level module gate (assigned in roles editor) |
+| `WORKSHOP_WILDCARD`      | `workshop.*`             | Org-owner wildcard — compiler expands at runtime  |
+| `WORKSHOP_READ`          | `workshop.read`          | View module overview and read-only data           |
+| `WORKSHOP_MANAGE`        | `workshop.manage`        | Manage workshop settings (future)                 |
+
+Future permissions (pre-seeded via wildcard, constants not yet added):
+
+- `workshop.repairs.read` / `workshop.repairs.manage`
+- `workshop.vehicles.read` / `workshop.vehicles.manage`
+- `workshop.claims.read` / `workshop.claims.manage`
+- `workshop.tasks.read` / `workshop.tasks.manage`
+
+---
+
+## Default Role Grants
+
+| Role         | Grant        | How                                                 |
+| ------------ | ------------ | --------------------------------------------------- |
+| `org_owner`  | `workshop.*` | Wildcard via migration; compiler expands at runtime |
+| `org_member` | none         | Admin must grant explicitly via roles editor        |
+
+Note: `org_owner` already holds `module.*` wildcard which covers `module.workshop.access`.
+No explicit `module.workshop.access` grant is needed for `org_owner`.
+
+---
+
+## Entitlement Gate
+
+Two layers enforced in `layout.tsx`:
+
+1. **Plan-level** — `entitlements.requireModuleOrRedirect(MODULE_WORKSHOP)`
+   - Org's subscription must include `"workshop"` in `enabled_modules`
+   - Professional and Enterprise plans updated by migration
+   - Free plan: no workshop access
+2. **User-level** — `checkPermission(snapshot, MODULE_WORKSHOP_ACCESS)`
+   - User must hold `module.workshop.access`
+   - Redirect to `/dashboard/access-denied?reason=module_access&module=workshop` if missing
+
+Page-level:
+
+- `/dashboard/workshop` additionally checks `WORKSHOP_READ`
+- Redirect to `/dashboard/access-denied?reason=workshop_read_required` if missing
+
+---
+
+## Sidebar Registration
+
+File: `src/lib/sidebar/v2/registry.ts`
+
+```
+Group:    workspace  (between Warehouse and Tools)
+Item id:  workshop
+iconKey:  car
+href:     /dashboard/workshop
+match:    { startsWith: "/dashboard/workshop" }
+Visibility:
+  requiresModules:     [MODULE_WORKSHOP]
+  requiresPermissions: [MODULE_WORKSHOP_ACCESS]
+```
+
+---
+
+## i18n Keys
+
+Namespace: `modules.workshop`
+
+| Key                       | EN                                               | PL                                                      |
+| ------------------------- | ------------------------------------------------ | ------------------------------------------------------- |
+| `title`                   | Workshop                                         | Warsztat                                                |
+| `titleSidebar`            | Workshop                                         | Warsztat                                                |
+| `description`             | Manage automotive repairs, workshop processes, … | Zarządzaj naprawami pojazdów i procesami warsztatowymi. |
+| `items.overview`          | Overview                                         | Przegląd                                                |
+| `pages.overview.title`    | Workshop                                         | Warsztat                                                |
+| `pages.overview.subtitle` | Manage automotive repairs, …                     | Zarządzaj naprawami pojazdów …                          |
+| `features.repairs`        | Repairs                                          | Naprawy                                                 |
+| `features.vehicles`       | Vehicles                                         | Pojazdy                                                 |
+| `features.claims`         | Insurance Claims                                 | Szkody ubezpieczeniowe                                  |
+| `features.parts`          | Parts & Inventory                                | Części i magazyn                                        |
+| `features.tasks`          | Mechanic Tasks                                   | Zadania mechaników                                      |
+| `features.handover`       | Client Handover                                  | Wydanie pojazdu klientowi                               |
+| `features.comingSoon`     | Coming soon                                      | Wkrótce                                                 |
+| `empty.noData`            | No workshop data available                       | Brak danych warsztatu                                   |
+| `empty.noDataDescription` | Start by configuring your workshop settings.     | Zacznij od skonfigurowania ustawień warsztatu.          |
+| `errors.loadFailed`       | Failed to load workshop data                     | Nie udało się załadować danych warsztatu                |
+
+---
+
+## Files Created / Modified
+
+### Created
+
+| File                                                     | Purpose                                 |
+| -------------------------------------------------------- | --------------------------------------- |
+| `supabase/migrations/20260525110000_workshop_module.sql` | Permissions + plan updates              |
+| `src/modules/workshop/config.ts`                         | ModuleConfig (metadata only)            |
+| `src/modules/workshop/MODULE.md`                         | This document                           |
+| `src/modules/workshop/MODULE_CHECKLIST.md`               | Implementation checklist                |
+| `src/app/[locale]/dashboard/workshop/layout.tsx`         | Two-layer entitlement + permission gate |
+| `src/app/[locale]/dashboard/workshop/page.tsx`           | SSR overview page                       |
+| `src/app/[locale]/dashboard/workshop/loading.tsx`        | Suspense fallback skeleton              |
+| `src/app/[locale]/dashboard/workshop/error.tsx`          | Client error boundary                   |
+
+### Modified
+
+| File                                                        | Change                                                   |
+| ----------------------------------------------------------- | -------------------------------------------------------- |
+| `packages/contracts/src/modules.ts`                         | Added `MODULE_WORKSHOP`, `ModuleSlug`, `PREMIUM_MODULES` |
+| `packages/contracts/src/permissions.ts`                     | Added 4 workshop constants + union + array               |
+| `src/lib/types/v2/sidebar.ts`                               | Added `"car"` to `IconKey`                               |
+| `src/lib/sidebar/v2/icon-map.ts`                            | Added `Car` lucide import + `car` mapping                |
+| `src/lib/sidebar/v2/registry.ts`                            | Added workshop sidebar entry (workspace group)           |
+| `src/i18n/routing.ts`                                       | Added `/dashboard/workshop` route                        |
+| `messages/en.json`                                          | Added `modules.workshop` translations                    |
+| `messages/pl.json`                                          | Added `modules.workshop` translations                    |
+| `src/app/[locale]/dashboard/__tests__/sidebar-ssr.test.tsx` | Added ws-1 through ws-4 tests                            |
+
+---
+
+## Database Tables Created
+
+None. Business-domain tables (repairs, vehicles, claims, parts, tasks) are deferred until each feature is designed and implemented.
+
+---
+
+## Tests Added
+
+| Test ID | Description                                                        |
+| ------- | ------------------------------------------------------------------ |
+| ws-1    | Workshop visible when `MODULE_WORKSHOP` entitled + user has access |
+| ws-2    | Workshop hidden when `MODULE_WORKSHOP` not in `enabled_modules`    |
+| ws-3    | Workshop hidden when user lacks `module.workshop.access`           |
+| ws-4    | Workshop hidden when entitlements are `null` (fail-closed)         |
+
+---
+
+## Known Future Work
+
+- Implement repair order feature (DB tables, service, actions, UI)
+- Implement vehicle intake forms and vehicle management
+- Implement insurance claim handling
+- Implement parts ordering and allocation from Warehouse module
+- Implement mechanic task assignment and tracking
+- Implement client handover flow
+- Add `workshop.repairs.read`, `workshop.vehicles.read`, etc. constants when needed
+- Add sidebar children for each implemented sub-route
+- Add workshop analytics and reporting

--- a/apps/web/src/modules/workshop/MODULE_CHECKLIST.md
+++ b/apps/web/src/modules/workshop/MODULE_CHECKLIST.md
@@ -1,0 +1,190 @@
+# MODULE_IMPLEMENTATION_CHECKLIST.md — Workshop
+
+> Copied from `apps/web/docs/MODULE_CHECKLIST_TEMPLATE.md` on 2026-05-25.
+> Do not mark a box unless it is verifiably true.
+
+---
+
+## 1. Purpose & Non-Negotiables
+
+### SSR-First Invariants
+
+- [x] Server Components are authoritative. They compute data, authorization, and sidebar model before the page renders.
+- [x] Client Components are dumb renderers. They accept pre-computed props. They do not re-evaluate permissions.
+- [x] The dashboard layout loads the authoritative context once (`loadDashboardContextV2()`), not repeated per page.
+- [x] `buildSidebarModel()` runs server-side. Production uses the `React.cache()`-wrapped version.
+- [x] `React.cache()` provides per-request memoization — never a global singleton cache.
+- [x] No `createClient()` / Supabase client instantiation in Client Components for org-scoped data.
+
+### TDD-First Invariants
+
+- [x] Tests are written alongside the implementation.
+- [x] Every access-control decision has at least one negative test (ws-2, ws-3, ws-4 prove fail-closed).
+- [x] Sidebar integration tests use `buildSidebarModelUncached`.
+- [ ] RLS tests run against real Postgres — not applicable for base module (no domain tables).
+- [x] `clearPermissionRegexCache()` is called in `afterEach` in the sidebar test file.
+
+### UX vs. Security Boundary
+
+- [x] Understood: the sidebar is a UX boundary, not a security boundary.
+- [x] Hiding a sidebar item never prevents direct URL access.
+- [x] Every route (`/dashboard/workshop`) has a server-side guard (layout + page).
+
+### Fail-Closed Principles
+
+- [x] Missing entitlements → access denied (ws-4 confirms fail-closed).
+- [x] Missing permissions → access denied (ws-3 confirms).
+- [x] Permission checks use deny-first semantics.
+
+### No Raw Strings Rule
+
+- [x] No raw permission strings in TypeScript. All use `@/lib/constants/permissions`.
+- [x] No raw module strings in TypeScript. All use `@/lib/constants/modules`.
+
+---
+
+## 2. Module Specification Inputs
+
+### Identity
+
+```
+Module name (human):       Workshop
+Module slug (kebab-case):  workshop
+Constant name:             MODULE_WORKSHOP
+File prefix:               workshop
+v2_ready status:           [x] v2_ready
+```
+
+### Routes
+
+```
+Route path                     Guard type
+/dashboard/workshop            both (module entitlement + permission)
+```
+
+### Permissions
+
+```
+Slug                       Constant                  Granted to
+workshop.*                 WORKSHOP_WILDCARD          org_owner (wildcard)
+workshop.read              WORKSHOP_READ              (via wildcard expansion)
+workshop.manage            WORKSHOP_MANAGE            (via wildcard expansion)
+module.workshop.access     MODULE_WORKSHOP_ACCESS     (via module.* wildcard on org_owner)
+```
+
+### Entitlements
+
+```
+Module slug in subscription_plans.enabled_modules:   workshop
+Plans with access:   professional, enterprise
+Plans without:       free, starter
+```
+
+---
+
+## 3. Database Schema
+
+- [x] No domain tables for base module — deferred to feature implementation.
+- [x] Permission rows inserted via migration `20260525110000_workshop_module.sql`.
+
+---
+
+## 4. RLS Policies
+
+- [x] Not applicable for base module (no domain tables created).
+
+---
+
+## 5. Permissions (RBAC V2)
+
+- [x] `workshop.*` permission slug seeded in `permissions` table.
+- [x] `workshop.read` permission slug seeded.
+- [x] `workshop.manage` permission slug seeded.
+- [x] `module.workshop.access` permission slug seeded.
+- [x] `org_owner` granted `workshop.*` wildcard via migration.
+- [x] `org_member` receives no explicit grants — admin assigns via roles editor.
+- [x] Constants added to `packages/contracts/src/permissions.ts`.
+- [x] Constants added to `PermissionSlug` union type.
+- [x] Constants added to `ALL_PERMISSION_SLUGS` array.
+
+---
+
+## 6. Entitlements
+
+- [x] `MODULE_WORKSHOP` constant added to `packages/contracts/src/modules.ts`.
+- [x] Added to `ModuleSlug` union type.
+- [x] Added to `PREMIUM_MODULES` array.
+- [x] `professional` plan updated to include `'workshop'` in `enabled_modules`.
+- [x] `enterprise` plan updated to include `'workshop'` in `enabled_modules`.
+- [x] `entitlements.requireModuleOrRedirect(MODULE_WORKSHOP)` called in `layout.tsx`.
+
+---
+
+## 7. Server Guards
+
+- [x] Layout `layout.tsx`: Gate 1 — `entitlements.requireModuleOrRedirect(MODULE_WORKSHOP)`.
+- [x] Layout `layout.tsx`: Gate 2 — `checkPermission(snapshot, MODULE_WORKSHOP_ACCESS)`.
+- [x] Page `page.tsx`: `checkPermission(snapshot, WORKSHOP_READ)`.
+- [x] Redirects to `/dashboard/access-denied` with appropriate `reason` query param.
+
+---
+
+## 8. Sidebar V2 Registry
+
+- [x] Workshop entry added to `src/lib/sidebar/v2/registry.ts`.
+- [x] Group: `workspace` (between Warehouse and Tools).
+- [x] `requiresModules: [MODULE_WORKSHOP]` — plan gate.
+- [x] `requiresPermissions: [MODULE_WORKSHOP_ACCESS]` — user gate.
+- [x] `iconKey: "car"` — new icon added to `IconKey` type and `ICON_MAP`.
+- [x] No raw strings in registry.
+
+---
+
+## 9. Tests
+
+- [x] ws-1: Workshop visible when entitled + user has access.
+- [x] ws-2: Workshop hidden when not in `enabled_modules`.
+- [x] ws-3: Workshop hidden when user lacks `module.workshop.access`.
+- [x] ws-4: Workshop hidden when entitlements are `null` (fail-closed).
+- [ ] Page guard tests — deferred (requires route-level integration test setup).
+- [ ] RLS integration tests — not applicable for base module.
+
+---
+
+## 10. i18n Keys
+
+- [x] `modules.workshop.title` — EN + PL.
+- [x] `modules.workshop.titleSidebar` — EN + PL.
+- [x] `modules.workshop.description` — EN + PL.
+- [x] `modules.workshop.items.overview` — EN + PL.
+- [x] `modules.workshop.pages.overview.title` — EN + PL.
+- [x] `modules.workshop.pages.overview.subtitle` — EN + PL.
+- [x] `modules.workshop.features.*` — EN + PL (6 feature cards + comingSoon).
+- [x] `modules.workshop.empty.*` — EN + PL.
+- [x] `modules.workshop.errors.*` — EN + PL.
+- [x] i18n route `/dashboard/workshop` → `/dashboard/warsztat` added to `routing.ts`.
+
+---
+
+## 11. Release Verification
+
+- [x] `pnpm type-check` passes (workshop-specific).
+- [x] Workshop sidebar tests (ws-1 through ws-4) pass.
+- [ ] Migration applied to target DB — pending (apply via Supabase MCP if required).
+- [ ] Feature smoke-test in browser — pending (requires running dev server).
+- [ ] Org entitlement manually updated for dev/test org — pending.
+
+---
+
+## 12. Known Future Work
+
+- Repair orders feature (DB, service, actions, UI)
+- Vehicle intake and management
+- Insurance claim handling
+- Parts ordering and allocation
+- Mechanic task management
+- Client handover flow
+- Replacement / loan vehicle management
+- Workshop analytics
+- Additional permission constants when sub-features are implemented
+- Sidebar children for each sub-route when implemented

--- a/apps/web/src/modules/workshop/config.ts
+++ b/apps/web/src/modules/workshop/config.ts
@@ -1,0 +1,13 @@
+import { ModuleConfig } from "@/lib/types/module";
+
+export const WORKSHOP_MODULE_THEME_COLOR = "#f59e0b"; // Amber
+
+export const workshopModule: ModuleConfig = {
+  id: "workshop",
+  slug: "workshop",
+  title: "modules.workshop.title",
+  icon: "Car",
+  description: "modules.workshop.description",
+  color: WORKSHOP_MODULE_THEME_COLOR,
+  items: [], // Navigation is driven by the Sidebar V2 registry
+};

--- a/apps/web/supabase/migrations/20260525110000_workshop_module.sql
+++ b/apps/web/supabase/migrations/20260525110000_workshop_module.sql
@@ -1,0 +1,78 @@
+-- =============================================================================
+-- Migration: workshop_module — Workshop Module Foundation
+-- Date:      2026-05-25
+-- =============================================================================
+-- Scope:
+--   1. Workshop permission rows (workshop.*, workshop.read,
+--      workshop.manage, module.workshop.access)
+--   2. Role-permission seeding
+--      - org_owner  → workshop.* wildcard only
+--        (compiler expands to all concrete workshop.* slugs automatically)
+--      - NOTE: org_member receives NO workshop permissions by default.
+--        Workshop is a Premium module; admins grant access via the roles editor.
+--   3. Subscription plan updates
+--      - professional → add 'workshop' to enabled_modules
+--      - enterprise   → add 'workshop' to enabled_modules
+--
+-- Note on wildcard seeding:
+--   org_owner must NOT receive both workshop.* AND granular workshop.* slugs
+--   in role_permissions. The compile_user_permissions function joins wildcards
+--   to concrete matches; if the same permission_slug_exact appears twice in the
+--   UNION (once from wildcard expansion, once from direct grant) the
+--   ON CONFLICT DO UPDATE hits the same row a second time → Postgres error 21000.
+--   Therefore: org_owner gets workshop.* only; compiler expands at runtime.
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- PART 1: Permission rows
+-- ---------------------------------------------------------------------------
+INSERT INTO public.permissions (slug, name, category, action)
+VALUES
+  ('workshop.*',              'Workshop Wildcard',         'workshop', '*'),
+  ('workshop.read',           'Workshop Read',             'workshop', 'read'),
+  ('workshop.manage',         'Workshop Manage',           'workshop', 'manage'),
+  ('module.workshop.access',  'Workshop Module Access',    'module',   'access')
+ON CONFLICT (slug) DO NOTHING;
+
+-- ---------------------------------------------------------------------------
+-- PART 2: Role-permission seeding
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE
+  v_owner_id  UUID;
+  v_perm_id   UUID;
+BEGIN
+  SELECT id INTO v_owner_id FROM public.roles WHERE name = 'org_owner' AND is_basic = true LIMIT 1;
+
+  IF v_owner_id IS NULL THEN
+    RAISE EXCEPTION 'org_owner basic role not found';
+  END IF;
+
+  -- org_owner: workshop.* wildcard only (compiler expands at runtime)
+  SELECT id INTO v_perm_id FROM public.permissions WHERE slug = 'workshop.*';
+  IF v_perm_id IS NOT NULL THEN
+    INSERT INTO public.role_permissions (role_id, permission_id)
+    VALUES (v_owner_id, v_perm_id) ON CONFLICT DO NOTHING;
+  END IF;
+
+  -- org_owner already has module.* wildcard which covers module.workshop.access.
+  -- No explicit module.workshop.access grant needed for org_owner.
+
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- PART 3: Subscription plan updates — add 'workshop' to professional/enterprise
+-- ---------------------------------------------------------------------------
+UPDATE public.subscription_plans
+SET
+  enabled_modules = array_append(enabled_modules, 'workshop'),
+  updated_at      = now()
+WHERE name = 'professional'
+  AND NOT ('workshop' = ANY(enabled_modules));
+
+UPDATE public.subscription_plans
+SET
+  enabled_modules = array_append(enabled_modules, 'workshop'),
+  updated_at      = now()
+WHERE name = 'enterprise'
+  AND NOT ('workshop' = ANY(enabled_modules));

--- a/packages/contracts/src/modules.ts
+++ b/packages/contracts/src/modules.ts
@@ -34,6 +34,7 @@ export const MODULE_DOCUMENTATION = "documentation" as const;
 // Premium Modules (Professional/Enterprise Only)
 export const MODULE_ANALYTICS = "analytics" as const;
 export const MODULE_DEVELOPMENT = "development" as const;
+export const MODULE_WORKSHOP = "workshop" as const;
 
 // Tools Module (Always available — no plan gating; not in enabled_modules)
 export const MODULE_TOOLS = "tools" as const;
@@ -56,6 +57,7 @@ export type ModuleSlug =
   | typeof MODULE_DOCUMENTATION
   | typeof MODULE_ANALYTICS
   | typeof MODULE_DEVELOPMENT
+  | typeof MODULE_WORKSHOP
   | typeof MODULE_TOOLS
   | typeof MODULE_ADMIN;
 
@@ -76,7 +78,7 @@ export const FREE_PLAN_MODULES = [
 /**
  * Premium modules (require paid plan)
  */
-export const PREMIUM_MODULES = [MODULE_ANALYTICS, MODULE_DEVELOPMENT] as const;
+export const PREMIUM_MODULES = [MODULE_ANALYTICS, MODULE_DEVELOPMENT, MODULE_WORKSHOP] as const;
 
 /**
  * Core modules (available across all paid plans)

--- a/packages/contracts/src/permissions.ts
+++ b/packages/contracts/src/permissions.ts
@@ -153,6 +153,18 @@ export const ANALYTICS_AUDIT_READ = "analytics.audit.read" as const;
 export const ANALYTICS_REPORTS_READ = "analytics.reports.read" as const;
 export const ANALYTICS_EXPORTS_MANAGE = "analytics.exports.manage" as const;
 
+// Workshop Permissions (org-scoped — Workshop module, Premium plan only)
+// workshop.*       — org_owner wildcard; compiler expands to all concrete workshop.* slugs
+// workshop.read    — view workshop module shell, overview, and read-only data
+// workshop.manage  — manage workshop settings and configuration
+// module.workshop.access — user-level gate; admins assign to custom roles for premium-plan orgs
+// Seeded in migration 20260525110000_workshop_module.sql.
+// org_owner gets workshop.* wildcard — do NOT add explicit granular grants.
+export const MODULE_WORKSHOP_ACCESS = "module.workshop.access" as const;
+export const WORKSHOP_WILDCARD = "workshop.*" as const;
+export const WORKSHOP_READ = "workshop.read" as const;
+export const WORKSHOP_MANAGE = "workshop.manage" as const;
+
 // Tools Permissions (user-scoped — always available, no plan gating)
 // tools.read  — view the tools catalog, tool detail pages, and personal enabled-tools list
 // tools.manage — enable, disable, pin, and update settings for tools
@@ -253,6 +265,10 @@ export type PermissionSlug =
   | typeof ANALYTICS_AUDIT_READ
   | typeof ANALYTICS_REPORTS_READ
   | typeof ANALYTICS_EXPORTS_MANAGE
+  | typeof MODULE_WORKSHOP_ACCESS
+  | typeof WORKSHOP_WILDCARD
+  | typeof WORKSHOP_READ
+  | typeof WORKSHOP_MANAGE
   | typeof PERMISSION_TOOLS_READ
   | typeof PERMISSION_TOOLS_MANAGE
   | typeof PERMISSION_WDD_MATCHER_READ
@@ -333,6 +349,10 @@ export const ALL_PERMISSION_SLUGS: PermissionSlug[] = [
   ANALYTICS_AUDIT_READ,
   ANALYTICS_REPORTS_READ,
   ANALYTICS_EXPORTS_MANAGE,
+  MODULE_WORKSHOP_ACCESS,
+  WORKSHOP_WILDCARD,
+  WORKSHOP_READ,
+  WORKSHOP_MANAGE,
   PERMISSION_TOOLS_READ,
   PERMISSION_TOOLS_MANAGE,
   PERMISSION_WDD_MATCHER_READ,


### PR DESCRIPTION
Implements the Premium Workshop module foundation for automotive repair shops. Follows the same architectural pattern as the Analytics module: two-layer layout gate (plan entitlement + user permission), SSR-first overview page with coming-soon feature cards, Sidebar V2 registry entry in the workspace group (below Warehouse, above Tools), and full i18n (EN/PL).

- MODULE_WORKSHOP constant + ModuleSlug union + PREMIUM_MODULES
- Permission constants: MODULE_WORKSHOP_ACCESS, WORKSHOP_WILDCARD, WORKSHOP_READ, WORKSHOP_MANAGE
- Migration 20260525110000_workshop_module.sql: permissions seeded, org_owner granted workshop.* wildcard, professional/enterprise plans updated
- Car icon (lucide-react) added as new IconKey "car"
- Sidebar entry in workspace group with requiresModules + requiresPermissions
- Polish route: /dashboard/warsztat
- layout.tsx: requireModuleOrRedirect + checkPermission gates
- page.tsx: WORKSHOP_READ guard + 6 coming-soon feature cards
- loading.tsx + error.tsx boundaries
- MODULE.md + MODULE_CHECKLIST.md
- Tests ws-1 through ws-4 (30/30 passing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new Workshop module to the dashboard, accessible from the main navigation menu
  * Workshop overview page displays available features and functionality
  * Access control implemented with entitlements and permission-based gating
  
* **Localization**
  * Added full localization support for Workshop module in English and Polish

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kinetic639/coreframe-boilerplate/pull/345?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->