### PR TITLE
fix(help-desk): pass activeBranchId as branch_id when creating tickets

### DIFF
--- a/apps/web/src/app/[locale]/dashboard/help-desk/tickets/new/_components/new-ticket-form.tsx
+++ b/apps/web/src/app/[locale]/dashboard/help-desk/tickets/new/_components/new-ticket-form.tsx
@@ -125,6 +125,7 @@ export function NewTicketForm({
         status: "waiting_response",
         priority,
         ticket_type_id: ticketTypeId || undefined,
+        branch_id: activeBranchId || undefined,
         assignee_user_ids: assigneeIds,
         requires_acceptance: requiresAcceptance,
         acceptor_user_ids: acceptorIds,


### PR DESCRIPTION
The form received activeBranchId as a prop (used to filter branch-scoped ticket types) but never included it in the mutation payload. Tickets were always created with branch_id = null, making the branch filter and column useless. Now passes branch_id: activeBranchId to createTicketMutation.