### PR TITLE
fix(help-desk): branch filter, multi-select status, redirect fix, acc…

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3029,6 +3029,7 @@
           "createdAt": "Created Date",
           "createdBy": "Created By",
           "assignedTo": "Assigned To",
+          "branch": "Branch",
           "status": "Status",
           "priority": "Priority",
           "ticketType": "Ticket Type"

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -3000,6 +3000,7 @@
           "createdAt": "Data utworzenia",
           "createdBy": "Utworzone przez",
           "assignedTo": "Przypisane do",
+          "branch": "Oddział",
           "status": "Status",
           "priority": "Priorytet",
           "ticketType": "Typ zgłoszenia"

--- a/apps/web/src/app/[locale]/dashboard/help-desk/tickets/_components/tickets-client.tsx
+++ b/apps/web/src/app/[locale]/dashboard/help-desk/tickets/_components/tickets-client.tsx
@@ -43,6 +43,7 @@ interface TicketsClientProps {
   initialData: PaginatedResult<HelpdeskTicketListRow>;
   ticketTypes: HelpdeskTicketType[];
   members: Array<{ user_id: string; name: string | null; email: string | null }>;
+  branches: Array<{ id: string; name: string }>;
   canCreate: boolean;
   canManage: boolean;
   currentUserId: string;
@@ -63,12 +64,15 @@ function TicketDetailPanel({
   const [activity, setActivity] = useState<HelpdeskTicketActivity[]>(detail.activity);
   const [commentValue, setCommentValue] = useState<RichTextValue>(createEmptyRichText);
 
+  const [acceptedAt, setAcceptedAt] = useState<string | null>(detail.accepted_at);
+  const [acceptedByName, setAcceptedByName] = useState<string | null>(detail.accepted_by_name);
+
   const addCommentMutation = useAddTicketCommentMutation(detail.ticket_number);
   const acceptMutation = useAcceptTicketMutation(detail.ticket_number);
   const canComment = detail.status !== "closed" && detail.status !== "cancelled";
   const canAccept =
     detail.requires_acceptance &&
-    !detail.accepted_at &&
+    !acceptedAt &&
     (canManage || detail.acceptors.some((a) => a.user_id === currentUserId));
 
   const handleAddComment = useCallback(
@@ -94,7 +98,7 @@ function TicketDetailPanel({
   );
 
   return (
-    <div className="flex flex-col gap-4 p-4">
+    <div className="flex flex-col gap-3">
       {/* Header */}
       <div>
         <p className="text-muted-foreground font-mono text-xs">{detail.ticket_number}</p>
@@ -118,7 +122,7 @@ function TicketDetailPanel({
       </div>
 
       {/* Two-column body */}
-      <div className="flex min-w-0 flex-col gap-4 lg:flex-row lg:items-start">
+      <div className="flex min-w-0 flex-col gap-4 lg:flex-row">
         {/* Main: description + comments */}
         <div className="min-w-0 flex-1 space-y-4">
           {(detail.description_rich || detail.description_plain) && (
@@ -177,7 +181,7 @@ function TicketDetailPanel({
         </div>
 
         {/* Sidebar: view button + details */}
-        <div className="w-full shrink-0 space-y-3 lg:w-52">
+        <div className="w-full shrink-0 space-y-3 self-start lg:w-52">
           <Button
             variant="outline"
             size="sm"
@@ -196,18 +200,16 @@ function TicketDetailPanel({
               <p className="text-muted-foreground text-[10px] uppercase font-medium">
                 {t("tickets.acceptance.label")}
               </p>
-              {detail.accepted_at ? (
+              {acceptedAt ? (
                 <div className="space-y-1">
                   <span className="inline-block rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900/30 dark:text-green-300">
                     {t("tickets.acceptance.accepted")}
                   </span>
-                  {detail.accepted_by_name && (
-                    <p className="text-xs text-muted-foreground truncate">
-                      {detail.accepted_by_name}
-                    </p>
+                  {acceptedByName && (
+                    <p className="truncate text-xs text-muted-foreground">{acceptedByName}</p>
                   )}
                   <p className="text-xs text-muted-foreground">
-                    {new Date(detail.accepted_at).toLocaleString()}
+                    {new Date(acceptedAt).toLocaleString()}
                   </p>
                 </div>
               ) : (
@@ -239,7 +241,25 @@ function TicketDetailPanel({
                   size="sm"
                   className="w-full"
                   disabled={acceptMutation.isPending}
-                  onClick={() => acceptMutation.mutate({ ticket_id: detail.id })}
+                  onClick={() =>
+                    acceptMutation.mutate(
+                      { ticket_id: detail.id },
+                      {
+                        onSuccess: async () => {
+                          const fresh = await getTicketDetailAction(
+                            detail.ticket_number,
+                            detail.org_id
+                          );
+                          if (fresh.success && fresh.data) {
+                            setAcceptedAt(fresh.data.accepted_at);
+                            setAcceptedByName(fresh.data.accepted_by_name);
+                            setComments(fresh.data.comments);
+                            setActivity(fresh.data.activity);
+                          }
+                        },
+                      }
+                    )
+                  }
                 >
                   {acceptMutation.isPending ? (
                     <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
@@ -367,6 +387,7 @@ export function TicketsClient({
   initialData,
   ticketTypes,
   members,
+  branches,
   canCreate,
   canManage,
   currentUserId,
@@ -405,6 +426,11 @@ export function TicketsClient({
         value: m.user_id,
       })),
     [members]
+  );
+
+  const branchOptions = useMemo(
+    () => branches.map((b) => ({ label: b.name, value: b.id })),
+    [branches]
   );
 
   const columns = useMemo<DataViewColumnDef<HelpdeskTicketListRow>[]>(
@@ -574,7 +600,7 @@ export function TicketsClient({
         options: memberOptions,
       },
       {
-        type: "select",
+        type: "multi-select",
         key: "status",
         label: t("tickets.filters.status"),
         options: [
@@ -608,8 +634,18 @@ export function TicketsClient({
             },
           ]
         : []),
+      ...(branchOptions.length > 0
+        ? [
+            {
+              type: "select" as const,
+              key: "branchId",
+              label: t("tickets.filters.branch"),
+              options: branchOptions,
+            },
+          ]
+        : []),
     ],
-    [t, memberOptions, typeOptions]
+    [t, memberOptions, typeOptions, branchOptions]
   );
 
   return (
@@ -639,11 +675,11 @@ export function TicketsClient({
           getRowId={(row) => row.ticket_number}
           renderCompactItem={(row) => (
             <div className="flex flex-col gap-1">
-              <div className="flex items-center gap-2">
+              <div className="flex items-center justify-between gap-2">
                 <span className="text-muted-foreground font-mono text-xs">{row.ticket_number}</span>
                 <TicketStatusBadge status={row.status} />
               </div>
-              <span className="max-w-[28ch] truncate text-sm font-medium" title={row.title}>
+              <span className="truncate text-sm font-medium" title={row.title}>
                 {row.title}
               </span>
             </div>

--- a/apps/web/src/app/[locale]/dashboard/help-desk/tickets/new/_components/new-ticket-form.tsx
+++ b/apps/web/src/app/[locale]/dashboard/help-desk/tickets/new/_components/new-ticket-form.tsx
@@ -102,7 +102,7 @@ export function NewTicketForm({ ticketTypes, members }: NewTicketFormProps) {
           toast.success(t("tickets.created", { number: data.ticket_number }));
           router.push({
             pathname: "/dashboard/help-desk/tickets/[ticketId]",
-            params: { ticketId: data.id },
+            params: { ticketId: data.ticket_number },
           });
         },
       }

--- a/apps/web/src/app/[locale]/dashboard/help-desk/tickets/page.tsx
+++ b/apps/web/src/app/[locale]/dashboard/help-desk/tickets/page.tsx
@@ -63,6 +63,7 @@ export default async function HelpDeskTicketsPage({ searchParams }: PageProps = 
       initialData={initialData}
       ticketTypes={ticketTypes}
       members={members}
+      branches={context.app.availableBranches.map((b) => ({ id: b.id, name: b.name }))}
       canCreate={checkPermission(context.user.permissionSnapshot, HELPDESK_TICKETS_CREATE)}
       canManage={checkPermission(context.user.permissionSnapshot, HELPDESK_TICKETS_MANAGE)}
       currentUserId={context.user.user?.id ?? ""}

--- a/apps/web/src/lib/validations/helpdesk.ts
+++ b/apps/web/src/lib/validations/helpdesk.ts
@@ -82,13 +82,14 @@ export const closeTicketSchema = z.object({
 });
 
 export const ticketListFiltersSchema = z.object({
-  status: z.enum(TICKET_STATUSES).optional(),
+  status: z.union([z.enum(TICKET_STATUSES), z.array(z.enum(TICKET_STATUSES))]).optional(),
   priority: z.enum(TICKET_PRIORITIES).optional(),
   ticketTypeId: z.string().uuid().optional(),
   createdBy: z.string().uuid().optional(),
   assignedTo: z.string().uuid().optional(),
   createdAtFrom: z.string().optional(),
   createdAtTo: z.string().optional(),
+  branchId: z.string().uuid().optional(),
 });
 
 export type CreateTicketInput = z.infer<typeof createTicketSchema>;

--- a/apps/web/src/server/services/helpdesk-tickets.service.ts
+++ b/apps/web/src/server/services/helpdesk-tickets.service.ts
@@ -243,9 +243,16 @@ export class HelpdeskTicketsService {
       .is("deleted_at", null);
 
     // Filters
-    if (filters.status) query = query.eq("status", filters.status as string);
+    if (filters.status) {
+      if (Array.isArray(filters.status)) {
+        query = query.in("status", filters.status as string[]);
+      } else {
+        query = query.eq("status", filters.status as string);
+      }
+    }
     if (filters.priority) query = query.eq("priority", filters.priority as string);
     if (filters.ticketTypeId) query = query.eq("ticket_type_id", filters.ticketTypeId as string);
+    if (filters.branchId) query = query.eq("branch_id", filters.branchId as string);
     if (filters.createdBy) query = query.eq("created_by", filters.createdBy as string);
     if (filters.createdAtFrom) query = query.gte("created_at", filters.createdAtFrom as string);
     if (filters.createdAtTo) query = query.lte("created_at", filters.createdAtTo as string);


### PR DESCRIPTION
…eptance fixes

Filters:
- Status filter changed from single-select to multi-select; service handles both string (legacy) and string[] (multi-select) via .in() vs .eq()
- New Branch filter (select) passed from page via availableBranches; service filters by branch_id when set
- i18n: tickets.filters.branch added to en.json + pl.json

Bugs fixed:
- New ticket redirect used data.id (UUID) instead of data.ticket_number, causing 404 since routes now use ticket numbers (e.g. HD-000018)
- canAccept: restored canManage || acceptors check in both panel and detail page so managers can accept any ticket; DB RPC already enforces the same rule

Layout:
- TicketDetailPanel outer div: removed duplicate p-4 (DataView provides it), gap-4 → gap-3, removed lg:items-start in favour of self-start on sidebar column so the right sidebar is flush with the top of the card
- Compact item: justify-between moves status badge to the far right

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Branch filter to Help Desk tickets list for better ticket organization
  * Status filter now supports selecting multiple statuses simultaneously

* **Improvements**
  * Enhanced ticket acceptance workflow with improved state management
  * Refined ticket detail panel layout and spacing for better usability
  * Updated ticket navigation to use more consistent identifiers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->