### PR TITLE
perf(help-desk): parallelize getDetail DB queries with Promise.all

### DIFF
--- a/apps/web/src/server/services/helpdesk-tickets.service.ts
+++ b/apps/web/src/server/services/helpdesk-tickets.service.ts
@@ -344,12 +344,31 @@ export class HelpdeskTicketsService {
 
     const ticket = ticketRaw as any;
 
-    // Assignees
-    const { data: assigneeRows } = await supabase
-      .from("helpdesk_ticket_assignees")
-      .select("user_id, role, status, user:users!user_id(id,first_name,last_name,email,avatar_url)")
-      .eq("ticket_id", ticketId)
-      .is("deleted_at", null);
+    // Assignees, comments, activity are all independent — fetch in parallel
+    const [{ data: assigneeRows }, { data: commentRows }, { data: activityRows }] =
+      await Promise.all([
+        supabase
+          .from("helpdesk_ticket_assignees")
+          .select(
+            "user_id, role, status, user:users!user_id(id,first_name,last_name,email,avatar_url)"
+          )
+          .eq("ticket_id", ticketId)
+          .is("deleted_at", null),
+        supabase
+          .from("helpdesk_ticket_comments")
+          .select("*, commenter:users!created_by(id,first_name,last_name,email,avatar_url)")
+          .eq("ticket_id", ticketId)
+          .eq("org_id", orgId)
+          .is("deleted_at", null)
+          .order("created_at", { ascending: true }),
+        supabase
+          .from("helpdesk_ticket_activity")
+          .select("*, actor:users!actor_id(id,first_name,last_name,email)")
+          .eq("ticket_id", ticketId)
+          .eq("org_id", orgId)
+          .order("created_at", { ascending: false })
+          .limit(50),
+      ]);
 
     const assignees: HelpdeskAssigneeInfo[] = ((assigneeRows ?? []) as any[]).map((row) => {
       const u = row.user as {
@@ -369,15 +388,6 @@ export class HelpdeskTicketsService {
         profile_href: null,
       };
     });
-
-    // Comments
-    const { data: commentRows } = await supabase
-      .from("helpdesk_ticket_comments")
-      .select("*, commenter:users!created_by(id,first_name,last_name,email,avatar_url)")
-      .eq("ticket_id", ticketId)
-      .eq("org_id", orgId)
-      .is("deleted_at", null)
-      .order("created_at", { ascending: true });
 
     const comments: HelpdeskTicketComment[] = (commentRows ?? []).map((row) => {
       const u = row.commenter as {
@@ -404,15 +414,6 @@ export class HelpdeskTicketsService {
         deleted_at: (row.deleted_at as string | null) ?? null,
       };
     });
-
-    // Activity (last 50)
-    const { data: activityRows } = await supabase
-      .from("helpdesk_ticket_activity")
-      .select("*, actor:users!actor_id(id,first_name,last_name,email)")
-      .eq("ticket_id", ticketId)
-      .eq("org_id", orgId)
-      .order("created_at", { ascending: false })
-      .limit(50);
 
     const activity: HelpdeskTicketActivity[] = (activityRows ?? []).map((row) => {
       const a = row.actor as {


### PR DESCRIPTION
Assignees, comments, and activity queries are completely independent after the ticket row is fetched. Running them sequentially added 2 extra serial Supabase round-trips (~100-200ms each) on every DataView panel open.

Switch to Promise.all so all three fire concurrently — wall-clock time collapses from 4 sequential round-trips to 2 (ticket, then everything else).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized helpdesk ticket detail loading performance by fetching assignees, comments, and activity data concurrently.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kinetic639/coreframe-boilerplate/pull/349?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->