### PR TITLE
feat(help-desk): add Branch column to tickets DataView

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3020,6 +3020,7 @@
           "status": "Status",
           "priority": "Priority",
           "acceptance": "Acceptance",
+          "branch": "Branch",
           "createdBy": "Author",
           "responders": "Assigned",
           "createdAt": "Created",

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -2991,6 +2991,7 @@
           "status": "Status",
           "priority": "Priorytet",
           "acceptance": "Akceptacja",
+          "branch": "Oddział",
           "createdBy": "Autor",
           "responders": "Przypisani",
           "createdAt": "Utworzone",

--- a/apps/web/src/app/[locale]/dashboard/help-desk/tickets/_components/tickets-client.tsx
+++ b/apps/web/src/app/[locale]/dashboard/help-desk/tickets/_components/tickets-client.tsx
@@ -433,6 +433,8 @@ export function TicketsClient({
     [branches]
   );
 
+  const branchNameMap = useMemo(() => new Map(branches.map((b) => [b.id, b.name])), [branches]);
+
   const columns = useMemo<DataViewColumnDef<HelpdeskTicketListRow>[]>(
     () => [
       {
@@ -484,6 +486,18 @@ export function TicketsClient({
           ),
         sortable: false,
         defaultVisible: true,
+      },
+      {
+        key: "branch",
+        header: t("tickets.columns.branch"),
+        accessor: (row) =>
+          row.branch_id ? (
+            <span className="text-sm">{branchNameMap.get(row.branch_id) ?? "—"}</span>
+          ) : (
+            <span className="text-muted-foreground text-xs">—</span>
+          ),
+        sortable: false,
+        defaultVisible: branchOptions.length > 0,
       },
       {
         key: "status",
@@ -575,7 +589,7 @@ export function TicketsClient({
         defaultVisible: false,
       },
     ],
-    [t, router]
+    [t, router, branchNameMap, branchOptions.length]
   );
 
   const filters = useMemo<DataViewFilterDef[]>(


### PR DESCRIPTION
Uses a Map built from the branches prop (already loaded from context) for O(1) lookups — no extra query. Column is hidden by default when the org has no branches and visible when branches exist.