### PR TITLE
fix(help-desk): auto-acceptors from type, priority labels use org con…

### DIFF
--- a/apps/web/src/app/[locale]/dashboard/help-desk/ticket-types/_components/ticket-type-form-dialog.tsx
+++ b/apps/web/src/app/[locale]/dashboard/help-desk/ticket-types/_components/ticket-type-form-dialog.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/components/ui/select";
 import { MemberSelector } from "@/components/help-desk/member-selector";
 import type { MemberOption } from "@/components/help-desk/member-selector";
+import type { PriorityBadgeConfig } from "@/components/help-desk/ticket-priority-badge";
 import {
   createTicketTypeWithRespondersAction,
   updateTicketTypeWithRespondersAction,
@@ -37,6 +38,7 @@ interface TicketTypeFormDialogProps {
   editingType: HelpdeskTicketTypeWithDetails | null;
   members: MemberOption[];
   availableBranches: Array<{ id: string; name: string }>;
+  priorityConfigs: Record<string, PriorityBadgeConfig> | null;
   onSaved: (type: HelpdeskTicketTypeWithDetails) => void;
 }
 
@@ -46,6 +48,7 @@ export function TicketTypeFormDialog({
   editingType,
   members,
   availableBranches,
+  priorityConfigs,
   onSaved,
 }: TicketTypeFormDialogProps) {
   const t = useTranslations("modules.helpDesk");
@@ -248,7 +251,7 @@ export function TicketTypeFormDialog({
               <SelectContent>
                 {TICKET_PRIORITIES.map((p) => (
                   <SelectItem key={p} value={p}>
-                    {t(`tickets.priority.${p}`)}
+                    {priorityConfigs?.[p]?.label ?? t(`tickets.priority.${p}`)}
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/apps/web/src/app/[locale]/dashboard/help-desk/ticket-types/_components/ticket-types-client.tsx
+++ b/apps/web/src/app/[locale]/dashboard/help-desk/ticket-types/_components/ticket-types-client.tsx
@@ -17,6 +17,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { deleteTicketTypeAction } from "@/app/actions/help-desk";
+import type { PriorityBadgeConfig } from "@/components/help-desk/ticket-priority-badge";
 import type { HelpdeskTicketTypeWithDetails } from "@/server/services/helpdesk-ticket-types.service";
 import type { MemberOption } from "@/components/help-desk/member-selector";
 import { TicketTypeFormDialog } from "./ticket-type-form-dialog";
@@ -25,12 +26,14 @@ interface TicketTypesClientProps {
   initialTypes: HelpdeskTicketTypeWithDetails[];
   members: MemberOption[];
   availableBranches: Array<{ id: string; name: string }>;
+  priorityConfigs: Record<string, PriorityBadgeConfig> | null;
 }
 
 export function TicketTypesClient({
   initialTypes,
   members,
   availableBranches,
+  priorityConfigs,
 }: TicketTypesClientProps) {
   const t = useTranslations("modules.helpDesk");
   const [types, setTypes] = useState(initialTypes);
@@ -195,6 +198,7 @@ export function TicketTypesClient({
         editingType={editingType}
         members={members}
         availableBranches={availableBranches}
+        priorityConfigs={priorityConfigs}
         onSaved={handleSaved}
       />
 

--- a/apps/web/src/app/[locale]/dashboard/help-desk/ticket-types/page.tsx
+++ b/apps/web/src/app/[locale]/dashboard/help-desk/ticket-types/page.tsx
@@ -27,9 +27,10 @@ export default async function HelpDeskTicketTypesPage() {
   const supabase = await createClient();
   const orgId = context.app.activeOrgId;
 
-  const [typesResult, membersResult] = await Promise.all([
+  const [typesResult, membersResult, settingsResult] = await Promise.all([
     HelpdeskTicketTypesService.listWithDetails(supabase, orgId),
     OrgMembersService.listMembers(supabase, orgId),
+    HelpdeskTicketTypesService.getSettings(supabase, orgId),
   ]);
 
   const types = typesResult.success ? typesResult.data : [];
@@ -42,11 +43,14 @@ export default async function HelpDeskTicketTypesPage() {
       }))
     : [];
 
+  const settings = settingsResult.success ? settingsResult.data : null;
+
   return (
     <TicketTypesClient
       initialTypes={types}
       members={members}
       availableBranches={context.app.availableBranches.map((b) => ({ id: b.id, name: b.name }))}
+      priorityConfigs={settings?.priority_configs ?? null}
     />
   );
 }

--- a/apps/web/src/app/[locale]/dashboard/help-desk/tickets/new/_components/new-ticket-form.tsx
+++ b/apps/web/src/app/[locale]/dashboard/help-desk/tickets/new/_components/new-ticket-form.tsx
@@ -28,15 +28,26 @@ import {
 import {
   useCreateTicketMutation,
   useTicketTypeDefaultRespondersQuery,
+  useTicketTypeDefaultAcceptorsQuery,
 } from "@/hooks/queries/help-desk";
+import type { StatusBadgeConfig } from "@/components/help-desk/ticket-status-badge";
+import type { PriorityBadgeConfig } from "@/components/help-desk/ticket-priority-badge";
 
 interface NewTicketFormProps {
   ticketTypes: HelpdeskTicketType[];
   members: MemberOption[];
   activeBranchId: string | null;
+  statusConfigs: Record<string, StatusBadgeConfig> | null;
+  priorityConfigs: Record<string, PriorityBadgeConfig> | null;
 }
 
-export function NewTicketForm({ ticketTypes, members, activeBranchId }: NewTicketFormProps) {
+export function NewTicketForm({
+  ticketTypes,
+  members,
+  activeBranchId,
+  statusConfigs,
+  priorityConfigs,
+}: NewTicketFormProps) {
   const visibleTicketTypes = ticketTypes.filter(
     (tt) =>
       (tt as any).scope !== "branch" ||
@@ -56,13 +67,21 @@ export function NewTicketForm({ ticketTypes, members, activeBranchId }: NewTicke
 
   // Cached query — re-selecting the same type reuses the cached result, no extra network call
   const { data: defaultResponders } = useTicketTypeDefaultRespondersQuery(ticketTypeId || null);
+  const { data: defaultAcceptors } = useTicketTypeDefaultAcceptorsQuery(ticketTypeId || null);
   const appliedTypeIdRef = useRef<string>("");
   const createTicketMutation = useCreateTicketMutation();
 
-  // Apply default responders + priority when ticket type changes
+  // Apply default responders, acceptors, and priority when ticket type changes
   useEffect(() => {
     if (!ticketTypeId || ticketTypeId === appliedTypeIdRef.current) return;
     if (defaultResponders === undefined) return; // still loading
+
+    const selectedType = ticketTypes.find((tt) => tt.id === ticketTypeId);
+    const typeRequiresAcceptance = (selectedType as any)?.requires_acceptance === true;
+
+    // Wait for acceptors query too when the type requires acceptance
+    if (typeRequiresAcceptance && defaultAcceptors === undefined) return;
+
     appliedTypeIdRef.current = ticketTypeId;
 
     if (defaultResponders.length > 0) {
@@ -70,15 +89,18 @@ export function NewTicketForm({ ticketTypes, members, activeBranchId }: NewTicke
       setAssigneeIds((prev) => [...new Set([...prev, ...defaultIds])]);
     }
 
-    const selectedType = ticketTypes.find((tt) => tt.id === ticketTypeId);
     if (selectedType?.default_priority) {
       setPriority(selectedType.default_priority);
     }
-    // Auto-enable acceptance if the type requires it
-    if ((selectedType as any)?.requires_acceptance) {
+
+    if (typeRequiresAcceptance) {
       setRequiresAcceptance(true);
+      if (defaultAcceptors && defaultAcceptors.length > 0) {
+        const ids = defaultAcceptors.map((a) => a.user_id);
+        setAcceptorIds((prev) => [...new Set([...prev, ...ids])]);
+      }
     }
-  }, [ticketTypeId, defaultResponders, ticketTypes]);
+  }, [ticketTypeId, defaultResponders, defaultAcceptors, ticketTypes]);
 
   const validate = (): boolean => {
     const errs: Record<string, string> = {};
@@ -197,7 +219,7 @@ export function NewTicketForm({ ticketTypes, members, activeBranchId }: NewTicke
             <SelectContent>
               {TICKET_PRIORITIES.map((p) => (
                 <SelectItem key={p} value={p}>
-                  {t(`tickets.priority.${p}`)}
+                  {priorityConfigs?.[p]?.label ?? t(`tickets.priority.${p}`)}
                 </SelectItem>
               ))}
             </SelectContent>

--- a/apps/web/src/app/[locale]/dashboard/help-desk/tickets/new/page.tsx
+++ b/apps/web/src/app/[locale]/dashboard/help-desk/tickets/new/page.tsx
@@ -27,9 +27,10 @@ export default async function NewTicketPage() {
   const supabase = await createClient();
   const orgId = context.app.activeOrgId;
 
-  const [ticketTypesResult, membersResult] = await Promise.all([
+  const [ticketTypesResult, membersResult, settingsResult] = await Promise.all([
     HelpdeskTicketTypesService.list(supabase, orgId, false),
     OrgMembersService.listMembers(supabase, orgId),
+    HelpdeskTicketTypesService.getSettings(supabase, orgId),
   ]);
 
   const ticketTypes = ticketTypesResult.success ? ticketTypesResult.data : [];
@@ -43,11 +44,15 @@ export default async function NewTicketPage() {
       }))
     : [];
 
+  const settings = settingsResult.success ? settingsResult.data : null;
+
   return (
     <NewTicketForm
       ticketTypes={ticketTypes}
       members={members}
       activeBranchId={context.app.activeBranchId ?? null}
+      statusConfigs={settings?.status_configs ?? null}
+      priorityConfigs={settings?.priority_configs ?? null}
     />
   );
 }

--- a/apps/web/src/hooks/queries/help-desk/index.ts
+++ b/apps/web/src/hooks/queries/help-desk/index.ts
@@ -6,6 +6,7 @@ import { toast } from "react-toastify";
 import {
   listTicketTypesAction,
   getTicketTypeDefaultRespondersAction,
+  getTicketTypeDefaultAcceptorsAction,
   listOrgMembersForTicketAssignmentAction,
   createTicketAction,
   getTicketDetailAction,
@@ -67,6 +68,23 @@ export function useTicketTypeDefaultRespondersQuery(ticketTypeId: string | null 
     queryFn: async () => {
       if (!ticketTypeId) return [];
       const result = await getTicketTypeDefaultRespondersAction(ticketTypeId);
+      if (!result.success) throw new Error((result as { success: false; error: string }).error);
+      return result.data;
+    },
+    enabled: !!ticketTypeId,
+    staleTime: 2 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+}
+
+export function useTicketTypeDefaultAcceptorsQuery(ticketTypeId: string | null | undefined) {
+  return useQuery({
+    queryKey: ticketTypeId
+      ? [...helpdeskKeys.ticketTypeDefaultResponders(ticketTypeId), "acceptors"]
+      : helpdeskKeys.ticketTypes(),
+    queryFn: async () => {
+      if (!ticketTypeId) return [];
+      const result = await getTicketTypeDefaultAcceptorsAction(ticketTypeId);
       if (!result.success) throw new Error((result as { success: false; error: string }).error);
       return result.data;
     },


### PR DESCRIPTION
…figs

Auto-acceptors:
- Add useTicketTypeDefaultAcceptorsQuery hook (mirrors default responders pattern)
- new-ticket-form: load default acceptors when type has requires_acceptance=true; wait for both responders and acceptors queries before applying, then pre-populate acceptorIds + enable the acceptance toggle automatically

Priority/status labels in forms:
- new-ticket-form priority select: use priorityConfigs?.[p].label ?? i18n fallback so org-configured labels (e.g. "Ważny!") appear instead of i18n defaults
- ticket-type-form-dialog priority select: same pattern
- Both pages (new ticket + ticket types) now load settings in parallel and pass priorityConfigs down to the forms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Priority and status badge labels in ticket creation and ticket type management forms can now be customized through helpdesk settings.
  * New ticket forms now automatically apply pre-configured default acceptors when creating tickets of specific types that require acceptance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->