### PR TITLE
feat(sidebar): better icons, taller flyout rows, fix descender clipping

### DIFF
--- a/apps/web/src/app/[locale]/dashboard/_components/dashboard-shell.tsx
+++ b/apps/web/src/app/[locale]/dashboard/_components/dashboard-shell.tsx
@@ -191,7 +191,7 @@ function NavL2Item({
 // ---------------------------------------------------------------------------
 
 const FLYOUT_W = 220;
-const FLYOUT_ROW_H = 30;
+const FLYOUT_ROW_H = 38;
 const FLYOUT_CLOSE_DELAY = 140;
 const ROOT_TRANSITION_MS = 145;
 
@@ -395,7 +395,7 @@ function FlyoutRow({
   const routeActive = item.disabledReason ? false : isItemActive(item, pathname);
 
   const className = cn(
-    "group relative z-20 flex items-center gap-1.5 px-2.5 text-[13px] leading-none select-none overflow-visible",
+    "group relative z-20 flex items-center gap-1.5 px-2.5 text-[13px] leading-normal select-none overflow-visible",
     "transition-[width,background-color,color,border-radius,box-shadow] duration-150 ease-out",
     stretched ? "" : "w-full",
     getFlyoutRowRadius({ role: stretched ? "title" : "item", index, total }),

--- a/apps/web/src/lib/sidebar/v2/icon-map.ts
+++ b/apps/web/src/lib/sidebar/v2/icon-map.ts
@@ -24,6 +24,16 @@ import {
   Car,
   LifeBuoy,
   Ticket,
+  Tags,
+  Building2,
+  CreditCard,
+  GitBranch,
+  TrendingUp,
+  ClipboardList,
+  Truck,
+  LayoutDashboard,
+  ArrowLeftRight,
+  ShieldCheck,
 } from "lucide-react";
 import type { IconKey } from "@/lib/types/v2/sidebar";
 
@@ -57,6 +67,16 @@ export const ICON_MAP: Record<IconKey, React.ComponentType<{ className?: string 
   car: Car,
   lifeBuoy: LifeBuoy,
   ticket: Ticket,
+  tags: Tags,
+  building: Building2,
+  creditCard: CreditCard,
+  branch: GitBranch,
+  trending: TrendingUp,
+  clipboard: ClipboardList,
+  truck: Truck,
+  dashboard: LayoutDashboard,
+  transfers: ArrowLeftRight,
+  shieldCheck: ShieldCheck,
 };
 
 /**

--- a/apps/web/src/lib/sidebar/v2/registry.ts
+++ b/apps/web/src/lib/sidebar/v2/registry.ts
@@ -77,7 +77,7 @@ export const MAIN_NAV_ITEMS: SidebarItem[] = [
         id: "warehouse.inventory",
         title: "Inventory",
         titleKey: "modules.warehouse.items.inventory.title",
-        iconKey: "warehouse",
+        iconKey: "clipboard",
         href: "/dashboard/warehouse/inventory",
         match: { startsWith: "/dashboard/warehouse/inventory" },
         visibility: {
@@ -88,7 +88,7 @@ export const MAIN_NAV_ITEMS: SidebarItem[] = [
             id: "warehouse.inventory.movements",
             title: "Stock Movements",
             titleKey: "modules.warehouse.items.inventory.movements",
-            iconKey: "warehouse",
+            iconKey: "transfers",
             href: "/dashboard/warehouse/inventory/movements",
             match: { startsWith: "/dashboard/warehouse/inventory/movements" },
             visibility: {
@@ -113,7 +113,7 @@ export const MAIN_NAV_ITEMS: SidebarItem[] = [
         id: "warehouse.purchases",
         title: "Purchases",
         titleKey: "modules.warehouse.items.purchases.title",
-        iconKey: "warehouse",
+        iconKey: "truck",
         href: "/dashboard/warehouse/purchases",
         match: { startsWith: "/dashboard/warehouse/purchases" },
         children: [
@@ -121,7 +121,7 @@ export const MAIN_NAV_ITEMS: SidebarItem[] = [
             id: "warehouse.deliveries",
             title: "Deliveries",
             titleKey: "modules.warehouse.items.deliveries.title",
-            iconKey: "warehouse",
+            iconKey: "truck",
             href: "/dashboard/warehouse/deliveries",
             match: { startsWith: "/dashboard/warehouse/deliveries" },
           },
@@ -129,7 +129,7 @@ export const MAIN_NAV_ITEMS: SidebarItem[] = [
             id: "warehouse.suppliers",
             title: "Suppliers",
             titleKey: "modules.warehouse.items.suppliers.title",
-            iconKey: "users",
+            iconKey: "building",
             href: "/dashboard/warehouse/suppliers",
             match: { startsWith: "/dashboard/warehouse/suppliers" },
           },
@@ -190,7 +190,7 @@ export const MAIN_NAV_ITEMS: SidebarItem[] = [
         id: "help-desk.overview",
         title: "Overview",
         titleKey: "modules.helpDesk.items.overview",
-        iconKey: "lifeBuoy",
+        iconKey: "dashboard",
         href: "/dashboard/help-desk",
         match: { exact: "/dashboard/help-desk" },
         visibility: {
@@ -212,7 +212,7 @@ export const MAIN_NAV_ITEMS: SidebarItem[] = [
         id: "help-desk.ticket-types",
         title: "Ticket Types",
         titleKey: "modules.helpDesk.items.ticketTypes",
-        iconKey: "ticket",
+        iconKey: "tags",
         href: "/dashboard/help-desk/ticket-types",
         match: { startsWith: "/dashboard/help-desk/ticket-types" },
         visibility: {
@@ -255,7 +255,7 @@ export const MAIN_NAV_ITEMS: SidebarItem[] = [
     group: "admin",
     title: "Organization",
     titleKey: "modules.organizationManagement.titleSidebar",
-    iconKey: "users",
+    iconKey: "building",
     visibility: {
       requiresModules: [MODULE_ORGANIZATION_MANAGEMENT],
       requiresPermissions: [MODULE_ORGANIZATION_MANAGEMENT_ACCESS],
@@ -265,7 +265,7 @@ export const MAIN_NAV_ITEMS: SidebarItem[] = [
         id: "organization.profile",
         title: "Profile",
         titleKey: "modules.organizationManagement.items.profile",
-        iconKey: "settings",
+        iconKey: "building",
         href: "/dashboard/organization/profile",
         match: { exact: "/dashboard/organization/profile" },
         visibility: {
@@ -287,7 +287,7 @@ export const MAIN_NAV_ITEMS: SidebarItem[] = [
         id: "organization.branches",
         title: "Branches",
         titleKey: "modules.organizationManagement.items.branches",
-        iconKey: "settings",
+        iconKey: "branch",
         href: "/dashboard/organization/branches",
         match: { exact: "/dashboard/organization/branches" },
         visibility: {
@@ -298,7 +298,7 @@ export const MAIN_NAV_ITEMS: SidebarItem[] = [
         id: "organization.billing",
         title: "Billing",
         titleKey: "modules.organizationManagement.items.billing",
-        iconKey: "settings",
+        iconKey: "creditCard",
         href: "/dashboard/organization/billing",
         match: { exact: "/dashboard/organization/billing" },
         visibility: {
@@ -327,7 +327,7 @@ export const MAIN_NAV_ITEMS: SidebarItem[] = [
         id: "analytics.overview",
         title: "Overview",
         titleKey: "modules.analytics.items.overview",
-        iconKey: "barChart",
+        iconKey: "trending",
         href: "/dashboard/analytics",
         match: { exact: "/dashboard/analytics" },
         visibility: {
@@ -349,7 +349,7 @@ export const MAIN_NAV_ITEMS: SidebarItem[] = [
         id: "analytics.audit",
         title: "Audit Log",
         titleKey: "modules.analytics.items.audit",
-        iconKey: "shield",
+        iconKey: "shieldCheck",
         href: "/dashboard/analytics/audit",
         match: { exact: "/dashboard/analytics/audit" },
         visibility: {

--- a/apps/web/src/lib/types/v2/sidebar.ts
+++ b/apps/web/src/lib/types/v2/sidebar.ts
@@ -49,7 +49,17 @@ export type IconKey =
   | "barChart"
   | "car"
   | "lifeBuoy"
-  | "ticket";
+  | "ticket"
+  | "tags"
+  | "building"
+  | "creditCard"
+  | "branch"
+  | "trending"
+  | "clipboard"
+  | "truck"
+  | "dashboard"
+  | "transfers"
+  | "shieldCheck";
 
 /**
  * Active route matching rules (strict discriminated union)


### PR DESCRIPTION
Icons — reduce repetition and improve semantic match:
- Warehouse Inventory: warehouse → clipboard (ClipboardList)
- Stock Movements: warehouse → transfers (ArrowLeftRight)
- Purchases/Deliveries: warehouse → truck
- Suppliers: users → building (Building2)
- Help Desk Overview: lifeBuoy → dashboard (LayoutDashboard)
- Ticket Types: ticket → tags (Tags)
- Organization module + Profile: users/settings → building
- Branches: settings → branch (GitBranch)
- Billing: settings → creditCard (CreditCard)
- Analytics Overview: barChart → trending (TrendingUp)
- Audit Log: shield → shieldCheck (ShieldCheck) Added 10 new IconKey entries + lucide imports to support them.

Collapsed sidebar flyouts:
- FLYOUT_ROW_H 30 → 38px: rows are easier to click/aim at
- leading-none → leading-normal: fixes g/y/j/q descenders being clipped