### PR TITLE
feat(help-desk): ticket acceptance workflow

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3019,6 +3019,7 @@
           "type": "Type",
           "status": "Status",
           "priority": "Priority",
+          "acceptance": "Acceptance",
           "createdBy": "Author",
           "responders": "Assigned",
           "createdAt": "Created",
@@ -3043,11 +3044,16 @@
           "responders": "Responders",
           "respondersPlaceholder": "Select responders",
           "respondersFixed": "Responders are fixed by the selected ticket type.",
-          "dueAt": "Due Date"
+          "dueAt": "Due Date",
+          "requiresAcceptance": "Requires Acceptance",
+          "requiresAcceptanceHint": "Ticket must be accepted by an authorized user before it can be resolved.",
+          "acceptors": "Authorized Acceptors",
+          "acceptorsPlaceholder": "Select authorized acceptors"
         },
         "validation": {
           "titleRequired": "Title is required.",
-          "responderRequired": "At least one responder is required."
+          "responderRequired": "At least one responder is required.",
+          "acceptorRequired": "At least one acceptor is required when acceptance is enabled."
         },
         "createTicket": "New Ticket",
         "newTicket": "New Ticket",
@@ -3072,9 +3078,19 @@
           "ticket_created": "created the ticket",
           "comment_added": "added a comment",
           "ticket_closed": "closed the ticket",
+          "ticket_accepted": "accepted the ticket",
           "status_changed": "changed the status",
           "assignee_added": "added a responder",
           "assignee_removed": "removed a responder"
+        },
+        "acceptance": {
+          "label": "Acceptance",
+          "pending": "Pending Acceptance",
+          "accepted": "Accepted",
+          "acceptButton": "Accept Ticket",
+          "acceptSuccess": "Ticket accepted successfully.",
+          "acceptedBy": "Accepted by",
+          "authorizedAcceptors": "Authorized Acceptors"
         }
       },
       "features": {
@@ -3097,7 +3113,11 @@
       "errors": {
         "loadFailed": "Failed to load help desk data",
         "ticketLoadFailed": "Failed to load tickets",
-        "ticketTypesLoadFailed": "Failed to load ticket types"
+        "ticketTypesLoadFailed": "Failed to load ticket types",
+        "createFailed": "Failed to create ticket.",
+        "commentFailed": "Failed to add comment.",
+        "closeFailed": "Failed to close ticket.",
+        "acceptFailed": "Failed to accept ticket."
       }
     },
     "analytics": {

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -2990,6 +2990,7 @@
           "type": "Typ",
           "status": "Status",
           "priority": "Priorytet",
+          "acceptance": "Akceptacja",
           "createdBy": "Autor",
           "responders": "Przypisani",
           "createdAt": "Utworzone",
@@ -3014,11 +3015,16 @@
           "responders": "Osoby odpowiedzialne",
           "respondersPlaceholder": "Wybierz osoby odpowiedzialne",
           "respondersFixed": "Osoby odpowiedzialne są ustalone przez wybrany typ zgłoszenia.",
-          "dueAt": "Termin"
+          "dueAt": "Termin",
+          "requiresAcceptance": "Wymaga akceptacji",
+          "requiresAcceptanceHint": "Zgłoszenie musi zostać zaakceptowane przez upoważnioną osobę przed rozwiązaniem.",
+          "acceptors": "Osoby upoważnione do akceptacji",
+          "acceptorsPlaceholder": "Wybierz osoby upoważnione do akceptacji"
         },
         "validation": {
           "titleRequired": "Tytuł jest wymagany.",
-          "responderRequired": "Wymagana jest co najmniej jedna osoba odpowiedzialna."
+          "responderRequired": "Wymagana jest co najmniej jedna osoba odpowiedzialna.",
+          "acceptorRequired": "Przy włączonej akceptacji wymagana jest co najmniej jedna osoba upoważniona."
         },
         "createTicket": "Nowe zgłoszenie",
         "newTicket": "Nowe zgłoszenie",
@@ -3043,9 +3049,19 @@
           "ticket_created": "utworzył(a) zgłoszenie",
           "comment_added": "dodał(a) komentarz",
           "ticket_closed": "zamknął(a) zgłoszenie",
+          "ticket_accepted": "zaakceptował(a) zgłoszenie",
           "status_changed": "zmienił(a) status",
           "assignee_added": "dodał(a) osobę odpowiedzialną",
           "assignee_removed": "usunął(a) osobę odpowiedzialną"
