### PR TITLE
fix: QR assignment lookup uses ticket UUID not ticket_number + return…

### DIFF
--- a/apps/web/src/app/[locale]/dashboard/help-desk/tickets/[ticketId]/_components/assign-qr-dialog.tsx
+++ b/apps/web/src/app/[locale]/dashboard/help-desk/tickets/[ticketId]/_components/assign-qr-dialog.tsx
@@ -54,11 +54,17 @@ export function AssignQrDialog({
     setLoading(true);
     listQrCodesAction().then((result) => {
       if (result.success) {
-        // Only show active unassigned codes
+        // Show only active codes that are either unassigned,
+        // or not already assigned to this specific ticket (UUID match).
         setCodes(
-          (result as { success: true; data: QrCodeWithStatus[] }).data.filter(
-            (c) => c.status === "active" && !c.assignment
-          )
+          (result as { success: true; data: QrCodeWithStatus[] }).data.filter((c) => {
+            if (c.status !== "active") return false;
+            if (!c.assignment) return true;
+            // Exclude if already linked to this ticket
+            return !(
+              c.assignment.target_type === "helpdesk.ticket" && c.assignment.target_id === ticketId
+            );
+          })
         );
       }
       setLoading(false);

--- a/apps/web/src/app/[locale]/dashboard/help-desk/tickets/[ticketId]/page.tsx
+++ b/apps/web/src/app/[locale]/dashboard/help-desk/tickets/[ticketId]/page.tsx
@@ -34,15 +34,19 @@ export default async function TicketDetailPage({ params }: PageProps) {
   const supabase = await createClient();
   const orgId = context.app.activeOrgId;
 
-  const [result, settingsResult, qrAssignmentResult] = await Promise.all([
+  // Fetch ticket + settings in parallel; QR assignment needs the ticket UUID
+  // which comes from getDetail, so it runs after.
+  const [result, settingsResult] = await Promise.all([
     HelpdeskTicketsService.getDetail(supabase, orgId, ticketId),
     HelpdeskTicketTypesService.getSettings(supabase, orgId),
-    getQrAssignmentForTicketAction(ticketId),
   ]);
 
   if (!result.success || !result.data) {
     notFound();
   }
+
+  // Now we have the UUID — look up the QR assignment with the correct target_id
+  const qrAssignmentResult = await getQrAssignmentForTicketAction(result.data.id);
 
   const canManage = checkPermission(context.user.permissionSnapshot, HELPDESK_TICKETS_MANAGE);
   const currentUserId = context.user.user?.id ?? "";

--- a/apps/web/src/app/[locale]/dashboard/layout.tsx
+++ b/apps/web/src/app/[locale]/dashboard/layout.tsx
@@ -1,6 +1,7 @@
 import { cache } from "react";
 import { headers } from "next/headers";
 import { redirect } from "@/i18n/navigation";
+import { redirect as nextRedirect } from "next/navigation";
 import { getLocale } from "next-intl/server";
 import { loadDashboardContextV2 } from "@/server/loaders/v2/load-dashboard-context.v2";
 import { loadAdminContextV2 } from "@/server/loaders/v2/load-admin-context.v2";
@@ -107,10 +108,10 @@ export default async function DashboardV2Layout({ children }: { children: React.
     const headersList = await headers();
     const rawPath = headersList.get("x-pathname") ?? "";
     const safeReturnUrl = rawPath.startsWith("/") && rawPath !== "/" ? rawPath : undefined;
-    return redirect({
-      href: safeReturnUrl ? `/sign-in?returnUrl=${encodeURIComponent(safeReturnUrl)}` : "/sign-in",
-      locale,
-    });
+    if (safeReturnUrl) {
+      return nextRedirect(`/${locale}/sign-in?returnUrl=${encodeURIComponent(safeReturnUrl)}`);
+    }
+    return redirect({ href: "/sign-in", locale });
   }
 
   // Authenticated but no org membership — show protection screen, not broken shell


### PR DESCRIPTION
…Url type fix

QR bugs:
- ticket [ticketId] page: getQrAssignmentForTicketAction was called with the route param (HD-000013) but target_id in qr_assignments stores the ticket UUID. Fix: fetch ticket first, then call the action with result.data.id
- assign-qr-dialog: add explicit filter to exclude codes already assigned to this ticket (target_type=helpdesk.ticket AND target_id=ticketId UUID) as a defensive guard against RLS join edge cases where assignment may appear null

returnUrl type fix:
- dashboard/layout.tsx: i18n redirect() is typed against registered pathnames; template literal /sign-in?returnUrl=... fails type check. Use next/navigation redirect directly for the parameterised URL, fall back to i18n redirect for the plain /sign-in case