### PR TITLE
feat: DataViewLoading component + proper loading pages across all mod…

### DIFF
--- a/apps/web/src/app/[locale]/dashboard/analytics/loading.tsx
+++ b/apps/web/src/app/[locale]/dashboard/analytics/loading.tsx
@@ -1,10 +1,5 @@
+import { DataViewLoading } from "@/components/v2/feedback/data-view-loading";
+
 export default function AnalyticsLoading() {
-  return (
-    <div className="flex flex-col gap-6 p-6">
-      <div className="space-y-2">
-        <div className="bg-muted h-8 w-48 animate-pulse rounded" />
-        <div className="bg-muted h-4 w-80 animate-pulse rounded" />
-      </div>
-    </div>
-  );
+  return <DataViewLoading showActionButton={false} />;
 }

--- a/apps/web/src/app/[locale]/dashboard/help-desk/settings/loading.tsx
+++ b/apps/web/src/app/[locale]/dashboard/help-desk/settings/loading.tsx
@@ -1,0 +1,26 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function HelpDeskSettingsLoading() {
+  return (
+    <div className="flex flex-col gap-8 p-6 max-w-2xl">
+      <div className="flex items-center justify-between">
+        <div className="space-y-2">
+          <Skeleton className="h-8 w-56" />
+          <Skeleton className="h-4 w-80" />
+        </div>
+        <Skeleton className="h-8 w-28 rounded-md" />
+      </div>
+      <Skeleton className="h-px w-full" />
+      <div className="space-y-4">
+        <Skeleton className="h-5 w-24" />
+        {Array.from({ length: 7 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-4">
+            <Skeleton className="h-6 w-32 rounded-full" />
+            <Skeleton className="h-8 flex-1 rounded-md" />
+            <Skeleton className="h-8 w-32 rounded-md" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/dashboard/help-desk/ticket-types/loading.tsx
+++ b/apps/web/src/app/[locale]/dashboard/help-desk/ticket-types/loading.tsx
@@ -1,17 +1,5 @@
+import { DataViewLoading } from "@/components/v2/feedback/data-view-loading";
+
 export default function HelpDeskTicketTypesLoading() {
-  return (
-    <div className="flex flex-col gap-6 p-6">
-      <div className="flex flex-col gap-2">
-        <div className="bg-muted h-8 w-40 animate-pulse rounded" />
-        <div className="bg-muted h-4 w-72 animate-pulse rounded" />
-      </div>
-      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-        {Array.from({ length: 4 }).map((_, i) => (
-          <div key={i} className="border-border rounded-lg border p-4">
-            <div className="bg-muted h-4 w-24 animate-pulse rounded" />
-          </div>
-        ))}
-      </div>
-    </div>
-  );
+  return <DataViewLoading columns={5} />;
 }

--- a/apps/web/src/app/[locale]/dashboard/help-desk/tickets/loading.tsx
+++ b/apps/web/src/app/[locale]/dashboard/help-desk/tickets/loading.tsx
@@ -1,17 +1,5 @@
+import { DataViewLoading } from "@/components/v2/feedback/data-view-loading";
+
 export default function HelpDeskTicketsLoading() {
-  return (
-    <div className="flex flex-col gap-6 p-6">
-      <div className="flex flex-col gap-2">
-        <div className="bg-muted h-8 w-32 animate-pulse rounded" />
-        <div className="bg-muted h-4 w-64 animate-pulse rounded" />
-      </div>
-      <div className="flex flex-col gap-2">
-        {Array.from({ length: 5 }).map((_, i) => (
-          <div key={i} className="border-border rounded-lg border p-4">
-            <div className="bg-muted h-4 w-full animate-pulse rounded" />
-          </div>
-        ))}
-      </div>
-    </div>
-  );
+  return <DataViewLoading columns={7} />;
 }

--- a/apps/web/src/app/[locale]/dashboard/warehouse/alerts/loading.tsx
+++ b/apps/web/src/app/[locale]/dashboard/warehouse/alerts/loading.tsx
@@ -1,5 +1,5 @@
 import { DataViewLoading } from "@/components/v2/feedback/data-view-loading";
 
-export default function WarehouseLoading() {
+export default function Loading() {
   return <DataViewLoading />;
 }

--- a/apps/web/src/app/[locale]/dashboard/warehouse/audits/loading.tsx
+++ b/apps/web/src/app/[locale]/dashboard/warehouse/audits/loading.tsx
@@ -1,5 +1,5 @@
 import { DataViewLoading } from "@/components/v2/feedback/data-view-loading";
 
-export default function WarehouseLoading() {
+export default function Loading() {
   return <DataViewLoading />;
 }

--- a/apps/web/src/app/[locale]/dashboard/warehouse/clients/loading.tsx
+++ b/apps/web/src/app/[locale]/dashboard/warehouse/clients/loading.tsx
@@ -1,5 +1,5 @@
 import { DataViewLoading } from "@/components/v2/feedback/data-view-loading";
 
-export default function WarehouseLoading() {
+export default function Loading() {
   return <DataViewLoading />;
 }

--- a/apps/web/src/app/[locale]/dashboard/warehouse/deliveries/loading.tsx
+++ b/apps/web/src/app/[locale]/dashboard/warehouse/deliveries/loading.tsx
@@ -1,5 +1,5 @@
 import { DataViewLoading } from "@/components/v2/feedback/data-view-loading";
 
-export default function WarehouseLoading() {
+export default function Loading() {
   return <DataViewLoading />;
 }

--- a/apps/web/src/app/[locale]/dashboard/warehouse/inventory/loading.tsx
+++ b/apps/web/src/app/[locale]/dashboard/warehouse/inventory/loading.tsx
@@ -1,5 +1,5 @@
 import { DataViewLoading } from "@/components/v2/feedback/data-view-loading";
 
-export default function WarehouseLoading() {
+export default function Loading() {
   return <DataViewLoading />;
 }

--- a/apps/web/src/app/[locale]/dashboard/warehouse/inventory/movements/loading.tsx
+++ b/apps/web/src/app/[locale]/dashboard/warehouse/inventory/movements/loading.tsx
@@ -1,5 +1,5 @@
 import { DataViewLoading } from "@/components/v2/feedback/data-view-loading";
 
-export default function WarehouseLoading() {
+export default function Loading() {
   return <DataViewLoading />;
 }

--- a/apps/web/src/app/[locale]/dashboard/warehouse/items/loading.tsx
+++ b/apps/web/src/app/[locale]/dashboard/warehouse/items/loading.tsx
@@ -1,5 +1,5 @@
 import { DataViewLoading } from "@/components/v2/feedback/data-view-loading";
 
-export default function WarehouseLoading() {
+export default function Loading() {
   return <DataViewLoading />;
 }

--- a/apps/web/src/app/[locale]/dashboard/warehouse/purchase-orders/loading.tsx
+++ b/apps/web/src/app/[locale]/dashboard/warehouse/purchase-orders/loading.tsx
@@ -1,5 +1,5 @@
 import { DataViewLoading } from "@/components/v2/feedback/data-view-loading";
 
-export default function WarehouseLoading() {
+export default function Loading() {
   return <DataViewLoading />;
 }

--- a/apps/web/src/app/[locale]/dashboard/warehouse/purchases/loading.tsx
+++ b/apps/web/src/app/[locale]/dashboard/warehouse/purchases/loading.tsx
@@ -1,5 +1,5 @@
 import { DataViewLoading } from "@/components/v2/feedback/data-view-loading";
 
-export default function WarehouseLoading() {
+export default function Loading() {
   return <DataViewLoading />;
 }

--- a/apps/web/src/app/[locale]/dashboard/warehouse/sales-orders/loading.tsx
+++ b/apps/web/src/app/[locale]/dashboard/warehouse/sales-orders/loading.tsx
@@ -1,5 +1,5 @@
 import { DataViewLoading } from "@/components/v2/feedback/data-view-loading";
 
-export default function WarehouseLoading() {
+export default function Loading() {
   return <DataViewLoading />;
 }

--- a/apps/web/src/app/[locale]/dashboard/warehouse/sales/loading.tsx
+++ b/apps/web/src/app/[locale]/dashboard/warehouse/sales/loading.tsx
@@ -1,5 +1,5 @@
 import { DataViewLoading } from "@/components/v2/feedback/data-view-loading";
 
-export default function WarehouseLoading() {
+export default function Loading() {
   return <DataViewLoading />;
 }

--- a/apps/web/src/app/[locale]/dashboard/warehouse/suppliers/loading.tsx
+++ b/apps/web/src/app/[locale]/dashboard/warehouse/suppliers/loading.tsx
@@ -1,5 +1,5 @@
 import { DataViewLoading } from "@/components/v2/feedback/data-view-loading";
 
-export default function WarehouseLoading() {
+export default function Loading() {
   return <DataViewLoading />;
 }

--- a/apps/web/src/components/v2/feedback/data-view-loading.tsx
+++ b/apps/web/src/components/v2/feedback/data-view-loading.tsx
@@ -1,0 +1,80 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface DataViewLoadingProps {
+  /** Number of skeleton table rows */
+  rows?: number;
+  /** Number of skeleton columns */
+  columns?: number;
+  /** Show a "New …" button skeleton on the right of the header */
+  showActionButton?: boolean;
+}
+
+/**
+ * Loading skeleton that matches the standard DataView page layout:
+ * header (title + subtitle + optional action button) → filter bar → table.
+ */
+export function DataViewLoading({
+  rows = 8,
+  columns = 5,
+  showActionButton = true,
+}: DataViewLoadingProps) {
+  return (
+    <div className="flex h-[calc(100vh-4rem)] flex-col gap-4 p-4 md:p-6">
+      {/* Page header */}
+      <div className="flex items-center justify-between">
+        <div className="space-y-2">
+          <Skeleton className="h-8 w-40" />
+          <Skeleton className="h-4 w-64" />
+        </div>
+        {showActionButton && <Skeleton className="h-8 w-28 rounded-md" />}
+      </div>
+
+      {/* DataView container */}
+      <div className="min-h-0 flex-1 overflow-hidden rounded-lg border bg-background">
+        {/* Toolbar row: search + filter pills */}
+        <div className="flex items-center gap-2 border-b px-4 py-2.5">
+          <Skeleton className="h-7 w-48 rounded-md" />
+          <Skeleton className="h-7 w-20 rounded-md" />
+          <Skeleton className="h-7 w-20 rounded-md" />
+          <Skeleton className="h-7 w-20 rounded-md" />
+          <div className="ml-auto flex items-center gap-2">
+            <Skeleton className="h-7 w-7 rounded-md" />
+            <Skeleton className="h-7 w-7 rounded-md" />
+          </div>
+        </div>
+
+        {/* Table header */}
+        <div
+          className="grid border-b px-4"
+          style={{ gridTemplateColumns: `repeat(${columns}, 1fr)` }}
+        >
+          {Array.from({ length: columns }).map((_, i) => (
+            <div key={i} className="py-3 pr-4">
+              <Skeleton className="h-4 w-24" />
+            </div>
+          ))}
+        </div>
+
+        {/* Table rows */}
+        <div className="divide-y">
+          {Array.from({ length: rows }).map((_, rowIdx) => (
+            <div
+              key={rowIdx}
+              className="grid items-center px-4"
+              style={{ gridTemplateColumns: `repeat(${columns}, 1fr)` }}
+            >
+              {Array.from({ length: columns }).map((__, colIdx) => (
+                <div key={colIdx} className="py-4 pr-4">
+                  <Skeleton
+                    className="h-4"
+                    style={{ width: colIdx === 0 ? "60%" : colIdx % 3 === 0 ? "40%" : "70%" }}
+                  />
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
…ules

New DataViewLoading component matches the actual DataView page layout: header (title + subtitle + optional action button) → toolbar with search and filter pill skeletons → table header row → skeleton data rows with varying column widths so it looks like real content is loading.

Loading pages fixed/added:
- warehouse/ (was card grid → DataViewLoading)
- warehouse/inventory, inventory/movements, items, suppliers, deliveries, purchases, purchase-orders, sales, sales-orders, audits, clients, alerts (all were missing → DataViewLoading)
- help-desk/tickets (was raw pulse divs → DataViewLoading 7 cols)
- help-desk/ticket-types (wrong → DataViewLoading 5 cols)
- help-desk/settings (missing → settings-specific skeleton)
- analytics/ (was title-only → DataViewLoading without action button)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new standardized loading component that provides consistent visual feedback and smooth transitions while dashboard pages load

* **Refactor**
  * Unified loading state displays across multiple dashboard sections, replacing numerous custom skeleton layout implementations with a single shared loading interface to enhance visual consistency and deliver a more polished user experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->