+        },
+        "acceptance": {
+          "label": "Akceptacja",
+          "pending": "Oczekuje na akceptację",
+          "accepted": "Zaakceptowane",
+          "acceptButton": "Zaakceptuj zgłoszenie",
+          "acceptSuccess": "Zgłoszenie zostało zaakceptowane.",
+          "acceptedBy": "Zaakceptowane przez",
+          "authorizedAcceptors": "Osoby upoważnione"
         }
       },
       "features": {
@@ -3068,7 +3084,11 @@
       "errors": {
         "loadFailed": "Nie udało się załadować danych Help Desk",
         "ticketLoadFailed": "Nie udało się załadować zgłoszeń",
-        "ticketTypesLoadFailed": "Nie udało się załadować typów zgłoszeń"
+        "ticketTypesLoadFailed": "Nie udało się załadować typów zgłoszeń",
+        "createFailed": "Nie udało się utworzyć zgłoszenia.",
+        "commentFailed": "Nie udało się dodać komentarza.",
+        "closeFailed": "Nie udało się zamknąć zgłoszenia.",
+        "acceptFailed": "Nie udało się zaakceptować zgłoszenia."
       }
     },
     "analytics": {

--- a/apps/web/src/app/[locale]/dashboard/help-desk/tickets/[ticketId]/_components/ticket-detail-client.tsx
+++ b/apps/web/src/app/[locale]/dashboard/help-desk/tickets/[ticketId]/_components/ticket-detail-client.tsx
@@ -27,6 +27,7 @@ import {
   useTicketDetailQuery,
   useAddTicketCommentMutation,
   useCloseTicketMutation,
+  useAcceptTicketMutation,
 } from "@/hooks/queries/help-desk";
 
 interface TicketDetailClientProps {
@@ -64,6 +65,12 @@ export function TicketDetailClient({
   );
   const addCommentMutation = useAddTicketCommentMutation(initialTicket.ticket_number);
   const closeTicketMutation = useCloseTicketMutation(initialTicket.ticket_number);
+  const acceptTicketMutation = useAcceptTicketMutation(initialTicket.ticket_number);
+
+  const canAccept =
+    ticket.requires_acceptance &&
+    !ticket.accepted_at &&
+    (canManage || ticket.acceptors.some((a) => a.user_id === currentUserId));
   const [commentValue, setCommentValue] = useState<RichTextValue>(createEmptyRichText);
 
   const isCreator = ticket.created_by === currentUserId;
@@ -200,6 +207,65 @@ export function TicketDetailClient({
               )}
               {t("tickets.closeTicket")}
             </Button>
+          )}
+
+          {/* Acceptance */}
+          {ticket.requires_acceptance && (
+            <div className="rounded-lg border p-4 space-y-3">
+              <h3 className="text-sm font-semibold">{t("tickets.acceptance.label")}</h3>
+              {ticket.accepted_at ? (
+                <div className="space-y-1">
+                  <span className="inline-block rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900/30 dark:text-green-300">
+                    {t("tickets.acceptance.accepted")}
+                  </span>
+                  {ticket.accepted_by_name && <p className="text-sm">{ticket.accepted_by_name}</p>}
+                  <p className="text-xs text-muted-foreground">{formatDate(ticket.accepted_at)}</p>
+                </div>
+              ) : (
+                <span className="inline-block rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300">
+                  {t("tickets.acceptance.pending")}
+                </span>
+              )}
+              {ticket.acceptors.length > 0 && (
+                <>
+                  <Separator />
+                  <div>
+                    <p className="text-muted-foreground mb-2 text-xs font-medium uppercase tracking-wide">
+                      {t("tickets.acceptance.authorizedAcceptors")}
+                    </p>
+                    <div className="space-y-2">
+                      {ticket.acceptors.map((a) => (
+                        <div key={a.user_id} className="flex items-center gap-2">
+                          <UserAvatar
+                            className="h-6 w-6"
+                            fullName={a.name}
+                            email={a.email}
+                            src={a.avatar_url}
+                            profileHref={a.profile_href}
+                          />
+                          <span className="truncate text-sm">{a.name ?? a.email ?? a.user_id}</span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </>
+              )}
+              {canAccept && (
+                <Button
+                  variant="default"
+                  className="w-full"
+                  onClick={() => acceptTicketMutation.mutate({ ticket_id: ticket.id })}
+                  disabled={acceptTicketMutation.isPending}
+                >
+                  {acceptTicketMutation.isPending ? (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  ) : (
+                    <CheckCircle className="mr-2 h-4 w-4" />
+                  )}
+                  {t("tickets.acceptance.acceptButton")}
+                </Button>
+              )}
+            </div>
           )}
 
           {/* Details */}

--- a/apps/web/src/app/[locale]/dashboard/help-desk/tickets/_components/tickets-client.tsx
+++ b/apps/web/src/app/[locale]/dashboard/help-desk/tickets/_components/tickets-client.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo, useCallback } from "react";
 import { useTranslations } from "next-intl";
 import { useRouter } from "@/i18n/navigation";
-import { Plus, Ticket, Calendar, Clock, Tag, User } from "lucide-react";
+import { Plus, Ticket, Calendar, Clock, Tag, User, CheckCircle, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { DataView } from "@/components/data-view/data-view";
@@ -14,7 +14,7 @@ import type {
   PaginatedResult,
 } from "@/components/data-view/data-view.types";
 import { listTicketsForDataViewAction, getTicketDetailAction } from "@/app/actions/help-desk";
-import { useAddTicketCommentMutation } from "@/hooks/queries/help-desk";
+import { useAddTicketCommentMutation, useAcceptTicketMutation } from "@/hooks/queries/help-desk";
 import type {
   HelpdeskTicketListRow,
   HelpdeskTicketDetail,
@@ -44,17 +44,32 @@ interface TicketsClientProps {
   ticketTypes: HelpdeskTicketType[];
   members: Array<{ user_id: string; name: string | null; email: string | null }>;
   canCreate: boolean;
+  canManage: boolean;
+  currentUserId: string;
   orgId: string;
 }
 
-function TicketDetailPanel({ detail }: { detail: HelpdeskTicketDetail }) {
+function TicketDetailPanel({
+  detail,
+  canManage,
+  currentUserId,
+}: {
+  detail: HelpdeskTicketDetail;
+  canManage: boolean;
+  currentUserId: string;
+}) {
   const t = useTranslations("modules.helpDesk");
   const [comments, setComments] = useState<HelpdeskTicketComment[]>(detail.comments);
   const [activity, setActivity] = useState<HelpdeskTicketActivity[]>(detail.activity);
   const [commentValue, setCommentValue] = useState<RichTextValue>(createEmptyRichText);
 
   const addCommentMutation = useAddTicketCommentMutation(detail.ticket_number);
+  const acceptMutation = useAcceptTicketMutation(detail.ticket_number);
   const canComment = detail.status !== "closed" && detail.status !== "cancelled";
+  const canAccept =
+    detail.requires_acceptance &&
+    !detail.accepted_at &&
+    (canManage || detail.acceptors.some((a) => a.user_id === currentUserId));
 
   const handleAddComment = useCallback(
     (value: RichTextValue) => {
@@ -175,6 +190,68 @@ function TicketDetailPanel({ detail }: { detail: HelpdeskTicketDetail }) {
             {t("tickets.viewFull")}
           </Button>
 
+          {/* Acceptance card */}
+          {detail.requires_acceptance && (
+            <div className="rounded-lg border p-3 space-y-2">
+              <p className="text-muted-foreground text-[10px] uppercase font-medium">
+                {t("tickets.acceptance.label")}
+              </p>
+              {detail.accepted_at ? (
+                <div className="space-y-1">
+                  <span className="inline-block rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900/30 dark:text-green-300">
+                    {t("tickets.acceptance.accepted")}
+                  </span>
+                  {detail.accepted_by_name && (
+                    <p className="text-xs text-muted-foreground truncate">
+                      {detail.accepted_by_name}
+                    </p>
+                  )}
+                  <p className="text-xs text-muted-foreground">
+                    {new Date(detail.accepted_at).toLocaleString()}
+                  </p>
+                </div>
+              ) : (
+                <span className="inline-block rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300">
+                  {t("tickets.acceptance.pending")}
+                </span>
+              )}
+              {detail.acceptors.length > 0 && (
+                <div className="space-y-1.5">
+                  <p className="text-[10px] text-muted-foreground uppercase">
+                    {t("tickets.acceptance.authorizedAcceptors")}
+                  </p>
+                  {detail.acceptors.map((a) => (
+                    <div key={a.user_id} className="flex items-center gap-2">
+                      <UserAvatar
+                        className="h-5 w-5"
+                        fullName={a.name}
+                        email={a.email}
+                        src={a.avatar_url}
+                        profileHref={a.profile_href}
+                      />
+                      <span className="truncate text-xs">{a.name ?? a.email}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+              {canAccept && (
+                <Button
+                  size="sm"
+                  className="w-full"
+                  disabled={acceptMutation.isPending}
+                  onClick={() => acceptMutation.mutate({ ticket_id: detail.id })}
+                >
+                  {acceptMutation.isPending ? (
+                    <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                  ) : (
+                    <CheckCircle className="mr-1.5 h-3.5 w-3.5" />
+                  )}
+                  {t("tickets.acceptance.acceptButton")}
+                </Button>
+              )}
+            </div>
+          )}
+
           <div className="rounded-lg border p-3 space-y-2">
             <div className="flex items-start gap-2">
               <User className="text-muted-foreground mt-0.5 h-3.5 w-3.5 shrink-0" />
@@ -291,6 +368,8 @@ export function TicketsClient({
   ticketTypes,
   members,
   canCreate,
+  canManage,
+  currentUserId,
   orgId,
 }: TicketsClientProps) {
   const t = useTranslations("modules.helpDesk");
@@ -392,6 +471,26 @@ export function TicketsClient({
         header: t("tickets.columns.priority"),
         accessor: (row) => <TicketPriorityBadge priority={row.priority} />,
         sortable: true,
+        defaultVisible: true,
+      },
+      {
+        key: "acceptance",
+        header: t("tickets.columns.acceptance"),
+        accessor: (row) =>
+          row.requires_acceptance ? (
+            row.accepted_at ? (
+              <span className="inline-block rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900/30 dark:text-green-300">
+                {t("tickets.acceptance.accepted")}
+              </span>
+            ) : (
+              <span className="inline-block rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300">
+                {t("tickets.acceptance.pending")}
+              </span>
+            )
+          ) : (
+            <span className="text-muted-foreground text-xs">—</span>
+          ),
+        sortable: false,
         defaultVisible: true,
       },
       {
@@ -549,7 +648,14 @@ export function TicketsClient({
               </span>
             </div>
           )}
-          renderDetail={(detail) => <TicketDetailPanel key={detail.id} detail={detail} />}
+          renderDetail={(detail) => (
+            <TicketDetailPanel
+              key={detail.id}
+              detail={detail}
+              canManage={canManage}
+              currentUserId={currentUserId}
+            />
+          )}
           renderToolbarControls={() =>
             canCreate ? (
               <Button size="sm" onClick={() => router.push("/dashboard/help-desk/tickets/new")}>

--- a/apps/web/src/app/[locale]/dashboard/help-desk/tickets/new/_components/new-ticket-form.tsx
+++ b/apps/web/src/app/[locale]/dashboard/help-desk/tickets/new/_components/new-ticket-form.tsx
@@ -8,6 +8,7 @@ import { ArrowLeft, Send, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
 import {
   Select,
   SelectContent,
@@ -40,6 +41,8 @@ export function NewTicketForm({ ticketTypes, members }: NewTicketFormProps) {
 
   const [title, setTitle] = useState("");
   const [descriptionRich, setDescriptionRich] = useState<RichTextValue>(createEmptyRichText);
+  const [requiresAcceptance, setRequiresAcceptance] = useState(false);
+  const [acceptorIds, setAcceptorIds] = useState<string[]>([]);
   const [ticketTypeId, setTicketTypeId] = useState<string>("");
   const [priority, setPriority] = useState<TicketPriority>("medium");
   const [assigneeIds, setAssigneeIds] = useState<string[]>([]);
@@ -71,6 +74,8 @@ export function NewTicketForm({ ticketTypes, members }: NewTicketFormProps) {
     const errs: Record<string, string> = {};
     if (!title.trim()) errs.title = t("tickets.validation.titleRequired");
     if (assigneeIds.length === 0) errs.assignees = t("tickets.validation.responderRequired");
+    if (requiresAcceptance && acceptorIds.length === 0)
+      errs.acceptors = t("tickets.validation.acceptorRequired");
     setErrors(errs);
     return Object.keys(errs).length === 0;
   };
@@ -89,6 +94,8 @@ export function NewTicketForm({ ticketTypes, members }: NewTicketFormProps) {
         priority,
         ticket_type_id: ticketTypeId || undefined,
         assignee_user_ids: assigneeIds,
+        requires_acceptance: requiresAcceptance,
+        acceptor_user_ids: acceptorIds,
       },
       {
         onSuccess: (data) => {
@@ -203,6 +210,44 @@ export function NewTicketForm({ ticketTypes, members }: NewTicketFormProps) {
           {errors.assignees && <p className="text-destructive text-xs">{errors.assignees}</p>}
           {!allowsManualAssignees && (
             <p className="text-muted-foreground text-xs">{t("tickets.fields.respondersFixed")}</p>
+          )}
+        </div>
+
+        {/* Requires Acceptance */}
+        <div className="space-y-3">
+          <div className="flex items-center justify-between gap-4">
+            <div className="space-y-0.5">
+              <Label htmlFor="requiresAcceptance">{t("tickets.fields.requiresAcceptance")}</Label>
+              <p className="text-muted-foreground text-xs">
+                {t("tickets.fields.requiresAcceptanceHint")}
+              </p>
+            </div>
+            <Switch
+              id="requiresAcceptance"
+              checked={requiresAcceptance}
+              onCheckedChange={(checked) => {
+                setRequiresAcceptance(checked);
+                if (!checked) setAcceptorIds([]);
+              }}
+              disabled={createTicketMutation.isPending}
+            />
+          </div>
+
+          {requiresAcceptance && (
+            <div className="space-y-2">
+              <Label>
+                {t("tickets.fields.acceptors")}
+                <span className="text-destructive ml-1">*</span>
+              </Label>
+              <MemberSelector
+                members={members}
+                selectedIds={acceptorIds}
+                onChange={setAcceptorIds}
+                placeholder={t("tickets.fields.acceptorsPlaceholder")}
+                disabled={createTicketMutation.isPending}
+              />
+              {errors.acceptors && <p className="text-destructive text-xs">{errors.acceptors}</p>}
+            </div>
           )}
         </div>
 

--- a/apps/web/src/app/[locale]/dashboard/help-desk/tickets/page.tsx
+++ b/apps/web/src/app/[locale]/dashboard/help-desk/tickets/page.tsx
@@ -2,7 +2,11 @@ import { redirect } from "@/i18n/navigation";
 import { getLocale } from "next-intl/server";
 import { loadDashboardContextV2 } from "@/server/loaders/v2/load-dashboard-context.v2";
 import { checkPermission } from "@/lib/utils/permissions";
-import { HELPDESK_TICKETS_READ, HELPDESK_TICKETS_CREATE } from "@/lib/constants/permissions";
+import {
+  HELPDESK_TICKETS_READ,
+  HELPDESK_TICKETS_CREATE,
+  HELPDESK_TICKETS_MANAGE,
+} from "@/lib/constants/permissions";
 import { createClient } from "@/utils/supabase/server";
 import { HelpdeskTicketsService } from "@/server/services/helpdesk-tickets.service";
 import { HelpdeskTicketTypesService } from "@/server/services/helpdesk-ticket-types.service";
@@ -60,6 +64,8 @@ export default async function HelpDeskTicketsPage({ searchParams }: PageProps = 
       ticketTypes={ticketTypes}
       members={members}
       canCreate={checkPermission(context.user.permissionSnapshot, HELPDESK_TICKETS_CREATE)}
+      canManage={checkPermission(context.user.permissionSnapshot, HELPDESK_TICKETS_MANAGE)}
+      currentUserId={context.user.user?.id ?? ""}
       orgId={orgId}
     />
   );

--- a/apps/web/src/app/actions/help-desk/index.ts
+++ b/apps/web/src/app/actions/help-desk/index.ts
@@ -24,8 +24,10 @@ import {
   createTicketTypeSchema,
   updateTicketTypeSchema,
   createTicketSchema,
+  acceptTicketSchema,
   closeTicketSchema,
   addTicketCommentSchema,
+  type AcceptTicketInput,
   type CreateTicketTypeInput,
   type UpdateTicketTypeInput,
   type CreateTicketInput,
@@ -308,6 +310,25 @@ export async function listTicketsAction(
     if (!checkPermission(ctx.context.user.permissionSnapshot, HELPDESK_TICKETS_READ))
       return { success: false, error: "Insufficient permissions" };
     return HelpdeskTicketsService.list(ctx.supabase, ctx.orgId, filters);
+  } catch {
+    return { success: false, error: "Unexpected error" };
+  }
+}
+
+export async function acceptTicketAction(
+  input: AcceptTicketInput
+): Promise<
+  ActionResult<{ id: string; ticket_number: string; accepted_by: string; accepted_at: string }>
+> {
+  try {
+    const ctx = await getAuthedContext();
+    if (!ctx) return { success: false, error: "Unauthorized" };
+    if (!checkPermission(ctx.context.user.permissionSnapshot, HELPDESK_TICKETS_READ))
+      return { success: false, error: "Insufficient permissions" };
+    const parsed = acceptTicketSchema.safeParse(input);
+    if (!parsed.success)
+      return { success: false, error: parsed.error.errors[0]?.message ?? parsed.error.message };
+    return HelpdeskTicketsService.acceptTicket(ctx.supabase, ctx.orgId, ctx.userId, parsed.data);
   } catch {
     return { success: false, error: "Unexpected error" };
   }

--- a/apps/web/src/hooks/queries/help-desk/index.ts
+++ b/apps/web/src/hooks/queries/help-desk/index.ts
@@ -11,8 +11,10 @@ import {
   getTicketDetailAction,
   addTicketCommentAction,
   closeTicketAction,
+  acceptTicketAction,
 } from "@/app/actions/help-desk";
 import type {
+  AcceptTicketInput,
   CreateTicketInput,
   AddTicketCommentInput,
   CloseTicketInput,
@@ -177,6 +179,31 @@ export function useCloseTicketMutation(ticketNumber: string) {
     },
     onError: (err: Error) => {
       toast.error(err.message || t("errors.closeFailed"));
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Accept Ticket
+// ---------------------------------------------------------------------------
+
+export function useAcceptTicketMutation(ticketNumber: string) {
+  const queryClient = useQueryClient();
+  const t = useTranslations("modules.helpDesk");
+
+  return useMutation({
+    mutationFn: async (input: AcceptTicketInput) => {
+      const result = await acceptTicketAction(input);
+      if (!result.success) throw new Error((result as { success: false; error: string }).error);
+      return result.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: helpdeskKeys.ticketDetail(ticketNumber) });
+      queryClient.invalidateQueries({ queryKey: helpdeskKeys.ticketsDataView() });
+      toast.success(t("tickets.acceptance.acceptSuccess"));
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || t("errors.acceptFailed"));
     },
   });
 }

--- a/apps/web/src/lib/validations/helpdesk.ts
+++ b/apps/web/src/lib/validations/helpdesk.ts
@@ -52,17 +52,29 @@ export type UpdateTicketTypeInput = z.infer<typeof updateTicketTypeSchema>;
 // Tickets
 // ---------------------------------------------------------------------------
 
-export const createTicketSchema = z.object({
-  title: z.string().min(1, "Title is required").max(255),
-  description_plain: z.string().max(10000).optional(),
-  description_rich: z.unknown().optional(),
-  status: z.enum(TICKET_STATUSES).default("waiting_response"),
-  priority: z.enum(TICKET_PRIORITIES).default("medium"),
-  ticket_type_id: z.string().uuid().optional(),
-  assignee_user_ids: z.array(z.string().uuid()).min(1, "At least one responder is required"),
-  branch_id: z.string().uuid().optional(),
-  due_at: z.string().datetime().optional(),
-});
+export const createTicketSchema = z
+  .object({
+    title: z.string().min(1, "Title is required").max(255),
+    description_plain: z.string().max(10000).optional(),
+    description_rich: z.unknown().optional(),
+    status: z.enum(TICKET_STATUSES).default("waiting_response"),
+    priority: z.enum(TICKET_PRIORITIES).default("medium"),
+    ticket_type_id: z.string().uuid().optional(),
+    assignee_user_ids: z.array(z.string().uuid()).min(1, "At least one responder is required"),
+    branch_id: z.string().uuid().optional(),
+    due_at: z.string().datetime().optional(),
+    requires_acceptance: z.boolean().default(false),
+    acceptor_user_ids: z.array(z.string().uuid()).default([]),
+  })
+  .superRefine((data, ctx) => {
+    if (data.requires_acceptance && data.acceptor_user_ids.length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "At least one acceptor is required when acceptance is enabled.",
+        path: ["acceptor_user_ids"],
+      });
+    }
+  });
 
 export const closeTicketSchema = z.object({
   ticket_id: z.string().uuid(),
@@ -95,6 +107,16 @@ export const addTicketCommentSchema = z.object({
 });
 
 export type AddTicketCommentInput = z.infer<typeof addTicketCommentSchema>;
+
+// ---------------------------------------------------------------------------
+// Accept ticket
+// ---------------------------------------------------------------------------
+
+export const acceptTicketSchema = z.object({
+  ticket_id: z.string().uuid(),
+});
+
+export type AcceptTicketInput = z.infer<typeof acceptTicketSchema>;
 
 // ---------------------------------------------------------------------------
 // Legacy compat aliases used in existing service/action code

--- a/apps/web/src/server/services/helpdesk-tickets.service.ts
+++ b/apps/web/src/server/services/helpdesk-tickets.service.ts
@@ -2,6 +2,7 @@ import "server-only";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { createServiceClient } from "@/utils/supabase/service";
 import type {
+  AcceptTicketInput,
   AddTicketCommentInput,
   AssigneeRole,
   AssigneeStatus,
@@ -28,6 +29,14 @@ export interface HelpdeskAssigneeInfo {
   profile_href: string | null;
 }
 
+export interface HelpdeskAcceptorInfo {
+  user_id: string;
+  name: string | null;
+  email: string | null;
+  avatar_url: string | null;
+  profile_href: string;
+}
+
 export interface HelpdeskTicketListRow {
   id: string;
   org_id: string;
@@ -45,6 +54,11 @@ export interface HelpdeskTicketListRow {
   creator_avatar_url: string | null;
   creator_profile_href: string | null;
   assignees: HelpdeskAssigneeInfo[];
+  requires_acceptance: boolean;
+  accepted_by: string | null;
+  accepted_at: string | null;
+  accepted_by_name: string | null;
+  accepted_by_avatar_url: string | null;
   branch_id: string | null;
   closed_at: string | null;
   created_at: string;
@@ -60,6 +74,7 @@ export interface HelpdeskTicketDetail extends HelpdeskTicketListRow {
   due_at: string | null;
   comments: HelpdeskTicketComment[];
   activity: HelpdeskTicketActivity[];
+  acceptors: HelpdeskAcceptorInfo[];
 }
 
 export interface HelpdeskTicketComment {
@@ -217,8 +232,10 @@ export class HelpdeskTicketsService {
         [
           "id, org_id, ticket_number, title, status, priority,",
           "ticket_type_id, created_by, branch_id, closed_at, created_at, updated_at,",
+          "requires_acceptance, accepted_by, accepted_at,",
           "ticket_type:helpdesk_ticket_types!ticket_type_id(id,name,color,icon),",
-          "creator:users!created_by(id,first_name,last_name,email,avatar_url,avatar_path)",
+          "creator:users!created_by(id,first_name,last_name,email,avatar_url,avatar_path),",
+          "acceptor:users!accepted_by(id,first_name,last_name,email,avatar_url,avatar_path)",
         ].join(""),
         { count: "exact" }
       )
@@ -293,12 +310,16 @@ export class HelpdeskTicketsService {
       }
     }
 
-    // Collect all users with a private avatar_path, sign them in one batch call
+    // Collect all users with a private avatar_path for batch signing
     const avatarEntries: Array<{ userId: string; avatarPath: string }> = [];
     tickets.forEach((t) => {
       const creator = t.creator as { id: string; avatar_path: string | null } | null;
       if (creator?.avatar_path?.startsWith(`${creator.id}/`)) {
         avatarEntries.push({ userId: creator.id, avatarPath: creator.avatar_path });
+      }
+      const acceptor = t.acceptor as { id: string; avatar_path: string | null } | null;
+      if (acceptor?.avatar_path?.startsWith(`${acceptor.id}/`)) {
+        avatarEntries.push({ userId: acceptor.id, avatarPath: acceptor.avatar_path });
       }
     });
     assigneeMap.forEach((infos) => {
@@ -319,6 +340,14 @@ export class HelpdeskTicketsService {
         icon: string;
       } | null;
       const creator = t.creator as {
+        id: string;
+        first_name: string | null;
+        last_name: string | null;
+        email: string | null;
+        avatar_url: string | null;
+        avatar_path: string | null;
+      } | null;
+      const acceptorUser = t.acceptor as {
         id: string;
         first_name: string | null;
         last_name: string | null;
@@ -356,6 +385,20 @@ export class HelpdeskTicketsService {
           ),
           profile_href: memberProfileHref(a.user_id),
         })),
+        requires_acceptance: (t.requires_acceptance as boolean) ?? false,
+        accepted_by: (t.accepted_by as string | null) ?? null,
+        accepted_at: (t.accepted_at as string | null) ?? null,
+        accepted_by_name: acceptorUser
+          ? displayName(acceptorUser.first_name, acceptorUser.last_name, acceptorUser.email)
+          : null,
+        accepted_by_avatar_url: acceptorUser
+          ? resolveAvatarUrl(
+              acceptorUser.id,
+              acceptorUser.avatar_url,
+              acceptorUser.avatar_path,
+              signedAvatarUrls
+            )
+          : null,
         branch_id: (t.branch_id as string | null) ?? null,
         closed_at: (t.closed_at as string | null) ?? null,
         created_at: t.created_at as string,
@@ -394,33 +437,41 @@ export class HelpdeskTicketsService {
     // Sub-queries join on the internal UUID FK, not the human-readable ticket_number
     const ticketId = ticket.id as string;
 
-    // Assignees, comments, activity are all independent — fetch in parallel
-    const [{ data: assigneeRows }, { data: commentRows }, { data: activityRows }] =
-      await Promise.all([
-        supabase
-          .from("helpdesk_ticket_assignees")
-          .select(
-            "user_id, role, status, user:users!user_id(id,first_name,last_name,email,avatar_url,avatar_path)"
-          )
-          .eq("ticket_id", ticketId)
-          .is("deleted_at", null),
-        supabase
-          .from("helpdesk_ticket_comments")
-          .select(
-            "*, commenter:users!created_by(id,first_name,last_name,email,avatar_url,avatar_path)"
-          )
-          .eq("ticket_id", ticketId)
-          .eq("org_id", orgId)
-          .is("deleted_at", null)
-          .order("created_at", { ascending: true }),
-        supabase
-          .from("helpdesk_ticket_activity")
-          .select("*, actor:users!actor_id(id,first_name,last_name,email)")
-          .eq("ticket_id", ticketId)
-          .eq("org_id", orgId)
-          .order("created_at", { ascending: false })
-          .limit(50),
-      ]);
+    // Assignees, comments, activity, acceptors — all independent, fetch in parallel
+    const [
+      { data: assigneeRows },
+      { data: commentRows },
+      { data: activityRows },
+      { data: acceptorRows },
+    ] = await Promise.all([
+      supabase
+        .from("helpdesk_ticket_assignees")
+        .select(
+          "user_id, role, status, user:users!user_id(id,first_name,last_name,email,avatar_url,avatar_path)"
+        )
+        .eq("ticket_id", ticketId)
+        .is("deleted_at", null),
+      supabase
+        .from("helpdesk_ticket_comments")
+        .select(
+          "*, commenter:users!created_by(id,first_name,last_name,email,avatar_url,avatar_path)"
+        )
+        .eq("ticket_id", ticketId)
+        .eq("org_id", orgId)
+        .is("deleted_at", null)
+        .order("created_at", { ascending: true }),
+      supabase
+        .from("helpdesk_ticket_activity")
+        .select("*, actor:users!actor_id(id,first_name,last_name,email)")
+        .eq("ticket_id", ticketId)
+        .eq("org_id", orgId)
+        .order("created_at", { ascending: false })
+        .limit(50),
+      supabase
+        .from("helpdesk_ticket_acceptors")
+        .select("user_id, user:users!user_id(id,first_name,last_name,email,avatar_url,avatar_path)")
+        .eq("ticket_id", ticketId),
+    ]);
 
     const assignees = ((assigneeRows ?? []) as any[]).map((row) => {
       const u = row.user as {
@@ -508,7 +559,32 @@ export class HelpdeskTicketsService {
         detailAvatarEntries.push({ userId: u.id, avatarPath: u.avatar_path });
       }
     });
+    type RawAcceptorUser = {
+      id: string;
+      first_name: string | null;
+      last_name: string | null;
+      email: string | null;
+      avatar_url: string | null;
+      avatar_path: string | null;
+    };
+    const rawAcceptors = ((acceptorRows ?? []) as any[]).map((row) => ({
+      user_id: row.user_id as string,
+      u: row.user as RawAcceptorUser | null,
+    }));
+    rawAcceptors.forEach(({ u }) => {
+      if (u?.avatar_path?.startsWith(`${u.id}/`)) {
+        detailAvatarEntries.push({ userId: u.id, avatarPath: u.avatar_path });
+      }
+    });
     const detailSignedUrls = await batchSignAvatarUrls(detailAvatarEntries);
+
+    const acceptors: HelpdeskAcceptorInfo[] = rawAcceptors.map(({ user_id, u }) => ({
+      user_id,
+      name: u ? displayName(u.first_name, u.last_name, u.email) : null,
+      email: u?.email ?? null,
+      avatar_url: u ? resolveAvatarUrl(u.id, u.avatar_url, u.avatar_path, detailSignedUrls) : null,
+      profile_href: memberProfileHref(user_id),
+    }));
 
     const comments: HelpdeskTicketComment[] = rawComments.map(({ row, u }) => ({
       id: row.id as string,
@@ -561,6 +637,11 @@ export class HelpdeskTicketsService {
         ),
         profile_href: memberProfileHref(a.user_id),
       })),
+      requires_acceptance: (ticket.requires_acceptance as boolean) ?? false,
+      accepted_by: (ticket.accepted_by as string | null) ?? null,
+      accepted_at: (ticket.accepted_at as string | null) ?? null,
+      accepted_by_name: null,
+      accepted_by_avatar_url: null,
       branch_id: (ticket.branch_id as string | null) ?? null,
       closed_at: (ticket.closed_at as string | null) ?? null,
       created_at: ticket.created_at as string,
@@ -576,6 +657,7 @@ export class HelpdeskTicketsService {
         creator_profile_href: memberProfileHref(c.created_by),
       })),
       activity,
+      acceptors,
     };
 
     return { success: true, data: detail };
@@ -599,6 +681,8 @@ export class HelpdeskTicketsService {
       p_branch_id: input.branch_id ?? null,
       p_assignee_ids: input.assignee_user_ids,
       p_due_at: input.due_at ?? null,
+      p_requires_acceptance: input.requires_acceptance ?? false,
+      p_acceptor_ids: input.acceptor_user_ids ?? [],
     });
 
     if (error) return { success: false, error: error.message };
@@ -749,12 +833,43 @@ export class HelpdeskTicketsService {
         creator_avatar_url: null,
         creator_profile_href: null,
         assignees: [],
+        requires_acceptance: false,
+        accepted_by: null,
+        accepted_at: null,
+        accepted_by_name: null,
+        accepted_by_avatar_url: null,
         branch_id: (data.branch_id as string | null) ?? null,
         closed_at: data.closed_at as string,
         created_at: data.created_at as string,
         updated_at: data.updated_at as string,
       },
     };
+  }
+
+  // ── Accept Ticket ──────────────────────────────────────────────────────────
+
+  static async acceptTicket(
+    supabase: SupabaseClient,
+    _orgId: string,
+    _userId: string,
+    input: AcceptTicketInput
+  ): Promise<
+    ServiceResult<{ id: string; ticket_number: string; accepted_by: string; accepted_at: string }>
+  > {
+    const { data, error } = await supabase.rpc("helpdesk_accept_ticket", {
+      p_ticket_id: input.ticket_id,
+    });
+
+    if (error) return { success: false, error: error.message };
+
+    const result = data as {
+      id: string;
+      ticket_number: string;
+      accepted_by: string;
+      accepted_at: string;
+    };
+
+    return { success: true, data: result };
   }
 
   // ── Legacy methods kept for backward compat ────────────────────────────────

--- a/apps/web/supabase/migrations/20260529100000_helpdesk_acceptance_workflow.sql
+++ b/apps/web/supabase/migrations/20260529100000_helpdesk_acceptance_workflow.sql
@@ -1,0 +1,224 @@
+-- ---------------------------------------------------------------------------
+-- Helpdesk: Ticket Acceptance Workflow
+-- Adds optional "requires acceptance" flag to tickets, a table of authorized
+-- acceptors, and a SECURITY DEFINER RPC for the accept action.
+-- ---------------------------------------------------------------------------
+
+-- 1. New columns on helpdesk_tickets
+ALTER TABLE public.helpdesk_tickets
+  ADD COLUMN IF NOT EXISTS requires_acceptance BOOLEAN     NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS accepted_by         UUID        REFERENCES public.users(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS accepted_at         TIMESTAMPTZ;
+
+-- 2. Authorized acceptors table
+CREATE TABLE IF NOT EXISTS public.helpdesk_ticket_acceptors (
+  id         UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  ticket_id  UUID        NOT NULL REFERENCES public.helpdesk_tickets(id) ON DELETE CASCADE,
+  org_id     UUID        NOT NULL REFERENCES public.organizations(id)    ON DELETE CASCADE,
+  user_id    UUID        NOT NULL REFERENCES public.users(id)            ON DELETE CASCADE,
+  added_by   UUID        REFERENCES public.users(id) ON DELETE SET NULL,
+  added_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (ticket_id, user_id)
+);
+
+ALTER TABLE public.helpdesk_ticket_acceptors ENABLE ROW LEVEL SECURITY;
+
+CREATE INDEX IF NOT EXISTS helpdesk_ticket_acceptors_ticket_idx
+  ON public.helpdesk_ticket_acceptors (ticket_id);
+
+CREATE INDEX IF NOT EXISTS helpdesk_ticket_acceptors_user_org_idx
+  ON public.helpdesk_ticket_acceptors (org_id, user_id);
+
+-- RLS: any ticket reader can see who the acceptors are
+CREATE POLICY "helpdesk_ticket_acceptors_select"
+  ON public.helpdesk_ticket_acceptors
+  FOR SELECT TO authenticated
+  USING (
+    is_org_member(org_id)
+    AND has_permission(org_id, 'helpdesk.tickets.read')
+  );
+
+CREATE POLICY "helpdesk_ticket_acceptors_insert"
+  ON public.helpdesk_ticket_acceptors
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    is_org_member(org_id)
+    AND (
+      has_permission(org_id, 'helpdesk.tickets.create')
+      OR has_permission(org_id, 'helpdesk.tickets.manage')
+    )
+  );
+
+CREATE POLICY "helpdesk_ticket_acceptors_delete"
+  ON public.helpdesk_ticket_acceptors
+  FOR DELETE TO authenticated
+  USING (
+    is_org_member(org_id)
+    AND has_permission(org_id, 'helpdesk.tickets.manage')
+  );
+
+-- 3. Update helpdesk_create_ticket RPC to handle acceptors
+CREATE OR REPLACE FUNCTION public.helpdesk_create_ticket(
+  p_org_id              UUID,
+  p_title               TEXT,
+  p_description_plain   TEXT,
+  p_description_rich    JSONB,
+  p_status              TEXT,
+  p_priority            TEXT,
+  p_ticket_type_id      UUID,
+  p_branch_id           UUID,
+  p_assignee_ids        UUID[],
+  p_due_at              TIMESTAMPTZ DEFAULT NULL,
+  p_requires_acceptance BOOLEAN     DEFAULT false,
+  p_acceptor_ids        UUID[]      DEFAULT '{}'
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_ticket_id     UUID;
+  v_ticket_number TEXT;
+  v_prefix        TEXT := 'HD';
+  v_seq_num       BIGINT;
+  v_assignee_id   UUID;
+  v_acceptor_id   UUID;
+BEGIN
+  IF NOT (is_org_member(p_org_id) AND has_permission(p_org_id, 'helpdesk.tickets.create')) THEN
+    RAISE EXCEPTION 'Unauthorized: cannot create ticket';
+  END IF;
+
+  SELECT COALESCE(ticket_prefix, 'HD') INTO v_prefix
+  FROM   public.helpdesk_settings
+  WHERE  org_id = p_org_id;
+
+  v_seq_num       := nextval('public.helpdesk_ticket_number_seq');
+  v_ticket_number := COALESCE(v_prefix, 'HD') || '-' || LPAD(v_seq_num::TEXT, 6, '0');
+
+  INSERT INTO public.helpdesk_tickets (
+    org_id, ticket_number, title,
+    description, description_plain, description_rich,
+    status, priority, ticket_type_id, branch_id,
+    created_by, requested_by, due_at,
+    requires_acceptance
+  ) VALUES (
+    p_org_id, v_ticket_number, p_title,
+    p_description_plain, p_description_plain, p_description_rich,
+    p_status, p_priority, p_ticket_type_id, p_branch_id,
+    auth.uid(), auth.uid(), p_due_at,
+    p_requires_acceptance
+  )
+  RETURNING id INTO v_ticket_id;
+
+  IF p_assignee_ids IS NOT NULL AND array_length(p_assignee_ids, 1) > 0 THEN
+    FOREACH v_assignee_id IN ARRAY p_assignee_ids LOOP
+      INSERT INTO public.helpdesk_ticket_assignees (
+        org_id, ticket_id, user_id, role, status, assigned_by
+      ) VALUES (
+        p_org_id, v_ticket_id, v_assignee_id, 'responder', 'assigned', auth.uid()
+      )
+      ON CONFLICT (ticket_id, user_id) DO NOTHING;
+    END LOOP;
+  END IF;
+
+  IF p_requires_acceptance AND p_acceptor_ids IS NOT NULL
+     AND array_length(p_acceptor_ids, 1) > 0 THEN
+    FOREACH v_acceptor_id IN ARRAY p_acceptor_ids LOOP
+      INSERT INTO public.helpdesk_ticket_acceptors (
+        org_id, ticket_id, user_id, added_by
+      ) VALUES (
+        p_org_id, v_ticket_id, v_acceptor_id, auth.uid()
+      )
+      ON CONFLICT (ticket_id, user_id) DO NOTHING;
+    END LOOP;
+  END IF;
+
+  INSERT INTO public.helpdesk_ticket_activity (
+    ticket_id, org_id, actor_id, event_type, payload
+  ) VALUES (
+    v_ticket_id, p_org_id, auth.uid(), 'ticket_created',
+    jsonb_build_object(
+      'ticket_number',        v_ticket_number,
+      'title',                p_title,
+      'status',               p_status,
+      'priority',             p_priority,
+      'assignee_count',       COALESCE(array_length(p_assignee_ids, 1), 0),
+      'requires_acceptance',  p_requires_acceptance,
+      'acceptor_count',       COALESCE(array_length(p_acceptor_ids, 1), 0)
+    )
+  );
+
+  RETURN jsonb_build_object('id', v_ticket_id, 'ticket_number', v_ticket_number);
+END;
+$$;
+
+-- 4. SECURITY DEFINER RPC for accepting a ticket
+--    Validates: is org member + has read permission + is authorized acceptor or manager
+CREATE OR REPLACE FUNCTION public.helpdesk_accept_ticket(
+  p_ticket_id UUID
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_ticket       RECORD;
+  v_is_acceptor  BOOLEAN;
+  v_is_manager   BOOLEAN;
+  v_now          TIMESTAMPTZ := now();
+BEGIN
+  SELECT id, org_id, requires_acceptance, accepted_by, ticket_number
+  INTO   v_ticket
+  FROM   public.helpdesk_tickets
+  WHERE  id = p_ticket_id AND deleted_at IS NULL;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Ticket not found';
+  END IF;
+
+  IF NOT (is_org_member(v_ticket.org_id) AND has_permission(v_ticket.org_id, 'helpdesk.tickets.read')) THEN
+    RAISE EXCEPTION 'Unauthorized';
+  END IF;
+
+  IF NOT v_ticket.requires_acceptance THEN
+    RAISE EXCEPTION 'Ticket does not require acceptance';
+  END IF;
+
+  IF v_ticket.accepted_by IS NOT NULL THEN
+    RAISE EXCEPTION 'Ticket has already been accepted';
+  END IF;
+
+  v_is_manager := has_permission(v_ticket.org_id, 'helpdesk.tickets.manage');
+
+  SELECT EXISTS(
+    SELECT 1 FROM public.helpdesk_ticket_acceptors
+    WHERE  ticket_id = p_ticket_id AND user_id = auth.uid()
+  ) INTO v_is_acceptor;
+
+  IF NOT (v_is_manager OR v_is_acceptor) THEN
+    RAISE EXCEPTION 'Not authorized to accept this ticket';
+  END IF;
+
+  UPDATE public.helpdesk_tickets
+  SET    accepted_by = auth.uid(),
+         accepted_at = v_now,
+         updated_at  = v_now
+  WHERE  id = p_ticket_id;
+
+  INSERT INTO public.helpdesk_ticket_activity (
+    ticket_id, org_id, actor_id, event_type, payload
+  ) VALUES (
+    p_ticket_id, v_ticket.org_id, auth.uid(), 'ticket_accepted',
+    jsonb_build_object('accepted_at', v_now)
+  );
+
+  RETURN jsonb_build_object(
+    'id',            p_ticket_id,
+    'ticket_number', v_ticket.ticket_number,
+    'accepted_by',   auth.uid(),
+    'accepted_at',   v_now
+  );
+END;
+$$;


### PR DESCRIPTION
Tickets can now require acceptance by designated users before being resolved.

DB:
- helpdesk_tickets: +requires_acceptance, +accepted_by, +accepted_at
- helpdesk_ticket_acceptors table (ticket_id, user_id, added_by) with RLS
- helpdesk_create_ticket RPC: +p_requires_acceptance, +p_acceptor_ids — inserts acceptors atomically in the same transaction
- helpdesk_accept_ticket SECURITY DEFINER RPC — validates caller is in acceptors list or has helpdesk.tickets.manage; records accepted_by/accepted_at and writes ticket_accepted activity entry

Service:
- HelpdeskAcceptorInfo type; acceptors array on HelpdeskTicketDetail
- listForDataView: requires_acceptance / accepted_by / accepted_at / accepted_by_name from acceptor:users!accepted_by join; acceptors parallel query in getDetail
- createWithAssignees: passes new RPC params
- new acceptTicket method (calls helpdesk_accept_ticket RPC)

Actions / Hooks:
- acceptTicketAction (uses full getAuthedContext + acceptTicketSchema)
- useAcceptTicketMutation — invalidates ticketDetail + ticketsDataView on success

UI:
- new-ticket-form: Switch toggle + MemberSelector for acceptors (conditional)
- DataView table: new Acceptance column with Pending/Accepted badges
- TicketDetailPanel: acceptance card in sidebar (status, acceptors list, Accept button for authorized users); canManage + currentUserId threaded in
- ticket-detail-client: same acceptance sidebar section with Accept button
- i18n: all keys added to en.json and pl.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ticket acceptance workflow—users can now require acceptance for help desk tickets
  * New acceptance status display in ticket lists and detail views (showing accepted/pending states and accepted-by information)
  * Accept button and authorized acceptor list in ticket details
  * Form toggle and member selector when creating tickets to configure acceptance requirements
  * Multi-language support for acceptance workflow UI and error messages

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kinetic639/coreframe-boilerplate/pull/355?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->