### PR TITLE
feat(help-desk): ticket types DataView, detail panel, and dedicated t…

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3156,7 +3156,14 @@
         "deleteConfirmDescription": "This will archive the type. Existing tickets are not affected.",
         "createSuccess": "Ticket type created.",
         "updateSuccess": "Ticket type updated.",
-        "deleteSuccess": "Ticket type deleted."
+        "deleteSuccess": "Ticket type deleted.",
+        "backToList": "Back to ticket types",
+        "viewType": "View Type",
+        "name": "Name",
+        "inactive": "Inactive",
+        "allowsManualAssignees": "Manual Assignees",
+        "noDefaultAssignees": "No default assignees configured.",
+        "noDefaultAcceptors": "No default acceptors configured."
       }
     },
     "analytics": {

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -3127,7 +3127,14 @@
         "deleteConfirmDescription": "Typ zostanie zarchiwizowany. Istniejące zgłoszenia nie zostaną zmienione.",
         "createSuccess": "Typ zgłoszenia został utworzony.",
         "updateSuccess": "Typ zgłoszenia został zaktualizowany.",
-        "deleteSuccess": "Typ zgłoszenia został usunięty."
+        "deleteSuccess": "Typ zgłoszenia został usunięty.",
+        "backToList": "Wróć do typów zgłoszeń",
+        "viewType": "Zobacz typ",
+        "name": "Nazwa",
+        "inactive": "Nieaktywny",
+        "allowsManualAssignees": "Ręczny wybór osób",
+        "noDefaultAssignees": "Brak domyślnych osób odpowiedzialnych.",
+        "noDefaultAcceptors": "Brak domyślnych osób akceptujących."
       }
     },
     "analytics": {

--- a/apps/web/src/app/[locale]/dashboard/help-desk/ticket-types/[typeId]/_components/ticket-type-detail-client.tsx
+++ b/apps/web/src/app/[locale]/dashboard/help-desk/ticket-types/[typeId]/_components/ticket-type-detail-client.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "@/i18n/navigation";
+import { useTranslations } from "next-intl";
+import { toast } from "react-toastify";
+import { ArrowLeft, Pencil, Trash2, GitBranch, Building2, Users, ShieldCheck } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { deleteTicketTypeAction } from "@/app/actions/help-desk";
+import type { HelpdeskTicketTypeWithDetails } from "@/server/services/helpdesk-ticket-types.service";
+import type { MemberOption } from "@/components/help-desk/member-selector";
+import type { PriorityBadgeConfig } from "@/components/help-desk/ticket-priority-badge";
+import { TicketTypeFormDialog } from "../../_components/ticket-type-form-dialog";
+
+interface TicketTypeDetailClientProps {
+  type: HelpdeskTicketTypeWithDetails;
+  members: MemberOption[];
+  availableBranches: Array<{ id: string; name: string }>;
+  priorityConfigs: Record<string, PriorityBadgeConfig> | null;
+}
+
+export function TicketTypeDetailClient({
+  type: initialType,
+  members,
+  availableBranches,
+  priorityConfigs,
+}: TicketTypeDetailClientProps) {
+  const t = useTranslations("modules.helpDesk");
+  const router = useRouter();
+  const [type, setType] = useState(initialType);
+  const [formOpen, setFormOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const branchMap = new Map(availableBranches.map((b) => [b.id, b.name]));
+
+  const handleDelete = async () => {
+    setIsDeleting(true);
+    try {
+      const result = await deleteTicketTypeAction(type.id);
+      if (!result.success) {
+        toast.error((result as { success: false; error: string }).error);
+        return;
+      }
+      toast.success(t("ticketTypes.deleteSuccess"));
+      router.push("/dashboard/help-desk/ticket-types");
+    } finally {
+      setIsDeleting(false);
+      setDeleteOpen(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-6 p-6 max-w-2xl">
+      {/* Back + actions */}
+      <div className="flex items-center justify-between">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => router.push("/dashboard/help-desk/ticket-types")}
+        >
+          <ArrowLeft className="mr-1 h-4 w-4" />
+          {t("ticketTypes.backToList")}
+        </Button>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm" onClick={() => setFormOpen(true)}>
+            <Pencil className="mr-1.5 h-4 w-4" />
+            {t("ticketTypes.editType")}
+          </Button>
+          {!type.is_system && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="text-destructive hover:text-destructive"
+              onClick={() => setDeleteOpen(true)}
+            >
+              <Trash2 className="mr-1.5 h-4 w-4" />
+              Delete
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* Header */}
+      <div className="flex items-start gap-4">
+        <span
+          className="mt-1.5 h-5 w-5 shrink-0 rounded-full"
+          style={{ backgroundColor: type.color }}
+        />
+        <div className="space-y-1">
+          <h1 className="text-2xl font-semibold tracking-tight">{type.name}</h1>
+          {type.description && <p className="text-muted-foreground text-sm">{type.description}</p>}
+          <div className="flex flex-wrap gap-2 pt-1">
+            {!type.is_active && <Badge variant="secondary">{t("ticketTypes.inactive")}</Badge>}
+            {type.scope === "branch" ? (
+              <Badge variant="outline" className="gap-1">
+                <GitBranch className="h-3.5 w-3.5" />
+                {branchMap.get(type.branch_id ?? "") ?? t("ticketTypes.scopeBranch")}
+              </Badge>
+            ) : (
+              <Badge variant="outline" className="gap-1">
+                <Building2 className="h-3.5 w-3.5" />
+                {t("ticketTypes.scopeOrg")}
+              </Badge>
+            )}
+            {type.requires_acceptance && (
+              <Badge variant="outline" className="gap-1 text-green-700">
+                <ShieldCheck className="h-3.5 w-3.5" />
+                {t("tickets.fields.requiresAcceptance")}
+              </Badge>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <Separator />
+
+      {/* Properties */}
+      <div className="grid grid-cols-2 gap-6">
+        <div className="space-y-1">
+          <p className="text-muted-foreground text-xs uppercase tracking-wide">
+            {t("tickets.fields.priority")}
+          </p>
+          <p className="font-medium">
+            {priorityConfigs?.[type.default_priority]?.label ?? type.default_priority}
+          </p>
+        </div>
+        <div className="space-y-1">
+          <p className="text-muted-foreground text-xs uppercase tracking-wide">
+            {t("ticketTypes.allowsManualAssignees")}
+          </p>
+          <p className="font-medium">{type.allows_manual_assignees ? "Yes" : "No"}</p>
+        </div>
+        <div className="space-y-1">
+          <p className="text-muted-foreground text-xs uppercase tracking-wide">
+            {t("ticketTypes.requiresAcceptance")}
+          </p>
+          <p className="font-medium">{type.requires_acceptance ? "Yes" : "No"}</p>
+        </div>
+      </div>
+
+      {/* Default responders */}
+      <div className="space-y-3">
+        <div className="flex items-center gap-2">
+          <Users className="text-muted-foreground h-4 w-4" />
+          <h3 className="font-semibold">{t("ticketTypes.defaultAssignees")}</h3>
+          <span className="text-muted-foreground text-sm">({type.default_responders.length})</span>
+        </div>
+        {type.default_responders.length === 0 ? (
+          <p className="text-muted-foreground text-sm">{t("ticketTypes.noDefaultAssignees")}</p>
+        ) : (
+          <div className="rounded-lg border divide-y">
+            {type.default_responders.map((r) => (
+              <div
+                key={r.responder_user_id}
+                className="flex items-center justify-between px-4 py-2.5"
+              >
+                <span className="font-medium text-sm">
+                  {r.responder_name ?? r.responder_email ?? r.responder_user_id}
+                </span>
+                {r.responder_email && r.responder_name && (
+                  <span className="text-muted-foreground text-xs">{r.responder_email}</span>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Default acceptors */}
+      {type.requires_acceptance && (
+        <div className="space-y-3">
+          <div className="flex items-center gap-2">
+            <ShieldCheck className="text-muted-foreground h-4 w-4" />
+            <h3 className="font-semibold">{t("ticketTypes.defaultAcceptors")}</h3>
+            <span className="text-muted-foreground text-sm">({type.default_acceptors.length})</span>
+          </div>
+          {type.default_acceptors.length === 0 ? (
+            <p className="text-muted-foreground text-sm">{t("ticketTypes.noDefaultAcceptors")}</p>
+          ) : (
+            <div className="rounded-lg border divide-y">
+              {type.default_acceptors.map((a) => (
+                <div key={a.user_id} className="flex items-center justify-between px-4 py-2.5">
+                  <span className="font-medium text-sm">
+                    {a.user_name ?? a.user_email ?? a.user_id}
+                  </span>
+                  {a.user_email && a.user_name && (
+                    <span className="text-muted-foreground text-xs">{a.user_email}</span>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Edit dialog */}
+      <TicketTypeFormDialog
+        open={formOpen}
+        onOpenChange={setFormOpen}
+        editingType={type}
+        members={members}
+        availableBranches={availableBranches}
+        priorityConfigs={priorityConfigs}
+        onSaved={(saved) => {
+          setType(saved);
+          setFormOpen(false);
+        }}
+      />
+
+      {/* Delete confirm */}
+      <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("ticketTypes.deleteConfirm")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("ticketTypes.deleteConfirmDescription")}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeleting}>{t("tickets.cancel")}</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              disabled={isDeleting}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {isDeleting ? "Deleting…" : "Delete"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/dashboard/help-desk/ticket-types/[typeId]/page.tsx
+++ b/apps/web/src/app/[locale]/dashboard/help-desk/ticket-types/[typeId]/page.tsx
@@ -1,4 +1,4 @@
-import { redirect } from "@/i18n/navigation";
+import { notFound, redirect } from "next/navigation";
 import { getLocale } from "next-intl/server";
 import { loadDashboardContextV2 } from "@/server/loaders/v2/load-dashboard-context.v2";
 import { checkPermission } from "@/lib/utils/permissions";
@@ -6,42 +6,39 @@ import { HELPDESK_TICKET_TYPES_MANAGE } from "@/lib/constants/permissions";
 import { createClient } from "@/utils/supabase/server";
 import { HelpdeskTicketTypesService } from "@/server/services/helpdesk-ticket-types.service";
 import { OrgMembersService } from "@/server/services/organization.service";
-import { TicketTypesClient } from "./_components/ticket-types-client";
-import { parseDataViewSearchParams } from "@/components/data-view/data-view-search-params";
+import { TicketTypeDetailClient } from "./_components/ticket-type-detail-client";
 
 type PageProps = {
-  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+  params: Promise<{ typeId: string }>;
 };
 
-export default async function HelpDeskTicketTypesPage({ searchParams }: PageProps = {}) {
+export default async function TicketTypeDetailPage({ params }: PageProps) {
   const locale = await getLocale();
   const context = await loadDashboardContextV2();
 
-  if (!context?.app.activeOrgId) return redirect({ href: "/sign-in", locale });
-
-  if (!checkPermission(context.user.permissionSnapshot, HELPDESK_TICKET_TYPES_MANAGE)) {
-    return redirect({
-      href: {
-        pathname: "/dashboard/access-denied",
-        query: { reason: "helpdesk_ticket_types_manage_required" },
-      },
-      locale,
-    });
+  if (!context?.app.activeOrgId) {
+    redirect("/sign-in");
+    return null;
   }
 
-  const params = parseDataViewSearchParams(searchParams ? await searchParams : {});
+  if (!checkPermission(context.user.permissionSnapshot, HELPDESK_TICKET_TYPES_MANAGE)) {
+    redirect("/dashboard/access-denied");
+    return null;
+  }
+
+  const { typeId } = await params;
   const supabase = await createClient();
   const orgId = context.app.activeOrgId;
 
-  const [typesResult, membersResult, settingsResult] = await Promise.all([
-    HelpdeskTicketTypesService.listForDataView(supabase, orgId, params.page, params.pageSize),
+  const [typeResult, membersResult, settingsResult] = await Promise.all([
+    HelpdeskTicketTypesService.getDetailById(supabase, orgId, typeId),
     OrgMembersService.listMembers(supabase, orgId),
     HelpdeskTicketTypesService.getSettings(supabase, orgId),
   ]);
 
-  const initialData = typesResult.success
-    ? typesResult.data
-    : { rows: [], totalCount: 0, page: params.page, pageSize: params.pageSize };
+  if (!typeResult.success || !typeResult.data) {
+    notFound();
+  }
 
   const members = membersResult.success
     ? membersResult.data.map((m) => ({
@@ -55,12 +52,11 @@ export default async function HelpDeskTicketTypesPage({ searchParams }: PageProp
   const settings = settingsResult.success ? settingsResult.data : null;
 
   return (
-    <TicketTypesClient
-      initialData={initialData}
+    <TicketTypeDetailClient
+      type={typeResult.data}
       members={members}
       availableBranches={context.app.availableBranches.map((b) => ({ id: b.id, name: b.name }))}
       priorityConfigs={settings?.priority_configs ?? null}
-      orgId={orgId}
     />
   );
 }

--- a/apps/web/src/app/[locale]/dashboard/help-desk/ticket-types/_components/ticket-type-detail-panel.tsx
+++ b/apps/web/src/app/[locale]/dashboard/help-desk/ticket-types/_components/ticket-type-detail-panel.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import {
+  Pencil,
+  Trash2,
+  ExternalLink,
+  GitBranch,
+  Building2,
+  Users,
+  ShieldCheck,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import type { HelpdeskTicketTypeWithDetails } from "@/server/services/helpdesk-ticket-types.service";
+import type { PriorityBadgeConfig } from "@/components/help-desk/ticket-priority-badge";
+
+interface TicketTypeDetailPanelProps {
+  type: HelpdeskTicketTypeWithDetails;
+  priorityConfigs: Record<string, PriorityBadgeConfig> | null;
+  onEdit: (type: HelpdeskTicketTypeWithDetails) => void;
+  onDeleteRequest: (id: string) => void;
+}
+
+export function TicketTypeDetailPanel({
+  type,
+  priorityConfigs,
+  onEdit,
+  onDeleteRequest,
+}: TicketTypeDetailPanelProps) {
+  const t = useTranslations("modules.helpDesk");
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex min-w-0 items-start gap-3">
+          <span
+            className="mt-1 h-4 w-4 shrink-0 rounded-full"
+            style={{ backgroundColor: type.color }}
+          />
+          <div className="min-w-0">
+            <h3 className="text-base font-semibold leading-snug">{type.name}</h3>
+            {type.description && (
+              <p className="text-muted-foreground mt-0.5 text-sm">{type.description}</p>
+            )}
+          </div>
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => window.location.assign(`/dashboard/help-desk/ticket-types/${type.id}`)}
+          >
+            <ExternalLink className="mr-1.5 h-3.5 w-3.5" />
+            {t("ticketTypes.viewType")}
+          </Button>
+          <Button variant="ghost" size="icon" className="h-8 w-8" onClick={() => onEdit(type)}>
+            <Pencil className="h-4 w-4" />
+          </Button>
+          {!type.is_system && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 text-destructive hover:text-destructive"
+              onClick={() => onDeleteRequest(type.id)}
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {!type.is_active && (
+          <Badge variant="secondary" className="text-xs">
+            {t("ticketTypes.inactive")}
+          </Badge>
+        )}
+        {type.scope === "branch" ? (
+          <Badge variant="outline" className="gap-1 text-xs">
+            <GitBranch className="h-3 w-3" />
+            {t("ticketTypes.scopeBranch")}
+          </Badge>
+        ) : (
+          <Badge variant="outline" className="gap-1 text-xs">
+            <Building2 className="h-3 w-3" />
+            {t("ticketTypes.scopeOrg")}
+          </Badge>
+        )}
+        {type.requires_acceptance && (
+          <Badge variant="outline" className="gap-1 text-xs text-green-700">
+            <ShieldCheck className="h-3 w-3" />
+            {t("tickets.fields.requiresAcceptance")}
+          </Badge>
+        )}
+      </div>
+
+      <Separator />
+
+      {/* Details grid */}
+      <div className="grid grid-cols-2 gap-3 text-sm">
+        <div>
+          <p className="text-muted-foreground text-xs uppercase tracking-wide">
+            {t("tickets.fields.priority")}
+          </p>
+          <p className="mt-0.5 font-medium">
+            {priorityConfigs?.[type.default_priority]?.label ?? type.default_priority}
+          </p>
+        </div>
+        <div>
+          <p className="text-muted-foreground text-xs uppercase tracking-wide">
+            {t("ticketTypes.allowsManualAssignees")}
+          </p>
+          <p className="mt-0.5 font-medium">{type.allows_manual_assignees ? "Yes" : "No"}</p>
+        </div>
+      </div>
+
+      {/* Default responders */}
+      {type.default_responders.length > 0 && (
+        <>
+          <Separator />
+          <div className="space-y-2">
+            <div className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              <Users className="h-3.5 w-3.5" />
+              {t("ticketTypes.defaultAssignees")} ({type.default_responders.length})
+            </div>
+            <div className="space-y-1">
+              {type.default_responders.map((r) => (
+                <div key={r.responder_user_id} className="flex items-center gap-2 text-sm">
+                  <span className="truncate">
+                    {r.responder_name ?? r.responder_email ?? r.responder_user_id}
+                  </span>
+                  {r.responder_email && r.responder_name && (
+                    <span className="text-muted-foreground text-xs truncate">
+                      {r.responder_email}
+                    </span>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        </>
+      )}
+
+      {/* Default acceptors */}
+      {type.requires_acceptance && type.default_acceptors.length > 0 && (
+        <>
+          <Separator />
+          <div className="space-y-2">
+            <div className="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              <ShieldCheck className="h-3.5 w-3.5" />
+              {t("ticketTypes.defaultAcceptors")} ({type.default_acceptors.length})
+            </div>
+            <div className="space-y-1">
+              {type.default_acceptors.map((a) => (
+                <div key={a.user_id} className="flex items-center gap-2 text-sm">
+                  <span className="truncate">{a.user_name ?? a.user_email ?? a.user_id}</span>
+                  {a.user_email && a.user_name && (
+                    <span className="text-muted-foreground text-xs truncate">{a.user_email}</span>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/dashboard/help-desk/ticket-types/_components/ticket-type-form-dialog.tsx
+++ b/apps/web/src/app/[locale]/dashboard/help-desk/ticket-types/_components/ticket-type-form-dialog.tsx
@@ -39,7 +39,7 @@ interface TicketTypeFormDialogProps {
   members: MemberOption[];
   availableBranches: Array<{ id: string; name: string }>;
   priorityConfigs: Record<string, PriorityBadgeConfig> | null;
-  onSaved: (type: HelpdeskTicketTypeWithDetails) => void;
+  onSaved: (type?: HelpdeskTicketTypeWithDetails) => void;
 }
 
 export function TicketTypeFormDialog({

--- a/apps/web/src/app/[locale]/dashboard/help-desk/ticket-types/_components/ticket-types-client.tsx
+++ b/apps/web/src/app/[locale]/dashboard/help-desk/ticket-types/_components/ticket-types-client.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useMemo, useCallback } from "react";
 import { useTranslations } from "next-intl";
+import { useRouter } from "@/i18n/navigation";
 import { toast } from "react-toastify";
-import { Plus, Pencil, Trash2, GitBranch, Building2 } from "lucide-react";
+import { Plus, GitBranch, Building2, CheckCircle, Users, ShieldCheck } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -16,56 +17,69 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { deleteTicketTypeAction } from "@/app/actions/help-desk";
-import type { PriorityBadgeConfig } from "@/components/help-desk/ticket-priority-badge";
+import { DataView } from "@/components/data-view/data-view";
+import type {
+  DataViewColumnDef,
+  DataViewListParams,
+  PaginatedResult,
+} from "@/components/data-view/data-view.types";
+import {
+  deleteTicketTypeAction,
+  listTicketTypesForDataViewAction,
+  getTicketTypeDetailAction,
+} from "@/app/actions/help-desk";
 import type { HelpdeskTicketTypeWithDetails } from "@/server/services/helpdesk-ticket-types.service";
 import type { MemberOption } from "@/components/help-desk/member-selector";
+import type { PriorityBadgeConfig } from "@/components/help-desk/ticket-priority-badge";
 import { TicketTypeFormDialog } from "./ticket-type-form-dialog";
+import { TicketTypeDetailPanel } from "./ticket-type-detail-panel";
+
+const TICKET_TYPES_QUERY_KEY = ["helpdesk-ticket-types-dataview"];
 
 interface TicketTypesClientProps {
-  initialTypes: HelpdeskTicketTypeWithDetails[];
+  initialData: PaginatedResult<HelpdeskTicketTypeWithDetails>;
   members: MemberOption[];
   availableBranches: Array<{ id: string; name: string }>;
   priorityConfigs: Record<string, PriorityBadgeConfig> | null;
+  orgId: string;
 }
 
 export function TicketTypesClient({
-  initialTypes,
+  initialData,
   members,
   availableBranches,
   priorityConfigs,
+  orgId,
 }: TicketTypesClientProps) {
   const t = useTranslations("modules.helpDesk");
-  const [types, setTypes] = useState(initialTypes);
+  const router = useRouter();
   const [formOpen, setFormOpen] = useState(false);
   const [editingType, setEditingType] = useState<HelpdeskTicketTypeWithDetails | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
 
-  const branchMap = new Map(availableBranches.map((b) => [b.id, b.name]));
+  const branchMap = useMemo(
+    () => new Map(availableBranches.map((b) => [b.id, b.name])),
+    [availableBranches]
+  );
 
-  const handleOpenCreate = () => {
-    setEditingType(null);
-    setFormOpen(true);
-  };
+  const listFetcher = useCallback(
+    async (params: DataViewListParams): Promise<PaginatedResult<HelpdeskTicketTypeWithDetails>> => {
+      const result = await listTicketTypesForDataViewAction(orgId, params.page, params.pageSize);
+      if (result.success) return result.data;
+      throw new Error((result as { success: false; error: string }).error);
+    },
+    [orgId]
+  );
 
-  const handleOpenEdit = (type: HelpdeskTicketTypeWithDetails) => {
-    setEditingType(type);
-    setFormOpen(true);
-  };
-
-  const handleSaved = (saved: HelpdeskTicketTypeWithDetails) => {
-    setTypes((prev) => {
-      const idx = prev.findIndex((t) => t.id === saved.id);
-      if (idx >= 0) {
-        const next = [...prev];
-        next[idx] = saved;
-        return next;
-      }
-      return [...prev, saved];
-    });
-    setFormOpen(false);
-  };
+  const detailFetcher = useCallback(
+    async (id: string): Promise<HelpdeskTicketTypeWithDetails | null> => {
+      const result = await getTicketTypeDetailAction(id, orgId);
+      if (!result.success) return null;
+      return result.data;
+    },
+    [orgId]
+  );
 
   const handleDelete = async () => {
     if (!deletingId) return;
@@ -76,122 +90,186 @@ export function TicketTypesClient({
         toast.error((result as { success: false; error: string }).error);
         return;
       }
-      setTypes((prev) => prev.filter((t) => t.id !== deletingId));
       toast.success(t("ticketTypes.deleteSuccess"));
+      setDeletingId(null);
     } finally {
       setIsDeleting(false);
-      setDeletingId(null);
     }
   };
 
+  const columns = useMemo<DataViewColumnDef<HelpdeskTicketTypeWithDetails>[]>(
+    () => [
+      {
+        key: "name",
+        header: t("ticketTypes.name"),
+        accessor: (row) => (
+          <div className="flex items-center gap-2">
+            <span
+              className="h-3 w-3 shrink-0 rounded-full"
+              style={{ backgroundColor: row.color }}
+            />
+            <button
+              onClick={() =>
+                router.push({
+                  pathname: "/dashboard/help-desk/ticket-types/[typeId]",
+                  params: { typeId: row.id },
+                })
+              }
+              className="hover:text-primary truncate font-medium transition-colors"
+            >
+              {row.name}
+            </button>
+            {!row.is_active && (
+              <Badge variant="secondary" className="text-xs">
+                {t("ticketTypes.inactive")}
+              </Badge>
+            )}
+          </div>
+        ),
+        sortable: false,
+        defaultVisible: true,
+      },
+      {
+        key: "scope",
+        header: t("ticketTypes.scope"),
+        accessor: (row) =>
+          row.scope === "branch" ? (
+            <Badge variant="outline" className="gap-1 text-xs">
+              <GitBranch className="h-3 w-3" />
+              {branchMap.get(row.branch_id ?? "") ?? t("ticketTypes.scopeBranch")}
+            </Badge>
+          ) : (
+            <Badge variant="outline" className="gap-1 text-xs">
+              <Building2 className="h-3 w-3" />
+              {t("ticketTypes.scopeOrg")}
+            </Badge>
+          ),
+        sortable: false,
+        defaultVisible: true,
+      },
+      {
+        key: "default_priority",
+        header: t("tickets.fields.priority"),
+        accessor: (row) => (
+          <span className="text-sm">
+            {priorityConfigs?.[row.default_priority]?.label ?? row.default_priority}
+          </span>
+        ),
+        sortable: false,
+        defaultVisible: true,
+      },
+      {
+        key: "responders",
+        header: t("ticketTypes.defaultAssignees"),
+        accessor: (row) => (
+          <div className="flex items-center gap-1 text-sm text-muted-foreground">
+            <Users className="h-3.5 w-3.5" />
+            {row.default_responders.length}
+          </div>
+        ),
+        sortable: false,
+        defaultVisible: true,
+      },
+      {
+        key: "acceptance",
+        header: t("tickets.fields.requiresAcceptance"),
+        accessor: (row) =>
+          row.requires_acceptance ? (
+            <div className="flex items-center gap-1 text-sm">
+              <ShieldCheck className="h-3.5 w-3.5 text-green-600" />
+              <span className="text-green-700">{row.default_acceptors.length}</span>
+            </div>
+          ) : (
+            <span className="text-muted-foreground text-xs">—</span>
+          ),
+        sortable: false,
+        defaultVisible: true,
+      },
+    ],
+    [t, router, branchMap, priorityConfigs]
+  );
+
   return (
-    <div className="flex flex-col gap-6 p-6">
+    <div className="flex h-[calc(100vh-4rem)] flex-col gap-4 p-4 md:p-6">
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">{t("pages.ticketTypes.title")}</h1>
           <p className="text-muted-foreground mt-1 text-sm">{t("pages.ticketTypes.subtitle")}</p>
         </div>
-        <Button onClick={handleOpenCreate} size="sm">
+        <Button
+          size="sm"
+          onClick={() => {
+            setEditingType(null);
+            setFormOpen(true);
+          }}
+        >
           <Plus className="mr-2 h-4 w-4" />
           {t("ticketTypes.createType")}
         </Button>
       </div>
 
-      {types.length === 0 ? (
-        <div className="border-border bg-card rounded-lg border p-8 text-center">
-          <p className="text-muted-foreground text-sm">{t("empty.noTicketTypes")}</p>
-          <p className="text-muted-foreground mt-1 text-xs">
-            {t("empty.noTicketTypesDescription")}
-          </p>
-          <Button onClick={handleOpenCreate} size="sm" className="mt-4">
-            <Plus className="mr-2 h-4 w-4" />
-            {t("ticketTypes.createType")}
-          </Button>
-        </div>
-      ) : (
-        <div className="space-y-2">
-          {types.map((type) => (
-            <div
-              key={type.id}
-              className="border-border bg-card flex items-start gap-4 rounded-lg border p-4"
-            >
-              {/* Color swatch */}
-              <div
-                className="mt-0.5 h-4 w-4 shrink-0 rounded-full"
-                style={{ backgroundColor: type.color }}
-              />
-
-              {/* Info */}
-              <div className="min-w-0 flex-1 space-y-1">
-                <div className="flex flex-wrap items-center gap-2">
-                  <span className="font-medium">{type.name}</span>
-                  {!type.is_active && (
-                    <Badge variant="secondary" className="text-xs">
-                      Inactive
-                    </Badge>
-                  )}
-                  {type.scope === "branch" ? (
-                    <Badge variant="outline" className="gap-1 text-xs">
-                      <GitBranch className="h-3 w-3" />
-                      {branchMap.get(type.branch_id ?? "") ?? "Branch"}
-                    </Badge>
-                  ) : (
-                    <Badge variant="outline" className="gap-1 text-xs">
-                      <Building2 className="h-3 w-3" />
-                      {t("ticketTypes.scopeOrg")}
-                    </Badge>
-                  )}
-                  {type.requires_acceptance && (
-                    <Badge variant="outline" className="text-xs">
-                      {t("tickets.fields.requiresAcceptance")}
-                    </Badge>
-                  )}
-                </div>
-                {type.description && (
-                  <p className="text-muted-foreground text-sm">{type.description}</p>
-                )}
-                <div className="flex flex-wrap gap-3 text-xs text-muted-foreground">
-                  <span>
-                    {t("ticketTypes.defaultAssignees")}: {type.default_responders.length}
-                  </span>
-                  {type.requires_acceptance && (
-                    <span>
-                      {t("ticketTypes.defaultAcceptors")}: {type.default_acceptors.length}
-                    </span>
-                  )}
-                  <span>
-                    {t("tickets.fields.priority")}: {type.default_priority}
-                  </span>
-                </div>
+      <div className="min-h-0 flex-1">
+        <DataView<HelpdeskTicketTypeWithDetails, HelpdeskTicketTypeWithDetails>
+          entity="helpdesk-ticket-types"
+          columns={columns}
+          filters={[]}
+          initialData={initialData}
+          queryKey={TICKET_TYPES_QUERY_KEY}
+          listFetcher={listFetcher}
+          detailFetcher={detailFetcher}
+          getRowId={(row) => row.id}
+          renderCompactItem={(row) => (
+            <div className="flex flex-col gap-1">
+              <div className="flex items-center gap-2">
+                <span
+                  className="h-2.5 w-2.5 shrink-0 rounded-full"
+                  style={{ backgroundColor: row.color }}
+                />
+                <span className="truncate text-sm font-medium">{row.name}</span>
               </div>
-
-              {/* Actions */}
-              <div className="flex shrink-0 items-center gap-1">
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-8 w-8"
-                  onClick={() => handleOpenEdit(type)}
-                >
-                  <Pencil className="h-4 w-4" />
-                </Button>
-                {!type.is_system && (
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-8 w-8 text-destructive hover:text-destructive"
-                    onClick={() => setDeletingId(type.id)}
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </Button>
+              <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                {row.scope === "branch" ? (
+                  <span className="flex items-center gap-1">
+                    <GitBranch className="h-3 w-3" />
+                    {branchMap.get(row.branch_id ?? "") ?? t("ticketTypes.scopeBranch")}
+                  </span>
+                ) : (
+                  <span className="flex items-center gap-1">
+                    <Building2 className="h-3 w-3" />
+                    {t("ticketTypes.scopeOrg")}
+                  </span>
                 )}
               </div>
             </div>
-          ))}
-        </div>
-      )}
+          )}
+          renderDetail={(detail) => (
+            <TicketTypeDetailPanel
+              key={detail.id}
+              type={detail}
+              priorityConfigs={priorityConfigs}
+              onEdit={(type) => {
+                setEditingType(type);
+                setFormOpen(true);
+              }}
+              onDeleteRequest={(id) => setDeletingId(id)}
+            />
+          )}
+          renderToolbarControls={() => (
+            <Button
+              size="sm"
+              onClick={() => {
+                setEditingType(null);
+                setFormOpen(true);
+              }}
+            >
+              <Plus className="mr-2 h-4 w-4" />
+              {t("ticketTypes.createType")}
+            </Button>
+          )}
+          className="min-h-0 flex-1"
+        />
+      </div>
 
-      {/* Create / Edit dialog */}
       <TicketTypeFormDialog
         open={formOpen}
         onOpenChange={setFormOpen}
@@ -199,10 +277,9 @@ export function TicketTypesClient({
         members={members}
         availableBranches={availableBranches}
         priorityConfigs={priorityConfigs}
-        onSaved={handleSaved}
+        onSaved={() => setFormOpen(false)}
       />
 
-      {/* Delete confirm */}
       <AlertDialog open={!!deletingId} onOpenChange={(o) => !o && setDeletingId(null)}>
         <AlertDialogContent>
           <AlertDialogHeader>

--- a/apps/web/src/app/actions/help-desk/index.ts
+++ b/apps/web/src/app/actions/help-desk/index.ts
@@ -501,3 +501,38 @@ export async function getTicketTypeDefaultAcceptorsAction(
     return { success: false, error: "Unexpected error" };
   }
 }
+
+export async function listTicketTypesForDataViewAction(
+  orgId: string,
+  page = 1,
+  pageSize = 50
+): Promise<
+  ActionResult<import("@/lib/data-view/types").PaginatedResult<HelpdeskTicketTypeWithDetails>>
+> {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return { success: false, error: "Unauthorized" };
+    return HelpdeskTicketTypesService.listForDataView(supabase, orgId, page, pageSize);
+  } catch {
+    return { success: false, error: "Unexpected error" };
+  }
+}
+
+export async function getTicketTypeDetailAction(
+  typeId: string,
+  orgId: string
+): Promise<ActionResult<HelpdeskTicketTypeWithDetails>> {
+  try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return { success: false, error: "Unauthorized" };
+    return HelpdeskTicketTypesService.getDetailById(supabase, orgId, typeId);
+  } catch {
+    return { success: false, error: "Unexpected error" };
+  }
+}

--- a/apps/web/src/i18n/routing.ts
+++ b/apps/web/src/i18n/routing.ts
@@ -291,6 +291,10 @@ export const routing = defineRouting({
       en: "/dashboard/help-desk/settings",
       pl: "/dashboard/help-desk/ustawienia",
     },
+    "/dashboard/help-desk/ticket-types/[typeId]": {
+      en: "/dashboard/help-desk/ticket-types/[typeId]",
+      pl: "/dashboard/help-desk/typy-zgloszen/[typeId]",
+    },
     "/dashboard/help-desk/ticket-types": {
       en: "/dashboard/help-desk/ticket-types",
       pl: "/dashboard/help-desk/typy-zgloszen",

--- a/apps/web/src/server/services/helpdesk-ticket-types.service.ts
+++ b/apps/web/src/server/services/helpdesk-ticket-types.service.ts
@@ -6,6 +6,7 @@ import type {
   TicketPriority,
   UpdateTicketTypeInput,
 } from "@/lib/validations/helpdesk";
+import type { PaginatedResult } from "@/lib/data-view/types";
 
 export interface HelpdeskTicketType {
   id: string;
@@ -200,6 +201,48 @@ export class HelpdeskTicketTypesService {
 
     if (error) return { success: false, error: error.message };
     return { success: true, data: data as HelpdeskTicketType };
+  }
+
+  static async getDetailById(
+    supabase: SupabaseClient,
+    orgId: string,
+    id: string
+  ): Promise<ServiceResult<HelpdeskTicketTypeWithDetails>> {
+    const typeResult = await HelpdeskTicketTypesService.getById(supabase, orgId, id);
+    if (!typeResult.success)
+      return { success: false, error: (typeResult as { success: false; error: string }).error };
+
+    const [respondersResult, acceptorsResult] = await Promise.all([
+      HelpdeskTicketTypesService.getDefaultResponders(supabase, orgId, id),
+      HelpdeskTicketTypesService.getDefaultAcceptors(supabase, orgId, id),
+    ]);
+
+    return {
+      success: true,
+      data: {
+        ...typeResult.data,
+        default_responders: respondersResult.success ? respondersResult.data : [],
+        default_acceptors: acceptorsResult.success ? acceptorsResult.data : [],
+      },
+    };
+  }
+
+  static async listForDataView(
+    supabase: SupabaseClient,
+    orgId: string,
+    page = 1,
+    pageSize = 50
+  ): Promise<ServiceResult<PaginatedResult<HelpdeskTicketTypeWithDetails>>> {
+    const result = await HelpdeskTicketTypesService.listWithDetails(supabase, orgId);
+    if (!result.success)
+      return { success: false, error: (result as { success: false; error: string }).error };
+
+    const all = result.data;
+    const totalCount = all.length;
+    const offset = (page - 1) * pageSize;
+    const rows = all.slice(offset, offset + pageSize);
+
+    return { success: true, data: { rows, totalCount, page, pageSize } };
   }
 
   // ── Default responders ────────────────────────────────────────────────────


### PR DESCRIPTION
…ype page

DataView:
- listForDataView + getDetailById on HelpdeskTicketTypesService
- listTicketTypesForDataViewAction + getTicketTypeDetailAction (lightweight auth)
- TicketTypesClient rebuilt as full DataView with columns: name/color swatch, scope badge, priority, responder count, acceptance indicator
- TicketTypeDetailPanel in DataView detail card: properties, responders list, acceptors list, edit/delete/view-full buttons
- Compact sidebar item: color swatch + name + scope

Individual type page (/ticket-types/[typeId]):
- TicketTypeDetailClient: back button, property grid, responders and acceptors tables, inline edit dialog, delete confirm
- Routing added for [typeId] in en + pl (typy-zgloszen/[typeId])

i18n: name/inactive/viewType/backToList/allowsManualAssignees/
      noDefaultAssignees/noDefaultAcceptors added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated detail page for Help Desk ticket types with options to view, edit, and delete individual types.
  * Implemented pagination support for browsing the ticket types list.
  * Display of default responders and acceptors for each ticket type.
  * Extended translations for English and Polish in the ticket type management interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->