### PR TITLE
fix(help-desk): add 2s timeout to batchSignAvatarUrls to prevent resp…

### DIFF
--- a/apps/web/src/server/services/helpdesk-tickets.service.ts
+++ b/apps/web/src/server/services/helpdesk-tickets.service.ts
@@ -120,26 +120,39 @@ function memberProfileHref(userId: string): string {
 const USER_AVATAR_BUCKET = "user-avatars";
 const AVATAR_TTL_SECONDS = 60 * 60;
 
-// One batch call to Supabase storage for all users — O(1) network round-trips regardless of count
+// One batch call to Supabase storage for all users — O(1) network round-trips regardless of count.
+// Hard 2-second timeout: if storage is slow/unreachable we fall back to avatar_url (or null)
+// rather than hanging the entire ticket response.
+const AVATAR_SIGN_TIMEOUT_MS = 2_000;
+
 async function batchSignAvatarUrls(
   entries: Array<{ userId: string; avatarPath: string }>
 ): Promise<Map<string, string>> {
   if (entries.length === 0) return new Map();
-  try {
-    const svc = createServiceClient();
-    const { data, error } = await svc.storage.from(USER_AVATAR_BUCKET).createSignedUrls(
-      entries.map((e) => e.avatarPath),
-      AVATAR_TTL_SECONDS
-    );
-    if (error || !data) return new Map();
-    const map = new Map<string, string>();
-    data.forEach((item, i) => {
-      if (item.signedUrl) map.set(entries[i].userId, item.signedUrl);
-    });
-    return map;
-  } catch {
-    return new Map();
-  }
+
+  const sign = async (): Promise<Map<string, string>> => {
+    try {
+      const svc = createServiceClient();
+      const { data, error } = await svc.storage.from(USER_AVATAR_BUCKET).createSignedUrls(
+        entries.map((e) => e.avatarPath),
+        AVATAR_TTL_SECONDS
+      );
+      if (error || !data) return new Map();
+      const map = new Map<string, string>();
+      data.forEach((item, i) => {
+        if (item.signedUrl) map.set(entries[i].userId, item.signedUrl);
+      });
+      return map;
+    } catch {
+      return new Map();
+    }
+  };
+
+  const timeout = new Promise<Map<string, string>>((resolve) =>
+    setTimeout(() => resolve(new Map()), AVATAR_SIGN_TIMEOUT_MS)
+  );
+
+  return Promise.race([sign(), timeout]);
 }
 
 function resolveAvatarUrl(


### PR DESCRIPTION
…onse hang

Users with avatar_path set (private storage) but no avatar_url trigger a createSignedUrls call to Supabase Storage. If the storage API is slow or the service client's key is not configured for this project, that HTTP request can hang indefinitely, blocking the entire ticket detail response.

Wrap the signing call in Promise.race against a 2-second timeout. If storage doesn't respond in time, batchSignAvatarUrls returns an empty map and the ticket loads with null avatar_url (initials shown) rather than hanging forever.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Avatar signing now completes with a 2-second timeout instead of hanging indefinitely, improving responsiveness when storage is slow or unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kinetic639/coreframe-boilerplate/pull/353?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->