### PR TITLE
feat(planning): add Planning module base

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3166,6 +3166,41 @@
         "noDefaultAcceptors": "No default acceptors configured."
       }
     },
+    "planning": {
+      "title": "Planning",
+      "titleSidebar": "Planning",
+      "description": "Organize and track tasks across your organization.",
+      "items": {
+        "overview": "Overview",
+        "tasks": "Tasks",
+        "boards": "Boards"
+      },
+      "pages": {
+        "overview": {
+          "title": "Planning",
+          "subtitle": "Organize and track tasks across your organization."
+        },
+        "tasks": {
+          "title": "Tasks",
+          "subtitle": "All tasks in your organization"
+        },
+        "boards": {
+          "title": "Boards",
+          "subtitle": "Visualize tasks on a Kanban board"
+        }
+      },
+      "features": {
+        "tasks": "Tasks",
+        "boards": "Kanban Boards"
+      },
+      "empty": {
+        "noData": "No tasks yet",
+        "noDataDescription": "Create a task to get started."
+      },
+      "errors": {
+        "loadFailed": "Failed to load planning data"
+      }
+    },
     "analytics": {
       "title": "Analytics & Reports",
       "titleSidebar": "Analytics",

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -3137,6 +3137,41 @@
         "noDefaultAcceptors": "Brak domyślnych osób akceptujących."
       }
     },
+    "planning": {
+      "title": "Planowanie",
+      "titleSidebar": "Planowanie",
+      "description": "Organizuj i śledź zadania w całej organizacji.",
+      "items": {
+        "overview": "Przegląd",
+        "tasks": "Zadania",
+        "boards": "Tablice"
+      },
+      "pages": {
+        "overview": {
+          "title": "Planowanie",
+          "subtitle": "Organizuj i śledź zadania w całej organizacji."
+        },
+        "tasks": {
+          "title": "Zadania",
+          "subtitle": "Wszystkie zadania w organizacji"
+        },
+        "boards": {
+          "title": "Tablice",
+          "subtitle": "Wizualizuj zadania na tablicy Kanban"
+        }
+      },
+      "features": {
+        "tasks": "Zadania",
+        "boards": "Tablice Kanban"
+      },
+      "empty": {
+        "noData": "Brak zadań",
+        "noDataDescription": "Utwórz zadanie, aby rozpocząć."
+      },
+      "errors": {
+        "loadFailed": "Nie udało się załadować danych planowania"
+      }
+    },
     "analytics": {
       "title": "Analityka i Raporty",
       "titleSidebar": "Analityka",

--- a/apps/web/src/app/[locale]/dashboard/planning/boards/page.tsx
+++ b/apps/web/src/app/[locale]/dashboard/planning/boards/page.tsx
@@ -1,0 +1,33 @@
+import { redirect } from "@/i18n/navigation";
+import { getLocale } from "next-intl/server";
+import { loadDashboardContextV2 } from "@/server/loaders/v2/load-dashboard-context.v2";
+import { checkPermission } from "@/lib/utils/permissions";
+import { PLANNING_TASKS_READ } from "@/lib/constants/permissions";
+import { LayoutGrid } from "lucide-react";
+
+export default async function PlanningBoardsPage() {
+  const locale = await getLocale();
+  const context = await loadDashboardContextV2();
+
+  if (!context?.app.activeOrgId) return redirect({ href: "/sign-in", locale });
+
+  if (!checkPermission(context.user.permissionSnapshot, PLANNING_TASKS_READ)) {
+    return redirect({
+      href: {
+        pathname: "/dashboard/access-denied",
+        query: { reason: "planning_tasks_read_required" },
+      },
+      locale,
+    });
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 p-12 text-center">
+      <LayoutGrid className="h-10 w-10 text-muted-foreground" />
+      <div>
+        <p className="font-medium">Kanban Board</p>
+        <p className="text-muted-foreground mt-1 text-sm">Coming soon.</p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/dashboard/planning/error.tsx
+++ b/apps/web/src/app/[locale]/dashboard/planning/error.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+
+export default function PlanningError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("[Planning] page error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 p-12 text-center">
+      <p className="text-muted-foreground text-sm">Failed to load Planning. Please try again.</p>
+      <Button variant="outline" size="sm" onClick={reset}>
+        Try again
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/dashboard/planning/layout.tsx
+++ b/apps/web/src/app/[locale]/dashboard/planning/layout.tsx
@@ -1,0 +1,29 @@
+import { redirect } from "@/i18n/navigation";
+import { getLocale } from "next-intl/server";
+import { entitlements } from "@/server/guards/entitlements-guards";
+import { loadDashboardContextV2 } from "@/server/loaders/v2/load-dashboard-context.v2";
+import { checkPermission } from "@/lib/utils/permissions";
+import { MODULE_PLANNING } from "@/lib/constants/modules";
+import { MODULE_PLANNING_ACCESS } from "@/lib/constants/permissions";
+
+export default async function PlanningLayout({ children }: { children: React.ReactNode }) {
+  const locale = await getLocale();
+
+  // Gate 1: org must be entitled to the Planning module (plan-level)
+  await entitlements.requireModuleOrRedirect(MODULE_PLANNING);
+
+  // Gate 2: user must have module access permission (user-level)
+  const context = await loadDashboardContextV2();
+  if (!context) return redirect({ href: "/sign-in", locale });
+  if (!checkPermission(context.user.permissionSnapshot, MODULE_PLANNING_ACCESS)) {
+    return redirect({
+      href: {
+        pathname: "/dashboard/access-denied",
+        query: { reason: "module_access", module: "planning" },
+      },
+      locale,
+    });
+  }
+
+  return <>{children}</>;
+}

--- a/apps/web/src/app/[locale]/dashboard/planning/loading.tsx
+++ b/apps/web/src/app/[locale]/dashboard/planning/loading.tsx
@@ -1,0 +1,17 @@
+export default function PlanningLoading() {
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      <div className="flex flex-col gap-2">
+        <div className="bg-muted h-8 w-48 animate-pulse rounded" />
+        <div className="bg-muted h-4 w-80 animate-pulse rounded" />
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="border-border rounded-lg border p-5">
+            <div className="bg-muted h-4 w-32 animate-pulse rounded" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/dashboard/planning/page.tsx
+++ b/apps/web/src/app/[locale]/dashboard/planning/page.tsx
@@ -1,0 +1,51 @@
+import { redirect } from "@/i18n/navigation";
+import { getLocale } from "next-intl/server";
+import { loadDashboardContextV2 } from "@/server/loaders/v2/load-dashboard-context.v2";
+import { checkPermission } from "@/lib/utils/permissions";
+import { PLANNING_READ } from "@/lib/constants/permissions";
+import { getTranslations } from "next-intl/server";
+
+const FEATURE_CARDS = ["tasks", "boards"] as const;
+
+export default async function PlanningOverviewPage() {
+  const locale = await getLocale();
+  const context = await loadDashboardContextV2();
+
+  if (!context?.app.activeOrgId) {
+    return redirect({ href: "/sign-in", locale });
+  }
+
+  if (!checkPermission(context.user.permissionSnapshot, PLANNING_READ)) {
+    return redirect({
+      href: {
+        pathname: "/dashboard/access-denied",
+        query: { reason: "planning_read_required" },
+      },
+      locale,
+    });
+  }
+
+  const t = await getTranslations("modules.planning");
+
+  return (
+    <div className="flex flex-col gap-6 p-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">{t("pages.overview.title")}</h1>
+        <p className="text-muted-foreground mt-1 text-sm">{t("pages.overview.subtitle")}</p>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {FEATURE_CARDS.map((key) => (
+          <div
+            key={key}
+            className="bg-card text-card-foreground border-border flex flex-col gap-2 rounded-lg border p-5"
+          >
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium">{t(`features.${key}`)}</span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/dashboard/planning/tasks/_components/tasks-client.tsx
+++ b/apps/web/src/app/[locale]/dashboard/planning/tasks/_components/tasks-client.tsx
@@ -1,0 +1,278 @@
+"use client";
+
+import { useCallback } from "react";
+import { Plus, CheckSquare, LayoutGrid } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { DataView } from "@/components/data-view/data-view";
+import type {
+  DataViewColumnDef,
+  DataViewFilterDef,
+  DataViewListParams,
+  PaginatedResult,
+} from "@/components/data-view/data-view.types";
+import { listTasksForDataViewAction, getTaskDetailAction } from "@/app/actions/planning";
+import type {
+  PlanningTaskListRow,
+  PlanningTaskDetail,
+} from "@/server/services/planning-tasks.service";
+import type { TaskStatus, TaskPriority } from "@/lib/validations/planning";
+
+const PLANNING_TASKS_QUERY_KEY = ["planning-tasks-dataview"];
+
+interface TasksClientProps {
+  initialData: PaginatedResult<PlanningTaskListRow>;
+  canCreate: boolean;
+  canAssign: boolean;
+  members: Array<{ user_id: string; name: string | null; email: string | null }>;
+  orgId: string;
+}
+
+const STATUS_LABELS: Record<TaskStatus, string> = {
+  open: "Open",
+  in_progress: "In Progress",
+  completed: "Completed",
+};
+
+const STATUS_COLORS: Record<TaskStatus, string> = {
+  open: "bg-blue-100 text-blue-700 border-blue-200",
+  in_progress: "bg-amber-100 text-amber-700 border-amber-200",
+  completed: "bg-emerald-100 text-emerald-700 border-emerald-200",
+};
+
+const PRIORITY_LABELS: Record<TaskPriority, string> = {
+  low: "Low",
+  normal: "Normal",
+  high: "High",
+  urgent: "Urgent",
+};
+
+const PRIORITY_COLORS: Record<TaskPriority, string> = {
+  low: "bg-slate-100 text-slate-600 border-slate-200",
+  normal: "bg-blue-100 text-blue-600 border-blue-200",
+  high: "bg-orange-100 text-orange-700 border-orange-200",
+  urgent: "bg-red-100 text-red-700 border-red-200",
+};
+
+function TaskDetailPanel({ detail }: { detail: PlanningTaskDetail }) {
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <div>
+        <p className="text-muted-foreground text-xs font-medium uppercase tracking-wide">Title</p>
+        <p className="mt-1 text-sm">{detail.title}</p>
+      </div>
+      {detail.description && (
+        <div>
+          <p className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+            Description
+          </p>
+          <p className="mt-1 text-sm">{detail.description}</p>
+        </div>
+      )}
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <p className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+            Status
+          </p>
+          <Badge variant="outline" className={`mt-1 text-xs ${STATUS_COLORS[detail.status] ?? ""}`}>
+            {STATUS_LABELS[detail.status] ?? detail.status}
+          </Badge>
+        </div>
+        <div>
+          <p className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+            Priority
+          </p>
+          <Badge
+            variant="outline"
+            className={`mt-1 text-xs ${PRIORITY_COLORS[detail.priority] ?? ""}`}
+          >
+            {PRIORITY_LABELS[detail.priority] ?? detail.priority}
+          </Badge>
+        </div>
+      </div>
+      {detail.assignee_name && (
+        <div>
+          <p className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+            Assigned to
+          </p>
+          <p className="mt-1 text-sm">{detail.assignee_name}</p>
+        </div>
+      )}
+      {detail.due_at && (
+        <div>
+          <p className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+            Due date
+          </p>
+          <p className="mt-1 text-sm">{new Date(detail.due_at).toLocaleDateString()}</p>
+        </div>
+      )}
+      <div>
+        <p className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+          Created by
+        </p>
+        <p className="mt-1 text-sm">{detail.creator_name ?? detail.creator_email ?? "Unknown"}</p>
+      </div>
+    </div>
+  );
+}
+
+const COLUMNS: DataViewColumnDef<PlanningTaskListRow>[] = [
+  {
+    key: "title",
+    header: "Title",
+    accessor: (row) => (
+      <span className="block max-w-[280px] truncate font-medium">{row.title}</span>
+    ),
+    sortable: true,
+  },
+  {
+    key: "status",
+    header: "Status",
+    accessor: (row) => (
+      <Badge variant="outline" className={`text-xs ${STATUS_COLORS[row.status] ?? ""}`}>
+        {STATUS_LABELS[row.status] ?? row.status}
+      </Badge>
+    ),
+    sortable: true,
+  },
+  {
+    key: "priority",
+    header: "Priority",
+    accessor: (row) => (
+      <Badge variant="outline" className={`text-xs ${PRIORITY_COLORS[row.priority] ?? ""}`}>
+        {PRIORITY_LABELS[row.priority] ?? row.priority}
+      </Badge>
+    ),
+    sortable: true,
+  },
+  {
+    key: "assigned_to",
+    header: "Assignee",
+    accessor: (row) => (
+      <span className="text-muted-foreground text-sm">
+        {row.assignee_name ?? row.assignee_email ?? "—"}
+      </span>
+    ),
+  },
+  {
+    key: "due_at",
+    header: "Due date",
+    accessor: (row) =>
+      row.due_at ? (
+        <span className="text-sm">{new Date(row.due_at).toLocaleDateString()}</span>
+      ) : (
+        <span className="text-muted-foreground text-sm">—</span>
+      ),
+    sortable: true,
+  },
+  {
+    key: "created_at",
+    header: "Created",
+    accessor: (row) => (
+      <span className="text-muted-foreground text-sm">
+        {new Date(row.created_at).toLocaleDateString()}
+      </span>
+    ),
+    sortable: true,
+  },
+];
+
+const FILTERS: DataViewFilterDef[] = [
+  {
+    key: "status",
+    label: "Status",
+    type: "multi-select",
+    options: [
+      { value: "open", label: "Open" },
+      { value: "in_progress", label: "In Progress" },
+      { value: "completed", label: "Completed" },
+    ],
+  },
+  {
+    key: "priority",
+    label: "Priority",
+    type: "multi-select",
+    options: [
+      { value: "low", label: "Low" },
+      { value: "normal", label: "Normal" },
+      { value: "high", label: "High" },
+      { value: "urgent", label: "Urgent" },
+    ],
+  },
+];
+
+export function TasksClient({ initialData, canCreate, orgId }: TasksClientProps) {
+  const listFetcher = useCallback(
+    async (params: DataViewListParams): Promise<PaginatedResult<PlanningTaskListRow>> => {
+      const result = await listTasksForDataViewAction(params);
+      if (result.success) return result.data;
+      throw new Error((result as { success: false; error: string }).error);
+    },
+    []
+  );
+
+  const detailFetcher = useCallback(async (id: string): Promise<PlanningTaskDetail | null> => {
+    const result = await getTaskDetailAction(id);
+    if (!result.success) return null;
+    return result.data;
+  }, []);
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center justify-between border-b px-6 py-4">
+        <div className="flex items-center gap-2">
+          <CheckSquare className="h-5 w-5 text-teal-600" />
+          <h1 className="text-lg font-semibold">Tasks</h1>
+        </div>
+        {canCreate && (
+          <Button size="sm" className="gap-1.5">
+            <Plus className="h-4 w-4" />
+            New task
+          </Button>
+        )}
+      </div>
+
+      <div className="min-h-0 flex-1">
+        <DataView<PlanningTaskListRow, PlanningTaskDetail>
+          entity="planning-tasks"
+          columns={COLUMNS}
+          filters={FILTERS}
+          initialData={initialData}
+          queryKey={PLANNING_TASKS_QUERY_KEY}
+          listFetcher={listFetcher}
+          detailFetcher={detailFetcher}
+          getRowId={(row) => row.id}
+          renderCompactItem={(row) => (
+            <div className="flex flex-col gap-1">
+              <div className="flex items-center justify-between gap-2">
+                <Badge variant="outline" className={`text-xs ${STATUS_COLORS[row.status] ?? ""}`}>
+                  {STATUS_LABELS[row.status] ?? row.status}
+                </Badge>
+                <Badge
+                  variant="outline"
+                  className={`text-xs ${PRIORITY_COLORS[row.priority] ?? ""}`}
+                >
+                  {PRIORITY_LABELS[row.priority] ?? row.priority}
+                </Badge>
+              </div>
+              <span className="truncate text-sm font-medium" title={row.title}>
+                {row.title}
+              </span>
+            </div>
+          )}
+          renderDetail={(detail) => <TaskDetailPanel key={detail.id} detail={detail} />}
+          renderToolbarControls={
+            canCreate
+              ? () => (
+                  <Button size="sm" className="gap-1.5">
+                    <Plus className="h-4 w-4" />
+                    New task
+                  </Button>
+                )
+              : undefined
+          }
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/dashboard/planning/tasks/page.tsx
+++ b/apps/web/src/app/[locale]/dashboard/planning/tasks/page.tsx
@@ -1,0 +1,69 @@
+import { redirect } from "@/i18n/navigation";
+import { getLocale } from "next-intl/server";
+import { loadDashboardContextV2 } from "@/server/loaders/v2/load-dashboard-context.v2";
+import { checkPermission } from "@/lib/utils/permissions";
+import {
+  PLANNING_TASKS_READ,
+  PLANNING_TASKS_CREATE,
+  PLANNING_TASKS_ASSIGN,
+} from "@/lib/constants/permissions";
+import { createClient } from "@/utils/supabase/server";
+import { PlanningTasksService } from "@/server/services/planning-tasks.service";
+import { OrgMembersService } from "@/server/services/organization.service";
+import { parseDataViewSearchParams } from "@/components/data-view/data-view-search-params";
+import { TasksClient } from "./_components/tasks-client";
+
+type PageProps = {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export default async function PlanningTasksPage({ searchParams }: PageProps = {}) {
+  const locale = await getLocale();
+  const context = await loadDashboardContextV2();
+
+  if (!context?.app.activeOrgId) return redirect({ href: "/sign-in", locale });
+
+  if (!checkPermission(context.user.permissionSnapshot, PLANNING_TASKS_READ)) {
+    return redirect({
+      href: {
+        pathname: "/dashboard/access-denied",
+        query: { reason: "planning_tasks_read_required" },
+      },
+      locale,
+    });
+  }
+
+  const params = parseDataViewSearchParams(searchParams ? await searchParams : {});
+  const supabase = await createClient();
+  const orgId = context.app.activeOrgId;
+
+  const [tasksResult, membersResult] = await Promise.all([
+    PlanningTasksService.listForDataView(supabase, orgId, params),
+    OrgMembersService.listMembers(supabase, orgId),
+  ]);
+
+  const initialData = tasksResult.success
+    ? tasksResult.data
+    : { rows: [], totalCount: 0, page: params.page, pageSize: params.pageSize };
+
+  const members = membersResult.success
+    ? membersResult.data.map((m) => ({
+        user_id: m.user_id,
+        name: [m.user_first_name, m.user_last_name].filter(Boolean).join(" ") || null,
+        email: m.user_email,
+      }))
+    : [];
+
+  const canCreate = checkPermission(context.user.permissionSnapshot, PLANNING_TASKS_CREATE);
+  const canAssign = checkPermission(context.user.permissionSnapshot, PLANNING_TASKS_ASSIGN);
+
+  return (
+    <TasksClient
+      initialData={initialData}
+      canCreate={canCreate}
+      canAssign={canAssign}
+      members={members}
+      orgId={orgId}
+    />
+  );
+}

--- a/apps/web/src/app/actions/planning/index.ts
+++ b/apps/web/src/app/actions/planning/index.ts
@@ -1,0 +1,163 @@
+"use server";
+
+import { createClient } from "@/utils/supabase/server";
+import { loadDashboardContextV2 } from "@/server/loaders/v2/load-dashboard-context.v2";
+import { checkPermission } from "@/lib/utils/permissions";
+import {
+  PLANNING_READ,
+  PLANNING_TASKS_READ,
+  PLANNING_TASKS_CREATE,
+  PLANNING_TASKS_UPDATE,
+  PLANNING_TASKS_DELETE,
+  PLANNING_TASKS_ASSIGN,
+} from "@/lib/constants/permissions";
+import {
+  PlanningTasksService,
+  type PlanningTaskListRow,
+  type PlanningTaskDetail,
+} from "@/server/services/planning-tasks.service";
+import {
+  createTaskSchema,
+  updateTaskSchema,
+  changeTaskStatusSchema,
+  assignTaskSchema,
+  type CreateTaskInput,
+  type UpdateTaskInput,
+  type ChangeTaskStatusInput,
+  type AssignTaskInput,
+  type TaskListFilters,
+} from "@/lib/validations/planning";
+import type { DataViewListParams, PaginatedResult } from "@/lib/data-view/types";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type ActionResult<T> = { success: true; data: T } | { success: false; error: string };
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function getAuthedContext() {
+  const supabase = await createClient();
+  const context = await loadDashboardContextV2();
+  if (!context?.app.activeOrgId) return null;
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return null;
+  return { supabase, context, userId: user.id, orgId: context.app.activeOrgId };
+}
+
+// ---------------------------------------------------------------------------
+// Actions
+// ---------------------------------------------------------------------------
+
+export async function listTasksForDataViewAction(
+  params: DataViewListParams,
+  filters: TaskListFilters = {}
+): Promise<ActionResult<PaginatedResult<PlanningTaskListRow>>> {
+  try {
+    const ctx = await getAuthedContext();
+    if (!ctx) return { success: false, error: "Unauthorized" };
+    if (!checkPermission(ctx.context.user.permissionSnapshot, PLANNING_TASKS_READ))
+      return { success: false, error: "Insufficient permissions" };
+    return PlanningTasksService.listForDataView(ctx.supabase, ctx.orgId, params, filters);
+  } catch {
+    return { success: false, error: "Unexpected error" };
+  }
+}
+
+export async function getTaskDetailAction(
+  taskId: string
+): Promise<ActionResult<PlanningTaskDetail>> {
+  try {
+    const ctx = await getAuthedContext();
+    if (!ctx) return { success: false, error: "Unauthorized" };
+    if (!checkPermission(ctx.context.user.permissionSnapshot, PLANNING_TASKS_READ))
+      return { success: false, error: "Insufficient permissions" };
+    return PlanningTasksService.getDetail(ctx.supabase, ctx.orgId, taskId);
+  } catch {
+    return { success: false, error: "Unexpected error" };
+  }
+}
+
+export async function createTaskAction(
+  input: CreateTaskInput
+): Promise<ActionResult<PlanningTaskDetail>> {
+  try {
+    const ctx = await getAuthedContext();
+    if (!ctx) return { success: false, error: "Unauthorized" };
+    if (!checkPermission(ctx.context.user.permissionSnapshot, PLANNING_TASKS_CREATE))
+      return { success: false, error: "Insufficient permissions" };
+    const parsed = createTaskSchema.safeParse(input);
+    if (!parsed.success) return { success: false, error: parsed.error.message };
+    return PlanningTasksService.create(ctx.supabase, ctx.orgId, ctx.userId, parsed.data);
+  } catch {
+    return { success: false, error: "Unexpected error" };
+  }
+}
+
+export async function updateTaskAction(
+  input: UpdateTaskInput
+): Promise<ActionResult<PlanningTaskDetail>> {
+  try {
+    const ctx = await getAuthedContext();
+    if (!ctx) return { success: false, error: "Unauthorized" };
+    if (!checkPermission(ctx.context.user.permissionSnapshot, PLANNING_TASKS_UPDATE))
+      return { success: false, error: "Insufficient permissions" };
+    const parsed = updateTaskSchema.safeParse(input);
+    if (!parsed.success) return { success: false, error: parsed.error.message };
+    return PlanningTasksService.update(ctx.supabase, ctx.orgId, parsed.data);
+  } catch {
+    return { success: false, error: "Unexpected error" };
+  }
+}
+
+export async function changeTaskStatusAction(
+  input: ChangeTaskStatusInput
+): Promise<ActionResult<PlanningTaskDetail>> {
+  try {
+    const ctx = await getAuthedContext();
+    if (!ctx) return { success: false, error: "Unauthorized" };
+    if (!checkPermission(ctx.context.user.permissionSnapshot, PLANNING_TASKS_UPDATE))
+      return { success: false, error: "Insufficient permissions" };
+    const parsed = changeTaskStatusSchema.safeParse(input);
+    if (!parsed.success) return { success: false, error: parsed.error.message };
+    return PlanningTasksService.changeStatus(ctx.supabase, ctx.orgId, parsed.data);
+  } catch {
+    return { success: false, error: "Unexpected error" };
+  }
+}
+
+export async function assignTaskAction(
+  input: AssignTaskInput
+): Promise<ActionResult<PlanningTaskDetail>> {
+  try {
+    const ctx = await getAuthedContext();
+    if (!ctx) return { success: false, error: "Unauthorized" };
+    if (!checkPermission(ctx.context.user.permissionSnapshot, PLANNING_TASKS_ASSIGN))
+      return { success: false, error: "Insufficient permissions" };
+    const parsed = assignTaskSchema.safeParse(input);
+    if (!parsed.success) return { success: false, error: parsed.error.message };
+    return PlanningTasksService.assign(ctx.supabase, ctx.orgId, parsed.data);
+  } catch {
+    return { success: false, error: "Unexpected error" };
+  }
+}
+
+export async function deleteTaskAction(taskId: string): Promise<ActionResult<void>> {
+  try {
+    const ctx = await getAuthedContext();
+    if (!ctx) return { success: false, error: "Unauthorized" };
+    if (!checkPermission(ctx.context.user.permissionSnapshot, PLANNING_TASKS_DELETE))
+      return { success: false, error: "Insufficient permissions" };
+    return PlanningTasksService.softDelete(ctx.supabase, ctx.orgId, taskId);
+  } catch {
+    return { success: false, error: "Unexpected error" };
+  }
+}
+
+// Re-export read permission check helper for pages
+export { PLANNING_READ };

--- a/apps/web/src/i18n/routing.ts
+++ b/apps/web/src/i18n/routing.ts
@@ -300,6 +300,20 @@ export const routing = defineRouting({
       pl: "/dashboard/help-desk/typy-zgloszen",
     },
 
+    // === Planning module ===
+    "/dashboard/planning": {
+      en: "/dashboard/planning",
+      pl: "/dashboard/planowanie",
+    },
+    "/dashboard/planning/tasks": {
+      en: "/dashboard/planning/tasks",
+      pl: "/dashboard/planowanie/zadania",
+    },
+    "/dashboard/planning/boards": {
+      en: "/dashboard/planning/boards",
+      pl: "/dashboard/planowanie/tablice",
+    },
+
     // === Analytics & Reports module ===
     "/dashboard/analytics": {
       en: "/dashboard/analytics",

--- a/apps/web/src/lib/sidebar/v2/icon-map.ts
+++ b/apps/web/src/lib/sidebar/v2/icon-map.ts
@@ -34,6 +34,8 @@ import {
   LayoutDashboard,
   ArrowLeftRight,
   ShieldCheck,
+  CheckSquare,
+  LayoutGrid,
 } from "lucide-react";
 import type { IconKey } from "@/lib/types/v2/sidebar";
 
@@ -77,6 +79,8 @@ export const ICON_MAP: Record<IconKey, React.ComponentType<{ className?: string 
   dashboard: LayoutDashboard,
   transfers: ArrowLeftRight,
   shieldCheck: ShieldCheck,
+  checkSquare: CheckSquare,
+  layoutGrid: LayoutGrid,
 };
 
 /**

--- a/apps/web/src/lib/sidebar/v2/registry.ts
+++ b/apps/web/src/lib/sidebar/v2/registry.ts
@@ -21,6 +21,9 @@ import {
   HELPDESK_TICKETS_READ,
   HELPDESK_TICKET_TYPES_MANAGE,
   HELPDESK_SETTINGS_MANAGE,
+  MODULE_PLANNING_ACCESS,
+  PLANNING_READ,
+  PLANNING_TASKS_READ,
 } from "@/lib/constants/permissions";
 import {
   MODULE_ORGANIZATION_MANAGEMENT,
@@ -28,6 +31,7 @@ import {
   MODULE_ANALYTICS,
   MODULE_WORKSHOP,
   MODULE_HELPDESK,
+  MODULE_PLANNING,
 } from "@/lib/constants/modules";
 
 /**
@@ -303,6 +307,57 @@ export const MAIN_NAV_ITEMS: SidebarItem[] = [
         match: { exact: "/dashboard/organization/billing" },
         visibility: {
           requiresPermissions: [ORG_UPDATE], // Only owners see billing
+        },
+      },
+    ],
+  },
+
+  // ── Group: planning ─────────────────────────────────────────────────────
+
+  // Planning (plan-gated: MODULE_PLANNING must be in enabled_modules,
+  // user-gated: MODULE_PLANNING_ACCESS permission required)
+  {
+    id: "planning",
+    group: "planning",
+    title: "Planning",
+    titleKey: "modules.planning.titleSidebar",
+    iconKey: "checkSquare",
+    visibility: {
+      requiresModules: [MODULE_PLANNING],
+      requiresPermissions: [MODULE_PLANNING_ACCESS],
+    },
+    children: [
+      {
+        id: "planning.overview",
+        title: "Overview",
+        titleKey: "modules.planning.items.overview",
+        iconKey: "layoutGrid",
+        href: "/dashboard/planning",
+        match: { exact: "/dashboard/planning" },
+        visibility: {
+          requiresPermissions: [PLANNING_READ],
+        },
+      },
+      {
+        id: "planning.tasks",
+        title: "Tasks",
+        titleKey: "modules.planning.items.tasks",
+        iconKey: "checkSquare",
+        href: "/dashboard/planning/tasks",
+        match: { startsWith: "/dashboard/planning/tasks" },
+        visibility: {
+          requiresPermissions: [PLANNING_TASKS_READ],
+        },
+      },
+      {
+        id: "planning.boards",
+        title: "Boards",
+        titleKey: "modules.planning.items.boards",
+        iconKey: "layoutGrid",
+        href: "/dashboard/planning/boards",
+        match: { exact: "/dashboard/planning/boards" },
+        visibility: {
+          requiresPermissions: [PLANNING_TASKS_READ],
         },
       },
     ],

--- a/apps/web/src/lib/types/v2/sidebar.ts
+++ b/apps/web/src/lib/types/v2/sidebar.ts
@@ -59,7 +59,9 @@ export type IconKey =
   | "truck"
   | "dashboard"
   | "transfers"
-  | "shieldCheck";
+  | "shieldCheck"
+  | "checkSquare"
+  | "layoutGrid";
 
 /**
  * Active route matching rules (strict discriminated union)

--- a/apps/web/src/lib/validations/planning.ts
+++ b/apps/web/src/lib/validations/planning.ts
@@ -1,0 +1,56 @@
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+export const TASK_STATUSES = ["open", "in_progress", "completed"] as const;
+export const TASK_PRIORITIES = ["low", "normal", "high", "urgent"] as const;
+
+export type TaskStatus = (typeof TASK_STATUSES)[number];
+export type TaskPriority = (typeof TASK_PRIORITIES)[number];
+
+// ---------------------------------------------------------------------------
+// Task schemas
+// ---------------------------------------------------------------------------
+
+export const createTaskSchema = z.object({
+  title: z.string().min(1, "Title is required").max(200),
+  description: z.string().max(5000).optional(),
+  status: z.enum(TASK_STATUSES).default("open"),
+  priority: z.enum(TASK_PRIORITIES).default("normal"),
+  branch_id: z.string().uuid().nullable().optional(),
+  assigned_to: z.string().uuid().nullable().optional(),
+  due_at: z.string().datetime().nullable().optional(),
+});
+
+export const updateTaskSchema = createTaskSchema.extend({
+  id: z.string().uuid(),
+});
+
+export const changeTaskStatusSchema = z.object({
+  id: z.string().uuid(),
+  status: z.enum(TASK_STATUSES),
+});
+
+export const assignTaskSchema = z.object({
+  id: z.string().uuid(),
+  assigned_to: z.string().uuid().nullable(),
+});
+
+export type CreateTaskInput = z.infer<typeof createTaskSchema>;
+export type UpdateTaskInput = z.infer<typeof updateTaskSchema>;
+export type ChangeTaskStatusInput = z.infer<typeof changeTaskStatusSchema>;
+export type AssignTaskInput = z.infer<typeof assignTaskSchema>;
+
+// ---------------------------------------------------------------------------
+// Filters
+// ---------------------------------------------------------------------------
+
+export interface TaskListFilters {
+  search?: string;
+  status?: TaskStatus[];
+  priority?: TaskPriority[];
+  branch_id?: string | null;
+  assigned_to?: string | null;
+}

--- a/apps/web/src/modules/planning/MODULE.md
+++ b/apps/web/src/modules/planning/MODULE.md
@@ -1,0 +1,102 @@
+# Planning Module
+
+## Purpose
+
+Ambra's planning and work organization hub. Helps users organize and execute work across the organization.
+
+Answers:
+
+- What do I need to do?
+- What tasks are assigned to me?
+- What tasks are assigned to my team?
+- What is currently in progress?
+- What is completed?
+
+## Routes
+
+| Route                                | Description          |
+| ------------------------------------ | -------------------- |
+| `/dashboard/planning`                | Module overview      |
+| `/dashboard/planning/tasks`          | Task list (DataView) |
+| `/dashboard/planning/tasks/new`      | Create task          |
+| `/dashboard/planning/tasks/[taskId]` | Task detail          |
+| `/dashboard/planning/boards`         | Kanban board view    |
+
+## Permissions
+
+| Constant                 | Slug                     | Description                 |
+| ------------------------ | ------------------------ | --------------------------- |
+| `MODULE_PLANNING_ACCESS` | `module.planning.access` | Enter the Planning module   |
+| `PLANNING_READ`          | `planning.read`          | View module shell           |
+| `PLANNING_TASKS_READ`    | `planning.tasks.read`    | List and view tasks         |
+| `PLANNING_TASKS_CREATE`  | `planning.tasks.create`  | Create new tasks            |
+| `PLANNING_TASKS_UPDATE`  | `planning.tasks.update`  | Edit tasks, change status   |
+| `PLANNING_TASKS_DELETE`  | `planning.tasks.delete`  | Soft-delete tasks           |
+| `PLANNING_TASKS_ASSIGN`  | `planning.tasks.assign`  | Assign tasks to org members |
+
+## Role Assignments
+
+| Role         | Permissions                                                                                                        |
+| ------------ | ------------------------------------------------------------------------------------------------------------------ |
+| `org_owner`  | `planning.*` (wildcard — all)                                                                                      |
+| `org_member` | `planning.read`, `planning.tasks.read`, `planning.tasks.create`, `planning.tasks.update`, `module.planning.access` |
+
+## Tables
+
+### `planning_tasks`
+
+Core task entity. Org-scoped, soft-delete, with optional branch scoping.
+
+### `planning_task_comments`
+
+Simple comment thread on a task. Org-scoped, soft-delete.
+
+## Services
+
+| File                        | Purpose                                         |
+| --------------------------- | ----------------------------------------------- |
+| `planning-tasks.service.ts` | CRUD, list/filter, status transitions for tasks |
+
+## Actions
+
+| Action                       | Permission              |
+| ---------------------------- | ----------------------- |
+| `listTasksForDataViewAction` | `PLANNING_TASKS_READ`   |
+| `getTaskDetailAction`        | `PLANNING_TASKS_READ`   |
+| `createTaskAction`           | `PLANNING_TASKS_CREATE` |
+| `updateTaskAction`           | `PLANNING_TASKS_UPDATE` |
+| `changeTaskStatusAction`     | `PLANNING_TASKS_UPDATE` |
+| `assignTaskAction`           | `PLANNING_TASKS_ASSIGN` |
+| `deleteTaskAction`           | `PLANNING_TASKS_DELETE` |
+
+## Theme
+
+Color: `#0d9488` (Teal)
+
+---
+
+## Future Roadmap
+
+### Phase 2 (Not yet implemented)
+
+- Schedules
+- Calendar view
+- Recurring tasks
+
+### Phase 3 (Not yet implemented)
+
+- Workload planning
+- Team planning views
+- Capacity management
+
+### Phase 4 (Not yet implemented)
+
+- Planning templates
+- Recurring schedules
+- Task dependencies
+
+### Phase 5 (Not yet implemented)
+
+- Integration with Workshop (link tasks to repair orders)
+- Integration with Warehouse (link tasks to inventory actions)
+- Integration with Help Desk (convert tickets to tasks)

--- a/apps/web/src/modules/planning/MODULE_CHECKLIST.md
+++ b/apps/web/src/modules/planning/MODULE_CHECKLIST.md
@@ -1,0 +1,584 @@
+# MODULE_IMPLEMENTATION_CHECKLIST.md
+
+> **Copy this file** to `src/modules/<new-module>/MODULE_CHECKLIST.md` and work through it
+> top to bottom. Do not skip sections. Do not mark a box unless it is verifiably true.
+>
+> This checklist encodes the invariants of the Coreframe V2 architecture:
+> SSR-first · TDD-first · Security-first · Compiled permissions · Compiled entitlements · Sidebar V2
+
+---
+
+## 1. Purpose & Non-Negotiables
+
+Read these before touching any file. They are not preferences — they are architectural invariants.
+
+### SSR-First Invariants
+
+- [ ] Server Components are authoritative. They compute data, authorization, and sidebar model before the page renders.
+- [ ] Client Components are dumb renderers. They accept pre-computed props. They do not re-evaluate permissions.
+- [ ] The dashboard layout loads the authoritative context once (e.g. `loadDashboardContextV2()`), not repeated per page.
+- [ ] `buildSidebarModel()` runs server-side. Production uses the `React.cache()`-wrapped version (one call per request). The result (`SidebarModel`) is a JSON prop passed to the client renderer.
+- [ ] `React.cache()` provides per-request memoization — never a global singleton cache.
+- [ ] No `createClient()` / Supabase client instantiation in Client Components for org-scoped data.
+
+### TDD-First Invariants
+
+- [ ] Tests are written alongside (or before) the implementation, not after.
+- [ ] Every access-control decision has at least one negative test (prove it fails closed).
+- [ ] Sidebar integration tests use `buildSidebarModelUncached` (never `buildSidebarModel`). The uncached variant avoids `React.cache()` artifacts that would leak state between test cases.
+- [ ] RLS tests run against real Postgres, not mocked clients.
+- [ ] `clearPermissionRegexCache()` is called in `afterEach` in every test file that uses `checkPermission`.
+
+### UX vs. Security Boundary
+
+- [ ] Understood: **the sidebar is a UX boundary, not a security boundary.**
+- [ ] Hiding or disabling a sidebar item never prevents direct URL access.
+- [ ] Disabling a sidebar item never prevents a server action from executing.
+- [ ] Every route that hides a link in the sidebar also has a **server-side guard** that enforces access independently.
+- [ ] Every server action that is behind a hidden sidebar item also has a **permission check** at the top of the function.
+
+### Fail-Closed Principles
+
+- [ ] If `organization_entitlements` is missing (no subscription), all module access checks **throw** — never silently allow.
+- [ ] If `user_effective_permissions` is missing for a user, access is **denied** — never assumed.
+- [ ] If a limit check fails, throws, or returns an indeterminate result, treat it as limit reached — never as unlimited (fail closed).
+- [ ] Permission checks use deny-first semantics: a deny pattern overrides any allow pattern, including wildcards.
+
+### No Raw Strings Rule
+
+- [ ] **TypeScript code never contains raw permission strings** (e.g., `"org.update"`). Always import from `@/lib/constants/permissions`.
+- [ ] **TypeScript code never contains raw module strings** (e.g., `"warehouse"`). Always import from `@/lib/constants/modules`.
+- [ ] Raw string literals in SQL migrations are acceptable (e.g., `has_permission(org_id, 'org.update')`).
+- [ ] Raw string literals in SQL `INSERT INTO permissions (slug) VALUES (...)` are acceptable.
+- [ ] Verify: run a grep for `can("`, `requireModuleAccess("`, `hasPermission(` with a string literal argument — all must be zero hits in TypeScript files for this module.
+
+---
+
+## 2. Module Specification Inputs
+
+> Fill in every field **before** writing any code. If a field is unknown, resolve it first.
+> Incomplete specs are the primary cause of mismatched slugs, missing RLS, and broken entitlement gates.
+
+### Identity
+
+```
+Module name (human):       ___________________________________
+Module slug (kebab-case):  ___________________________________   (e.g. "analytics")
+Constant name:             MODULE_____________________________   (e.g. MODULE_ANALYTICS)
+File prefix:               ___________________________________   (e.g. analytics)
+v2_ready status:           [ ] v2_ready   [ ] planned   [ ] legacy
+```
+
+### Routes
+
+List every route this module exposes. Mark each with its guard type.
+
+```
+Route path                          Guard type (module / permission / both / public)
+_________________________________   ___________________________________________________
+_________________________________   ___________________________________________________
+_________________________________   ___________________________________________________
+_________________________________   ___________________________________________________
+```
+
+### Data Ownership & Scoping
+
+```
+Primary scope:             [ ] organization   [ ] branch   [ ] global   [ ] user-personal
+organization_id required:  [ ] Yes   [ ] No
+branch_id required:        [ ] Yes (all tables)   [ ] Yes (some tables)   [ ] No
+Multi-branch isolation:    [ ] Required   [ ] Not applicable
+Soft-delete required:      [ ] Yes (deleted_at)   [ ] No
+```
+
+### Tables / Entities
+
+```
+Table name                    Primary scope    Soft delete    PII/Sensitive
+____________________________  _______________  _____________  _______________
+____________________________  _______________  _____________  _______________
+____________________________  _______________  _____________  _______________
+```
+
+### Permission Matrix
+
+List every user action and the permission slug(s) required.
+
+```
+Route / Server Action                Permission slug(s) required        Deny effect
+___________________________________  _________________________________  _____________________
+___________________________________  _________________________________  _____________________
+___________________________________  _________________________________  _____________________
+___________________________________  _________________________________  _____________________
+```
+
+### Entitlement Gating
+
+```
+Is this module plan-gated?                   [ ] Yes   [ ] No
+Plans that include this module:              [ ] Free   [ ] Professional   [ ] Enterprise   [ ] All
+Add-on gated?                                [ ] Yes (add-on slug: ___________________)   [ ] No
+Manual override supported?                   [ ] Yes   [ ] No
+Module slug added to subscription_plans?     [ ] Pending   [ ] Done
+```
+
+### Limits
+
+```
+Limit key                              Enforcement point (Server Component / Server Action / Both)
+___________________________________   ___________________________________________________________
+___________________________________   ___________________________________________________________
+```
+
+### i18n Keys Required
+
+```
+Sidebar title key:        modules.___________.title
+Page title key:           ___________________________________
+Error message keys:       ___________________________________
+                          ___________________________________
+Other keys needed:        ___________________________________
+```
+
+### Risks & Edge Cases
+
+```
+[ ] Multi-branch data isolation is required
+[ ] Soft-delete means deleted rows must be excluded from queries (deleted_at IS NULL)
+[ ] Exports or bulk operations are count-limited (enforce at the guard layer, not just DB)
+[ ] FORCE RLS required (tables contain PII / audit logs / billing data)
+[ ] Module has a "coming_soon" sidebar entry before full release
+[ ] Module reuses an existing slug from another context (risk: slug collision)
+[ ] Other: _________________________________________________________________
+```
+
+---
+
+## 3. Repo Integration Map
+
+Every file or location a developer must touch to fully integrate this module.
+
+### Constants
+
+- [ ] `src/lib/constants/modules.ts` — add `MODULE_YOURMODULE` constant and update `ModuleSlug` union; update any module allowlists/arrays present in this file (if applicable)
+- [ ] `src/lib/constants/permissions.ts` — add new permission slug constants and update `PermissionSlug` union + `ALL_PERMISSION_SLUGS` array
+
+### Entitlements Types (if adding a new limit key)
+
+- [ ] `src/lib/types/entitlements.ts` — add to `LIMIT_KEYS` object and `LimitKey` union type
+
+### Database Migrations
+
+- [ ] `supabase/migrations/[timestamp]_create_[module]_tables.sql` — schema + indexes
+- [ ] `supabase/migrations/[timestamp]_rls_[module].sql` — RLS ENABLE, FORCE, policies
+- [ ] `supabase/migrations/[timestamp]_permissions_[module].sql` — INSERT INTO permissions + role_permissions
+- [ ] `supabase/migrations/[timestamp]_entitlements_[module].sql` — UPDATE subscription_plans.enabled_modules / limits (if gated)
+
+### Server Layer
+
+- [ ] `src/server/services/[module].service.ts` — static service class
+- [ ] `src/app/actions/[module]/index.ts` — server actions (with guards at top of each)
+
+### Client / App Layer
+
+- [ ] `src/hooks/queries/[module]/index.ts` — React Query hooks
+- [ ] `src/app/[locale]/dashboard/[module]/page.tsx` — Server Component + entitlements guard
+- [ ] `src/app/[locale]/dashboard/[module]/loading.tsx`
+- [ ] `src/app/[locale]/dashboard/[module]/error.tsx`
+- [ ] `src/app/[locale]/dashboard/[module]/_components/[module]-page-client.tsx`
+
+### Module Metadata
+
+- [ ] `src/modules/[module]/config.ts` — ModuleConfig (widgets, metadata only — not navigation)
+- [ ] `src/modules/index.ts` — register the new module in `getAllModules()`
+- [ ] `src/modules/[module]/MODULE.md` — module passport documentation (must exist and be up to date)
+
+### Sidebar V2 (Navigation)
+
+- [ ] `src/lib/sidebar/v2/registry.ts` — add entry to `MAIN_NAV_ITEMS` or `FOOTER_NAV_ITEMS`
+- [ ] `src/lib/sidebar/v2/icon-map.ts` — add icon if using a new key
+
+### i18n
+
+- [ ] `messages/en.json` — add all required keys
+- [ ] `messages/pl.json` — add all required keys
+
+### Tests
+
+- [ ] `src/app/[locale]/dashboard/__tests__/sidebar-ssr.test.tsx` — update/add SSR integration test for new sidebar items
+- [ ] `src/server/services/__tests__/[module].service.test.ts` — unit tests for service layer
+- [ ] `src/app/actions/__tests__/[module].test.ts` — guard and action tests
+- [ ] `supabase/tests/rls_[module].test.sql` (or TypeScript equivalent) — RLS isolation tests
+
+---
+
+## 4. Step-by-Step Build Flow
+
+Work through each domain in order. Complete one domain fully before moving to the next.
+
+---
+
+### A. Constants & Types
+
+- [ ] Add `MODULE_YOURMODULE = "your-module" as const` to `src/lib/constants/modules.ts`
+- [ ] Add `MODULE_YOURMODULE` to the `ModuleSlug` type union
+- [ ] Update any `ModuleSlug` unions or module allowlist arrays present in `modules.ts` (if the repo uses them); the authoritative plan gating lives in `subscription_plans.enabled_modules` via the entitlements system
+- [ ] For each new permission, add a named constant to `src/lib/constants/permissions.ts` (e.g., `export const YOURMODULE_READ = "yourmodule.read" as const`)
+- [ ] Add each new constant to `PermissionSlug` type union
+- [ ] Add each new constant to `ALL_PERMISSION_SLUGS` array
+- [ ] If adding a new limit, add it to `LIMIT_KEYS` in `src/lib/types/entitlements.ts` and to `LimitKey` union
+- [ ] Verify: run `npm run type-check` — zero new errors
+
+**Confirm no raw strings introduced:**
+
+- [ ] Grep `src/` for `can("your-module` → zero matches
+- [ ] Grep `src/` for `requireModuleAccess("your-module` → zero matches
+- [ ] Grep `src/` for `"yourmodule.` (raw permission string) → zero matches in `.ts`/`.tsx` files
+
+---
+
+### B. Database Schema
+
+- [ ] Create migration file `[timestamp]_create_[module]_tables.sql`
+- [ ] Every table includes: `id uuid DEFAULT gen_random_uuid() PRIMARY KEY`
+- [ ] Every org-scoped table includes: `organization_id uuid NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE`
+- [ ] Branch-scoped tables include: `branch_id uuid REFERENCES public.branches(id) ON DELETE SET NULL` (or CASCADE — document decision)
+- [ ] Soft-delete tables include: `deleted_at timestamptz DEFAULT NULL`
+- [ ] All tables include: `created_at timestamptz DEFAULT now() NOT NULL`, `updated_at timestamptz DEFAULT now() NOT NULL`, `created_by uuid REFERENCES auth.users(id)`
+- [ ] Index on `organization_id` for every table
+- [ ] Index on `(organization_id, deleted_at)` for soft-deleted tables
+- [ ] Index on `branch_id` if used
+- [ ] Index on columns used in frequent WHERE filters
+- [ ] Migration is idempotent where possible (use `IF NOT EXISTS`, `DO $$ BEGIN ... EXCEPTION WHEN duplicate_object` pattern)
+- [ ] TypeScript types regenerated: `npm run supabase:gen:types`
+- [ ] Verify generated types exist in `supabase/types/types.ts` for new tables
+
+---
+
+### C. RLS & Security in DB
+
+> RLS is a hard requirement. Every table with org data must have policies before any application code reads or writes it.
+
+- [ ] `ALTER TABLE public.your_table ENABLE ROW LEVEL SECURITY;` — all new tables
+- [ ] For tables containing PII, audit logs, billing, or permission data: `ALTER TABLE public.your_table FORCE ROW LEVEL SECURITY;`
+- [ ] **SELECT policy** exists using `is_org_member(organization_id)`:
+  ```sql
+  USING (is_org_member(organization_id) AND deleted_at IS NULL)
+  ```
+- [ ] **INSERT policy** exists using `has_permission(organization_id, 'yourmodule.create')` (raw string in SQL is acceptable)
+- [ ] **UPDATE policy** exists — covers both normal updates AND soft-deletes in a single policy:
+  ```sql
+  -- NOTE: WITH CHECK must mirror USING unless intentionally restricting updates.
+  -- See canonical update + escalation pattern in MODULE_DEVELOPMENT_GUIDE.md.
+  USING (is_org_member(organization_id))
+  WITH CHECK (has_permission(organization_id, 'yourmodule.update'))
+  ```
+- [ ] **DELETE policy** — only if hard-delete is used (prefer soft-delete + UPDATE policy)
+- [ ] No overly broad policies (e.g., `USING (true)` or `TO authenticated` without org scoping)
+- [ ] Do not write directly to `user_effective_permissions`, `organization_entitlements`, or `user_permission_overrides` — these are managed by DB triggers only
+- [ ] **Verify RLS**: run a cross-tenant isolation test — confirm org A cannot see org B's rows
+- [ ] **Verify fail-closed**: unauthenticated access must not return any rows and must not leak cross-tenant data — whether the DB returns zero rows or an auth error is acceptable; what is never acceptable is returning another tenant's data
+
+---
+
+### D. Permissions (RBAC V2 Compile Model)
+
+> Permissions are compiled into `user_effective_permissions` by DB triggers. Application code reads the compiled snapshot — it does not join roles at request time.
+
+All server-side permission checks must use `PermissionServiceV2` and the compiled permission snapshot; do not join roles/permissions at request time.
+
+- [ ] Create migration `[timestamp]_permissions_[module].sql`
+- [ ] Insert new slugs into `public.permissions` table:
+  ```sql
+  INSERT INTO public.permissions (slug, description, module)
+  VALUES ('yourmodule.read', 'Read yourmodule data', 'yourmodule')
+  ON CONFLICT (slug) DO NOTHING;
+  ```
+- [ ] Assign permissions to appropriate roles in `public.role_permissions`:
+  - Document which roles get which permissions (e.g., `org_owner` gets wildcard `yourmodule.*`, `org_member` gets `yourmodule.read` only)
+- [ ] Verify the slug in the migration exactly matches the constant in `src/lib/constants/permissions.ts` — copy-paste, don't retype
+- [ ] Verify `user_effective_permissions` re-compiles after migration (trigger should fire; if not, manually check the trigger definition)
+- [ ] **Wildcard consideration**: does `org_owner` need `yourmodule.*`? Document the decision:
+  ```
+  org_owner:    [ ] yourmodule.*   [ ] explicit slugs only
+  org_member:   [ ] yourmodule.*   [ ] yourmodule.read only   [ ] none
+  branch_admin: [ ] yourmodule.*   [ ] subset   [ ] none
+  ```
+- [ ] **Deny consideration**: are there actions that must be explicitly deniable even for owners? Document:
+  ```
+  Action requiring explicit deny capability: ___________________________________
+  ```
+- [ ] Prove by test: a user with `allow: ["yourmodule.*"]` and `deny: ["yourmodule.delete"]` cannot delete
+
+---
+
+### E. Entitlements (Compiled Snapshot)
+
+> Entitlements describe what an org may do based on its subscription. They are compiled into `organization_entitlements`. Do not query `subscription_plans` directly.
+
+**Guard placement rules (non-negotiable):**
+
+- **Server Components / layouts / route handlers**: use `requireModuleOrRedirect(MODULE_YOURMODULE)` when a redirect UX is appropriate, or `requireModuleAccess(MODULE_YOURMODULE)` when you want to throw instead.
+- **Server Actions**: always use `requireModuleAccess(MODULE_YOURMODULE)` — never `requireModuleOrRedirect` (calling `redirect()` inside a server action causes unintended navigation behavior). Wrap errors with `mapEntitlementError(error)` and return `{ success: false, error: mapped.message }`.
+
+- [ ] If module is plan-gated: create migration to add `MODULE_YOURMODULE` slug to `subscription_plans.enabled_modules` for the applicable plan(s), **following the exact pattern used in existing migrations in this repo** (column type and concatenation syntax may vary):
+  ```sql
+  -- Example only — verify column type and syntax against existing migrations before using:
+  -- UPDATE public.subscription_plans
+  --   SET enabled_modules = enabled_modules || '["your-module"]'::jsonb
+  --   WHERE name IN ('professional', 'enterprise');
+  ```
+- [ ] Verify `organization_entitlements.enabled_modules` is updated for test orgs after migration
+- [ ] If adding limits: add limit key to `subscription_plans.limits` JSONB for each plan tier
+- [ ] Verify `LIMIT_KEYS.YOURMODULE_MAX_X` constant matches the key string in `subscription_plans.limits`
+- [ ] `requireModuleOrRedirect(MODULE_YOURMODULE)` — use ONLY in Server Components and Route Handlers (never in Server Actions)
+- [ ] `requireModuleAccess(MODULE_YOURMODULE)` — use in layouts and Server Actions
+- [ ] `requireWithinLimit(LIMIT_KEYS.YOURMODULE_MAX_X)` — call BEFORE creating a new row for any limit-tracked resource
+- [ ] `checkLimit(LIMIT_KEYS.YOURMODULE_MAX_X)` — use for non-blocking UI feedback; if it fails or returns an indeterminate result, treat as limit reached (fail closed)
+- [ ] Confirm: if `organization_entitlements` row is missing, the module check **throws** — verify this is handled with `mapEntitlementError` in server actions
+- [ ] Fail-closed test: an org with no entitlements row cannot access any gated route or action
+
+---
+
+### F. Server Guards (Real Enforcement at Runtime)
+
+> The sidebar hiding a link is NOT enforcement. These guards are the enforcement layer.
+
+For every route in this module:
+
+- [ ] Route: `__________________________` has guard: `entitlements.requireModuleOrRedirect(MODULE_YOURMODULE)` in its Server Component
+- [ ] Route: `__________________________` has guard: `PermissionServiceV2.hasPermission(...)` for permission-gated operations
+- [ ] Route: `__________________________` has guard: _(repeat for each route)_
+
+For every server action in this module:
+
+- [ ] Action: `__________________________` calls `entitlements.requireModuleAccess(MODULE_YOURMODULE)` at the top (before any data access)
+- [ ] Action: `__________________________` calls `PermissionServiceV2.hasPermission(supabase, userId, orgId, PERMISSION_CONSTANT)` before any mutation
+- [ ] Action: `__________________________` wraps entitlement errors with `mapEntitlementError(error)` and returns `{ success: false, error: mapped.message }`
+- [ ] Action: `__________________________` _(repeat for each action)_
+
+Invariant checklist:
+
+- [ ] Verify: manually type the route URL while logged in as a user without module access → redirected or 403, not rendered
+- [ ] Verify: call a protected server action directly (simulate form POST) as a user without permission → returns `{ success: false }`, not data
+- [ ] Verify: no route in this module relies solely on sidebar visibility for access control
+
+---
+
+### G. Sidebar V2 (UX Integration)
+
+> The Sidebar V2 registry is the single source of truth for navigation. `ModuleConfig` is for widgets and metadata only — it does not drive sidebar rendering.
+
+- [ ] Add entry to `MAIN_NAV_ITEMS` or `FOOTER_NAV_ITEMS` in `src/lib/sidebar/v2/registry.ts`
+- [ ] Entry uses imported constants — not raw strings:
+  ```typescript
+  import { MODULE_YOURMODULE } from "@/lib/constants/modules";
+  import { YOURMODULE_READ } from "@/lib/constants/permissions";
+  // visibility: { requiresModules: [MODULE_YOURMODULE], requiresPermissions: [YOURMODULE_READ] }
+  ```
+- [ ] `iconKey` value exists in `src/lib/sidebar/v2/icon-map.ts` — if not, add it there
+- [ ] `titleKey` exists in `messages/en.json` and `messages/pl.json`; English `title` fallback is also set
+- [ ] `href` is set for active items; `href` is `undefined` for `coming_soon` items
+- [ ] If the module is not yet released: set `status: "coming_soon"` — item renders disabled, no href, regardless of user permissions
+- [ ] If the module should show as a teaser for upgrade: set `showWhenDisabled: true` — item appears disabled with `disabledReason: "entitlement"`
+- [ ] If the module has child links (group): parent carries `requiresModules`, children carry their individual `requiresPermissions`
+- [ ] Confirm parent pruning: if all children are pruned, the parent group disappears (no empty groups rendered)
+- [ ] Confirm: client renderer (`AppSidebar` in `dashboard-shell.tsx`) never reads `permissionSnapshot` or `entitlements` — it renders the model as-is
+- [ ] Confirm: `ModuleConfig` (`src/modules/[module]/config.ts`) does NOT contain navigation hrefs that duplicate registry entries
+
+---
+
+### H. Tests (TDD-First Proof)
+
+> Tests are not optional. "It works in the browser" is not a test.
+
+**Sidebar SSR Integration Tests** (`src/app/[locale]/dashboard/__tests__/sidebar-ssr.test.tsx`):
+
+- [ ] Test: module item appears when `enabled_modules` includes `"your-module"` and user has the required permission
+- [ ] Test: module item is **absent** when `enabled_modules` does NOT include `"your-module"` (free plan)
+- [ ] Test: module item is **absent** when user lacks the required permission slug
+- [ ] Test: `showWhenDisabled: true` item appears as disabled (not absent) when user lacks access
+- [ ] `afterEach(() => clearPermissionRegexCache())` is present in the test file
+
+**Unit Tests — Service Layer** (`src/server/services/__tests__/[module].service.test.ts`):
+
+- [ ] Happy path: correct org-scoped data is returned
+- [ ] Isolation: queries are scoped to `organization_id` (prove by checking the query argument in mock)
+- [ ] Soft-delete: deleted rows are excluded from list queries
+
+**Unit Tests — Server Actions** (`src/app/actions/__tests__/[module].test.ts`):
+
+- [ ] Guard test: action returns `{ success: false }` when user lacks module access
+- [ ] Guard test: action returns `{ success: false }` when user lacks required permission
+- [ ] Guard test: action returns `{ success: false }` when limit is exceeded
+- [ ] Happy path: action succeeds and returns correct shape
+
+> Mocked tests are allowed for service logic; RLS enforcement must be verified with real DB tests.
+
+**RLS Integration Tests** (real Postgres — not mocked):
+
+- [ ] Org A cannot SELECT rows belonging to Org B
+- [ ] Org A cannot UPDATE rows belonging to Org B
+- [ ] User without `yourmodule.create` permission cannot INSERT (RLS WITH CHECK blocks it)
+- [ ] Unauthenticated access returns no rows and leaks no cross-tenant data (fail closed; error vs empty is acceptable, cross-tenant exposure is not)
+
+**Negative / Fail-Closed Tests**:
+
+- [ ] Missing entitlements → module access throws, not silently allows
+- [ ] Missing permission → action returns error, not data
+- [ ] Limit check failure (any error or indeterminate result) → treated as limit reached in calling code (fail closed)
+
+**Final Build Gate**:
+
+- [ ] `npm run type-check` — zero errors
+- [ ] `npx vitest run` — all tests pass (run full suite, not just this module's tests)
+- [ ] `npm run build` — succeeds with no errors
+
+---
+
+### I. i18n / Metadata / UX Finishing
+
+- [ ] `messages/en.json` — all required keys added (sidebar title, page titles, error messages)
+- [ ] `messages/pl.json` — all keys translated (or placeholder added)
+- [ ] `titleKey` in sidebar registry resolves correctly — verify with a test or browser check
+- [ ] Error messages returned from server actions use `mapEntitlementError(error).message` — not raw error strings
+- [ ] Toast notifications use `react-toastify` only — no `sonner` imports
+- [ ] `toast.success`, `toast.error`, `toast.info`, `toast.warning` — correct variants used
+- [ ] Loading states: `loading.tsx` exists and uses a skeleton appropriate for the module
+- [ ] Error boundary: `error.tsx` exists and provides a recoverable error state (not a blank page)
+- [ ] Accessibility: interactive elements have accessible labels (button text, aria-label on icon-only buttons)
+
+---
+
+### J. Release / Verification Checklist
+
+- [ ] `npm run type-check` → clean
+- [ ] `npx vitest run` → all passing (zero skipped tests that matter)
+- [ ] `npm run build` → succeeds
+- [ ] Kill dev server: `pnpm dev` is terminated (per project convention)
+- [ ] **Smoke — module access gate**: log in as a free-plan user → direct URL to gated route → redirected to `/upgrade` (or equivalent), not rendered
+- [ ] **Smoke — permission gate**: log in as a user without required permission → direct URL → blocked server-side
+- [ ] **Smoke — server action gate**: submit a protected form as an unauthorized user (use browser devtools to bypass client UI) → action returns `{ success: false }`, not data
+- [ ] **Smoke — sidebar UX**: log in as authorized user → module appears in sidebar; log in as unauthorized user → module does not appear
+- [ ] **Smoke — coming_soon** (if applicable): item renders disabled with no href, not navigable
+- [ ] No TypeScript `any` types introduced by this module
+- [ ] No `console.log` / debug statements left in production paths
+- [ ] No new ESLint warnings introduced that are suppressed with `// eslint-disable`
+- [ ] **Service role key is NOT used in any request-time code** (pages, layouts, server actions, route handlers). Service role is allowed only in integration tests, seed scripts, and CLI tooling.
+
+**Diff discipline (PR / output gate):**
+
+- [ ] Only files necessary for this module were changed — no unrelated refactors or formatting-only edits in other modules
+- [ ] No commented-out code or debug artifacts left in the diff
+- [ ] PR/commit scope matches the module spec — no side-creep into unrelated systems
+- [ ] At least one reviewer verifies RLS policies and guard placement
+
+---
+
+### K. Entitlements Gate (MANDATORY IF MODULE IS PLAN-GATED)
+
+> Skip this section only if the module is available on all plans without gating.
+
+- [ ] Module slug constant added to `src/lib/constants/modules.ts`
+- [ ] No raw module slug strings anywhere in TypeScript code for this module
+- [ ] Subscription plan or add-on updated to include the module slug (migration applied)
+- [ ] Verified: compiled `organization_entitlements.enabled_modules` includes the slug for an entitled org (query the DB)
+- [ ] Verified: slug is NOT present in `organization_entitlements.enabled_modules` for a free/unentitled org
+- [ ] Page-level server guard implemented: `entitlements.requireModuleAccess(MODULE_YOURMODULE)` or `requireModuleOrRedirect(MODULE_YOURMODULE)` in every page
+- [ ] All server actions enforce module access at top (before any data access)
+
+---
+
+### L. Sidebar V2 Registry Integration (MANDATORY IF MODULE HAS UI ROUTES)
+
+> Skip this section only if the module has no user-facing dashboard routes.
+
+- [ ] Registry entry added to `MAIN_NAV_ITEMS` or `FOOTER_NAV_ITEMS` in `src/lib/sidebar/v2/registry.ts`
+- [ ] Entry uses module and permission constants only — no raw strings
+- [ ] `visibility.requiresModules` set to `[MODULE_YOURMODULE]` (if plan-gated)
+- [ ] `visibility.requiresPermissions` or `requiresAnyPermissions` set using permission constants
+- [ ] SSR sidebar integration test updated or added in `src/app/[locale]/dashboard/__tests__/sidebar-ssr.test.tsx`
+- [ ] Verified: org owner / entitled user sees the sidebar item
+- [ ] Verified: member without permission does NOT see the sidebar item
+
+---
+
+### M. Permission Slug Integrity Verification
+
+- [ ] All permission constants in `src/lib/constants/permissions.ts` exactly match slugs in the `public.permissions` DB table (copy-paste match, verified by query)
+- [ ] No permission slug used in application code is absent from the DB `permissions` table
+- [ ] No outdated or removed slugs referenced anywhere in this module's TypeScript
+- [ ] No raw permission strings in any `.ts` or `.tsx` file for this module (grep confirms zero hits)
+
+---
+
+### N. UI Responsiveness Verification
+
+- [ ] Verified layout at 390px viewport width — no horizontal overflow
+- [ ] Primary actions (create, save, submit) are reachable and tappable on mobile
+- [ ] Sidebar collapse/expand state does not obscure module content on small screens
+- [ ] No layout breakpoints cause primary actions or content to be hidden or unreachable
+- [ ] Tables or data-dense views have a mobile-appropriate fallback (horizontal scroll or card layout)
+
+---
+
+## 5. Definition of Done (Enterprise-Grade Gate)
+
+A module is **not complete** unless every statement below is verifiably true:
+
+- [ ] **Constants**: module slug constant exists in `modules.ts`; all permission constants exist in `permissions.ts`; `PermissionSlug` and `ModuleSlug` union types are updated
+- [ ] **No raw strings**: grep of `src/` finds zero raw permission or module strings in TypeScript files for this module
+- [ ] **Database**: all tables have `ENABLE ROW LEVEL SECURITY` (and `FORCE ROW LEVEL SECURITY` for sensitive tables)
+- [ ] **RLS policies**: SELECT, INSERT, UPDATE policies exist and are tenant-scoped using `is_org_member()` and `has_permission()`
+- [ ] **RLS tests**: cross-tenant isolation is proven by a test, not assumed
+- [ ] **Permission rows**: new slugs are inserted into `public.permissions` table via migration and assigned to roles in `public.role_permissions`
+- [ ] **Entitlements**: if module is plan-gated, it is listed in `subscription_plans.enabled_modules` for the correct plans; the compiled `organization_entitlements` snapshot reflects this
+- [ ] **Server guards**: every route has an `entitlements.requireModuleOrRedirect()` or `requireModuleAccess()` call; every mutating server action has both a module check and a permission check
+- [ ] **Sidebar registry**: entry exists in `src/lib/sidebar/v2/registry.ts`; uses constants, not raw strings; `iconKey` is valid; `titleKey` resolves
+- [ ] **No client-side authorization logic**: `usePermissions()` is used for UX only; no route or data is protected solely by client-side checks
+- [ ] **Tests pass**: `npx vitest run` is clean; sidebar SSR tests cover the new module; guard tests cover fail-closed cases; RLS tests cover isolation
+- [ ] **Type-check passes**: `npm run type-check` is clean
+- [ ] **Build passes**: `npm run build` succeeds
+- [ ] **i18n keys exist**: all `titleKey` values and user-facing strings have entries in both `en.json` and `pl.json`
+- [ ] **No direct writes to compiled tables**: no application code writes to `user_effective_permissions`, `organization_entitlements`, or `user_permission_overrides`
+- [ ] **No service role at runtime**: service role key does not appear in any page, layout, server action, or route handler for this module; allowed only in tests/seed/CLI
+- [ ] **MODULE.md created/updated and fully populated** (entitlements, permissions, sidebar registry, DB+RLS, tests, files changed). No placeholders.
+
+---
+
+## 6. Common Failure Modes (Anti-Footguns)
+
+These are the most common "looks done but isn't" mistakes. Check each before declaring done.
+
+- [ ] **Route exists but no server-side guard** — sidebar hides the link, but a user who types the URL directly gets the page. Verify by direct navigation without the sidebar.
+
+- [ ] **Sidebar shows the link but module is not enabled in the plan** — the registry entry has `requiresModules` set, but the slug was never added to `subscription_plans.enabled_modules`. Result: the link appears for all users on all plans. Fix: run the entitlements migration.
+
+- [ ] **Permission constant added to `permissions.ts` but not inserted into the DB** (or vice versa) — `PermissionServiceV2` checks the compiled `user_effective_permissions` table. If the slug was never inserted into `public.permissions` and assigned via `role_permissions`, no user will ever have it, even with a wildcard role. Fix: verify the migration ran and the slug exists in `SELECT * FROM public.permissions WHERE slug = '...'`.
+
+- [ ] **RLS enabled but not FORCE RLS on a sensitive table** — service role or table owner can bypass RLS. Fix: use `FORCE ROW LEVEL SECURITY` for tables with PII, audit logs, billing data, or permission data.
+
+- [ ] **Wrong policy command type** — UPDATE policy is missing a `WITH CHECK` clause; INSERT policy uses `USING` instead of `WITH CHECK`. Both silently allow the wrong behavior. Fix: review each policy with `\d+ your_table` in psql.
+
+- [ ] **Limits defined in `LIMIT_KEYS` but never enforced** — `requireWithinLimit` is not called before the create action. The limit key exists, the entitlement has the value, but the enforcement is missing. Fix: add the guard to every server action that creates a limit-tracked resource.
+
+- [ ] **`coming_soon` item accidentally has an `href`** — item is disabled visually but navigable. Fix: `coming_soon` items must have `href: undefined`.
+
+- [ ] **`ModuleConfig` navigation items duplicate sidebar registry entries** — developer added routes to `config.ts` expecting them to appear in the sidebar, but `ModuleConfig` does not drive the sidebar. Fix: all navigation belongs in `src/lib/sidebar/v2/registry.ts` only.
+
+- [ ] **Raw module or permission strings in TypeScript** — developer bypassed constants "just for this one case." These silently drift when slugs are renamed. Fix: import the constant. If the constant doesn't exist yet, create it.
+
+- [ ] **`buildSidebarModel` (cached) used in tests** — React `cache()` does not reset between tests; test isolation is broken. Fix: always use `buildSidebarModelUncached` in test files.
+
+- [ ] **`clearPermissionRegexCache()` missing from `afterEach`** — regex cache from test N leaks into test N+1, causing false positives or false negatives. Fix: add `afterEach(() => clearPermissionRegexCache())` to every test file that calls `checkPermission` or `buildSidebarModelUncached`.
+
+- [ ] **Server action uses `requireModuleOrRedirect`** — `redirect()` inside a server action produces unintended behavior (navigation side-effect instead of error return). Fix: use `requireModuleAccess()` in actions; use `requireModuleOrRedirect()` only in Server Components and Route Handlers.
+
+- [ ] **Client component re-evaluates permissions** — `usePermissions()` is used to gate data fetching, not just UI visibility. A determined user can manipulate client state. Fix: server actions must independently verify permissions; client checks are UX-only.
+
+- [ ] **TypeScript types not regenerated after migration** — new tables exist in Postgres but not in `supabase/types/types.ts`. Service code uses `any` or type assertions. Fix: run `npm run supabase:gen:types` after every migration.
+
+---
+
+_Checklist version: February 2026 — aligned with Permissions V2, Entitlements V2, Sidebar V2_
+_Architecture invariants sourced from: PERMISSIONS_ARCHITECTURE, ENTITLEMENTS_ARCHITECTURE, SIDEBAR_V2, MODULE_DEVELOPMENT_GUIDE_

--- a/apps/web/src/modules/planning/config.ts
+++ b/apps/web/src/modules/planning/config.ts
@@ -1,0 +1,13 @@
+import { ModuleConfig } from "@/lib/types/module";
+
+export const PLANNING_MODULE_THEME_COLOR = "#0d9488"; // Teal
+
+export const planningModule: ModuleConfig = {
+  id: "planning",
+  slug: "planning",
+  title: "modules.planning.title",
+  icon: "CheckSquare",
+  description: "modules.planning.description",
+  color: PLANNING_MODULE_THEME_COLOR,
+  items: [], // Navigation is driven by the Sidebar V2 registry
+};

--- a/apps/web/src/server/services/planning-tasks.service.ts
+++ b/apps/web/src/server/services/planning-tasks.service.ts
@@ -1,0 +1,325 @@
+import "server-only";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { DataViewListParams, PaginatedResult } from "@/lib/data-view/types";
+import type {
+  TaskStatus,
+  TaskPriority,
+  TaskListFilters,
+  CreateTaskInput,
+  UpdateTaskInput,
+  ChangeTaskStatusInput,
+  AssignTaskInput,
+} from "@/lib/validations/planning";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface PlanningTaskListRow {
+  id: string;
+  org_id: string;
+  title: string;
+  status: TaskStatus;
+  priority: TaskPriority;
+  branch_id: string | null;
+  assigned_to: string | null;
+  assignee_name: string | null;
+  assignee_email: string | null;
+  created_by: string;
+  creator_name: string | null;
+  creator_email: string | null;
+  due_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface PlanningTaskDetail extends PlanningTaskListRow {
+  description: string | null;
+  deleted_at: string | null;
+}
+
+type ActionResult<T> = { success: true; data: T } | { success: false; error: string };
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+export const PlanningTasksService = {
+  async listForDataView(
+    supabase: SupabaseClient,
+    orgId: string,
+    params: DataViewListParams,
+    filters: TaskListFilters = {}
+  ): Promise<ActionResult<PaginatedResult<PlanningTaskListRow>>> {
+    try {
+      const page = params.page ?? 1;
+      const pageSize = params.pageSize ?? 20;
+      const offset = (page - 1) * pageSize;
+
+      let query = supabase
+        .from("planning_tasks")
+        .select(
+          `
+          id, org_id, title, status, priority, branch_id, assigned_to,
+          due_at, created_by, created_at, updated_at,
+          assignee:profiles!planning_tasks_assigned_to_fkey(first_name, last_name, email),
+          creator:profiles!planning_tasks_created_by_fkey(first_name, last_name, email)
+        `,
+          { count: "exact" }
+        )
+        .eq("org_id", orgId)
+        .is("deleted_at", null);
+
+      if (filters.status?.length) {
+        query = query.in("status", filters.status);
+      }
+      if (filters.priority?.length) {
+        query = query.in("priority", filters.priority);
+      }
+      if (filters.branch_id !== undefined) {
+        if (filters.branch_id === null) {
+          query = query.is("branch_id", null);
+        } else {
+          query = query.eq("branch_id", filters.branch_id);
+        }
+      }
+      if (filters.assigned_to !== undefined) {
+        if (filters.assigned_to === null) {
+          query = query.is("assigned_to", null);
+        } else {
+          query = query.eq("assigned_to", filters.assigned_to);
+        }
+      }
+      if (filters.search) {
+        query = query.ilike("title", `%${filters.search}%`);
+      }
+
+      const sortField = params.sort?.field ?? "created_at";
+      const sortDir = params.sort?.direction === "asc";
+      query = query.order(sortField, { ascending: sortDir }).range(offset, offset + pageSize - 1);
+
+      const { data, error, count } = await query;
+
+      if (error) return { success: false, error: error.message };
+
+      const rows: PlanningTaskListRow[] = (data ?? []).map((r) => {
+        const assignee = Array.isArray(r.assignee) ? r.assignee[0] : r.assignee;
+        const creator = Array.isArray(r.creator) ? r.creator[0] : r.creator;
+        return {
+          id: r.id,
+          org_id: r.org_id,
+          title: r.title,
+          status: r.status as TaskStatus,
+          priority: r.priority as TaskPriority,
+          branch_id: r.branch_id ?? null,
+          assigned_to: r.assigned_to ?? null,
+          assignee_name: assignee
+            ? [assignee.first_name, assignee.last_name].filter(Boolean).join(" ") || null
+            : null,
+          assignee_email: assignee?.email ?? null,
+          created_by: r.created_by,
+          creator_name: creator
+            ? [creator.first_name, creator.last_name].filter(Boolean).join(" ") || null
+            : null,
+          creator_email: creator?.email ?? null,
+          due_at: r.due_at ?? null,
+          created_at: r.created_at,
+          updated_at: r.updated_at,
+        };
+      });
+
+      return {
+        success: true,
+        data: {
+          rows,
+          totalCount: count ?? 0,
+          page,
+          pageSize,
+        },
+      };
+    } catch (e) {
+      return { success: false, error: e instanceof Error ? e.message : "Unexpected error" };
+    }
+  },
+
+  async getDetail(
+    supabase: SupabaseClient,
+    orgId: string,
+    taskId: string
+  ): Promise<ActionResult<PlanningTaskDetail>> {
+    try {
+      const { data, error } = await supabase
+        .from("planning_tasks")
+        .select(
+          `
+          id, org_id, title, description, status, priority, branch_id, assigned_to,
+          due_at, created_by, created_at, updated_at, deleted_at,
+          assignee:profiles!planning_tasks_assigned_to_fkey(first_name, last_name, email),
+          creator:profiles!planning_tasks_created_by_fkey(first_name, last_name, email)
+        `
+        )
+        .eq("org_id", orgId)
+        .eq("id", taskId)
+        .is("deleted_at", null)
+        .single();
+
+      if (error) return { success: false, error: error.message };
+      if (!data) return { success: false, error: "Not found" };
+
+      const assignee = Array.isArray(data.assignee) ? data.assignee[0] : data.assignee;
+      const creator = Array.isArray(data.creator) ? data.creator[0] : data.creator;
+
+      return {
+        success: true,
+        data: {
+          id: data.id,
+          org_id: data.org_id,
+          title: data.title,
+          description: data.description ?? null,
+          status: data.status as TaskStatus,
+          priority: data.priority as TaskPriority,
+          branch_id: data.branch_id ?? null,
+          assigned_to: data.assigned_to ?? null,
+          assignee_name: assignee
+            ? [assignee.first_name, assignee.last_name].filter(Boolean).join(" ") || null
+            : null,
+          assignee_email: assignee?.email ?? null,
+          created_by: data.created_by,
+          creator_name: creator
+            ? [creator.first_name, creator.last_name].filter(Boolean).join(" ") || null
+            : null,
+          creator_email: creator?.email ?? null,
+          due_at: data.due_at ?? null,
+          created_at: data.created_at,
+          updated_at: data.updated_at,
+          deleted_at: data.deleted_at ?? null,
+        },
+      };
+    } catch (e) {
+      return { success: false, error: e instanceof Error ? e.message : "Unexpected error" };
+    }
+  },
+
+  async create(
+    supabase: SupabaseClient,
+    orgId: string,
+    userId: string,
+    input: CreateTaskInput
+  ): Promise<ActionResult<PlanningTaskDetail>> {
+    try {
+      const { data, error } = await supabase
+        .from("planning_tasks")
+        .insert({
+          org_id: orgId,
+          created_by: userId,
+          title: input.title,
+          description: input.description ?? null,
+          status: input.status,
+          priority: input.priority,
+          branch_id: input.branch_id ?? null,
+          assigned_to: input.assigned_to ?? null,
+          due_at: input.due_at ?? null,
+        })
+        .select("id")
+        .single();
+
+      if (error) return { success: false, error: error.message };
+
+      return PlanningTasksService.getDetail(supabase, orgId, data.id);
+    } catch (e) {
+      return { success: false, error: e instanceof Error ? e.message : "Unexpected error" };
+    }
+  },
+
+  async update(
+    supabase: SupabaseClient,
+    orgId: string,
+    input: UpdateTaskInput
+  ): Promise<ActionResult<PlanningTaskDetail>> {
+    try {
+      const { error } = await supabase
+        .from("planning_tasks")
+        .update({
+          title: input.title,
+          description: input.description ?? null,
+          status: input.status,
+          priority: input.priority,
+          branch_id: input.branch_id ?? null,
+          assigned_to: input.assigned_to ?? null,
+          due_at: input.due_at ?? null,
+        })
+        .eq("id", input.id)
+        .eq("org_id", orgId)
+        .is("deleted_at", null);
+
+      if (error) return { success: false, error: error.message };
+
+      return PlanningTasksService.getDetail(supabase, orgId, input.id);
+    } catch (e) {
+      return { success: false, error: e instanceof Error ? e.message : "Unexpected error" };
+    }
+  },
+
+  async changeStatus(
+    supabase: SupabaseClient,
+    orgId: string,
+    input: ChangeTaskStatusInput
+  ): Promise<ActionResult<PlanningTaskDetail>> {
+    try {
+      const { error } = await supabase
+        .from("planning_tasks")
+        .update({ status: input.status })
+        .eq("id", input.id)
+        .eq("org_id", orgId)
+        .is("deleted_at", null);
+
+      if (error) return { success: false, error: error.message };
+
+      return PlanningTasksService.getDetail(supabase, orgId, input.id);
+    } catch (e) {
+      return { success: false, error: e instanceof Error ? e.message : "Unexpected error" };
+    }
+  },
+
+  async assign(
+    supabase: SupabaseClient,
+    orgId: string,
+    input: AssignTaskInput
+  ): Promise<ActionResult<PlanningTaskDetail>> {
+    try {
+      const { error } = await supabase
+        .from("planning_tasks")
+        .update({ assigned_to: input.assigned_to })
+        .eq("id", input.id)
+        .eq("org_id", orgId)
+        .is("deleted_at", null);
+
+      if (error) return { success: false, error: error.message };
+
+      return PlanningTasksService.getDetail(supabase, orgId, input.id);
+    } catch (e) {
+      return { success: false, error: e instanceof Error ? e.message : "Unexpected error" };
+    }
+  },
+
+  async softDelete(
+    supabase: SupabaseClient,
+    orgId: string,
+    taskId: string
+  ): Promise<ActionResult<void>> {
+    try {
+      const { error } = await supabase
+        .from("planning_tasks")
+        .update({ deleted_at: new Date().toISOString() })
+        .eq("id", taskId)
+        .eq("org_id", orgId)
+        .is("deleted_at", null);
+
+      if (error) return { success: false, error: error.message };
+
+      return { success: true, data: undefined };
+    } catch (e) {
+      return { success: false, error: e instanceof Error ? e.message : "Unexpected error" };
+    }
+  },
+};

--- a/apps/web/supabase/migrations/20260601200000_planning_module.sql
+++ b/apps/web/supabase/migrations/20260601200000_planning_module.sql
@@ -1,0 +1,128 @@
+-- ===========================================================================
+-- Planning Module Migration
+-- ===========================================================================
+
+-- Part 1: Permission rows
+INSERT INTO public.permissions (slug, name, category, action)
+VALUES
+  ('planning.*',              'Planning Wildcard',            'planning', '*'),
+  ('planning.read',           'Planning Read',                'planning', 'read'),
+  ('planning.tasks.read',     'Planning Tasks Read',          'planning', 'read'),
+  ('planning.tasks.create',   'Planning Tasks Create',        'planning', 'create'),
+  ('planning.tasks.update',   'Planning Tasks Update',        'planning', 'update'),
+  ('planning.tasks.delete',   'Planning Tasks Delete',        'planning', 'delete'),
+  ('planning.tasks.assign',   'Planning Tasks Assign',        'planning', 'assign'),
+  ('module.planning.access',  'Planning Module Access',       'module',   'access')
+ON CONFLICT (slug) DO NOTHING;
+
+-- Part 2: Role-permission seeding
+DO $$
+DECLARE
+  v_owner_id  UUID;
+  v_member_id UUID;
+  v_perm_id   UUID;
+BEGIN
+  SELECT id INTO v_owner_id  FROM public.roles WHERE name = 'org_owner'  AND is_basic = true LIMIT 1;
+  SELECT id INTO v_member_id FROM public.roles WHERE name = 'org_member' AND is_basic = true LIMIT 1;
+
+  IF v_owner_id IS NOT NULL THEN
+    SELECT id INTO v_perm_id FROM public.permissions WHERE slug = 'planning.*';
+    IF v_perm_id IS NOT NULL THEN
+      INSERT INTO public.role_permissions (role_id, permission_id) VALUES (v_owner_id, v_perm_id) ON CONFLICT DO NOTHING;
+    END IF;
+  END IF;
+
+  IF v_member_id IS NOT NULL THEN
+    FOREACH v_perm_id IN ARRAY ARRAY(
+      SELECT id FROM public.permissions
+      WHERE slug IN ('planning.read','planning.tasks.read','planning.tasks.create','planning.tasks.update','module.planning.access')
+    ) LOOP
+      INSERT INTO public.role_permissions (role_id, permission_id) VALUES (v_member_id, v_perm_id) ON CONFLICT DO NOTHING;
+    END LOOP;
+  END IF;
+END;
+$$;
+
+-- Part 3: Subscription plan updates
+UPDATE public.subscription_plans
+SET enabled_modules = array_append(enabled_modules, 'planning'), updated_at = now()
+WHERE name IN ('professional', 'enterprise') AND NOT ('planning' = ANY(enabled_modules));
+
+-- Part 4: planning_tasks table
+CREATE TABLE IF NOT EXISTS public.planning_tasks (
+  id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id UUID        NOT NULL REFERENCES public.organizations(id)  ON DELETE CASCADE,
+  branch_id       UUID        REFERENCES public.branches(id)                ON DELETE SET NULL,
+  title           TEXT        NOT NULL CHECK (char_length(title) > 0 AND char_length(title) <= 500),
+  description_plain TEXT,
+  description_rich  JSONB,
+  status          TEXT        NOT NULL DEFAULT 'open'
+                    CHECK (status IN ('open', 'in_progress', 'completed')),
+  priority        TEXT        NOT NULL DEFAULT 'normal'
+                    CHECK (priority IN ('low', 'normal', 'high', 'urgent')),
+  assigned_to     UUID        REFERENCES public.users(id)  ON DELETE SET NULL,
+  created_by      UUID        NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  updated_by      UUID        REFERENCES public.users(id)  ON DELETE SET NULL,
+  completed_at    TIMESTAMPTZ,
+  due_at          TIMESTAMPTZ,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  deleted_at      TIMESTAMPTZ
+);
+
+CREATE OR REPLACE TRIGGER planning_tasks_updated_at
+  BEFORE UPDATE ON public.planning_tasks
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+
+CREATE INDEX IF NOT EXISTS planning_tasks_org_idx          ON public.planning_tasks (organization_id)                WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS planning_tasks_org_status_idx   ON public.planning_tasks (organization_id, status)         WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS planning_tasks_org_assigned_idx ON public.planning_tasks (organization_id, assigned_to)    WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS planning_tasks_org_created_idx  ON public.planning_tasks (organization_id, created_at DESC) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS planning_tasks_branch_idx       ON public.planning_tasks (branch_id)                       WHERE branch_id IS NOT NULL AND deleted_at IS NULL;
+
+-- Part 5: planning_task_comments table
+CREATE TABLE IF NOT EXISTS public.planning_task_comments (
+  id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  task_id         UUID        NOT NULL REFERENCES public.planning_tasks(id)  ON DELETE CASCADE,
+  organization_id UUID        NOT NULL REFERENCES public.organizations(id)   ON DELETE CASCADE,
+  body            TEXT        NOT NULL CHECK (char_length(body) > 0),
+  body_rich       JSONB,
+  created_by      UUID        NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  deleted_at      TIMESTAMPTZ
+);
+
+CREATE OR REPLACE TRIGGER planning_task_comments_updated_at
+  BEFORE UPDATE ON public.planning_task_comments
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+
+CREATE INDEX IF NOT EXISTS planning_task_comments_task_idx ON public.planning_task_comments (task_id) WHERE deleted_at IS NULL;
+
+-- Part 6: RLS
+ALTER TABLE public.planning_tasks         ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.planning_task_comments ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "planning_tasks_select" ON public.planning_tasks FOR SELECT TO authenticated
+  USING (is_org_member(organization_id) AND has_permission(organization_id, 'planning.tasks.read'));
+
+CREATE POLICY "planning_tasks_insert" ON public.planning_tasks FOR INSERT TO authenticated
+  WITH CHECK (is_org_member(organization_id) AND has_permission(organization_id, 'planning.tasks.create'));
+
+CREATE POLICY "planning_tasks_update" ON public.planning_tasks FOR UPDATE TO authenticated
+  USING (is_org_member(organization_id) AND ((deleted_at IS NULL AND has_permission(organization_id, 'planning.tasks.update')) OR has_permission(organization_id, 'planning.tasks.delete')))
+  WITH CHECK (is_org_member(organization_id) AND ((deleted_at IS NULL AND has_permission(organization_id, 'planning.tasks.update')) OR has_permission(organization_id, 'planning.tasks.delete')));
+
+CREATE POLICY "planning_tasks_delete" ON public.planning_tasks FOR DELETE TO authenticated USING (false);
+
+CREATE POLICY "planning_task_comments_select" ON public.planning_task_comments FOR SELECT TO authenticated
+  USING (is_org_member(organization_id) AND has_permission(organization_id, 'planning.tasks.read'));
+
+CREATE POLICY "planning_task_comments_insert" ON public.planning_task_comments FOR INSERT TO authenticated
+  WITH CHECK (is_org_member(organization_id) AND has_permission(organization_id, 'planning.tasks.create'));
+
+CREATE POLICY "planning_task_comments_update" ON public.planning_task_comments FOR UPDATE TO authenticated
+  USING (is_org_member(organization_id) AND has_permission(organization_id, 'planning.tasks.update'))
+  WITH CHECK (is_org_member(organization_id) AND has_permission(organization_id, 'planning.tasks.update'));
+
+CREATE POLICY "planning_task_comments_delete" ON public.planning_task_comments FOR DELETE TO authenticated USING (false);

--- a/packages/contracts/src/modules.ts
+++ b/packages/contracts/src/modules.ts
@@ -36,6 +36,7 @@ export const MODULE_ANALYTICS = "analytics" as const;
 export const MODULE_DEVELOPMENT = "development" as const;
 export const MODULE_WORKSHOP = "workshop" as const;
 export const MODULE_HELPDESK = "help-desk" as const;
+export const MODULE_PLANNING = "planning" as const;
 
 // Tools Module (Always available — no plan gating; not in enabled_modules)
 export const MODULE_TOOLS = "tools" as const;
@@ -60,6 +61,7 @@ export type ModuleSlug =
   | typeof MODULE_DEVELOPMENT
   | typeof MODULE_WORKSHOP
   | typeof MODULE_HELPDESK
+  | typeof MODULE_PLANNING
   | typeof MODULE_TOOLS
   | typeof MODULE_ADMIN;
 
@@ -85,6 +87,7 @@ export const PREMIUM_MODULES = [
   MODULE_DEVELOPMENT,
   MODULE_WORKSHOP,
   MODULE_HELPDESK,
+  MODULE_PLANNING,
 ] as const;
 
 /**

--- a/packages/contracts/src/permissions.ts
+++ b/packages/contracts/src/permissions.ts
@@ -187,6 +187,25 @@ export const HELPDESK_TICKETS_MANAGE = "helpdesk.tickets.manage" as const;
 export const HELPDESK_TICKET_TYPES_MANAGE = "helpdesk.ticket-types.manage" as const;
 export const HELPDESK_SETTINGS_MANAGE = "helpdesk.settings.manage" as const;
 
+// Planning Permissions (org-scoped — Professional/Enterprise)
+// planning.*              — wildcard for org_owner; compiler expands to all concrete planning.X slugs
+// planning.read           — view the Planning module shell and overview
+// planning.tasks.read     — list and view tasks in the org
+// planning.tasks.create   — create new tasks
+// planning.tasks.update   — edit task details, change status, priority
+// planning.tasks.delete   — soft-delete tasks
+// planning.tasks.assign   — assign tasks to other org members
+// module.planning.access  — user-level gate; admins assign to custom roles
+// Seeded in migration 20260601200000_planning_module.sql.
+export const MODULE_PLANNING_ACCESS = "module.planning.access" as const;
+export const PLANNING_WILDCARD = "planning.*" as const;
+export const PLANNING_READ = "planning.read" as const;
+export const PLANNING_TASKS_READ = "planning.tasks.read" as const;
+export const PLANNING_TASKS_CREATE = "planning.tasks.create" as const;
+export const PLANNING_TASKS_UPDATE = "planning.tasks.update" as const;
+export const PLANNING_TASKS_DELETE = "planning.tasks.delete" as const;
+export const PLANNING_TASKS_ASSIGN = "planning.tasks.assign" as const;
+
 // Tools Permissions (user-scoped — always available, no plan gating)
 // tools.read  — view the tools catalog, tool detail pages, and personal enabled-tools list
 // tools.manage — enable, disable, pin, and update settings for tools
@@ -300,6 +319,14 @@ export type PermissionSlug =
   | typeof HELPDESK_TICKETS_MANAGE
   | typeof HELPDESK_TICKET_TYPES_MANAGE
   | typeof HELPDESK_SETTINGS_MANAGE
+  | typeof MODULE_PLANNING_ACCESS
+  | typeof PLANNING_WILDCARD
+  | typeof PLANNING_READ
+  | typeof PLANNING_TASKS_READ
+  | typeof PLANNING_TASKS_CREATE
+  | typeof PLANNING_TASKS_UPDATE
+  | typeof PLANNING_TASKS_DELETE
+  | typeof PLANNING_TASKS_ASSIGN
   | typeof PERMISSION_TOOLS_READ
   | typeof PERMISSION_TOOLS_MANAGE
   | typeof PERMISSION_WDD_MATCHER_READ
@@ -393,6 +420,14 @@ export const ALL_PERMISSION_SLUGS: PermissionSlug[] = [
   HELPDESK_TICKETS_MANAGE,
   HELPDESK_TICKET_TYPES_MANAGE,
   HELPDESK_SETTINGS_MANAGE,
+  MODULE_PLANNING_ACCESS,
+  PLANNING_WILDCARD,
+  PLANNING_READ,
+  PLANNING_TASKS_READ,
+  PLANNING_TASKS_CREATE,
+  PLANNING_TASKS_UPDATE,
+  PLANNING_TASKS_DELETE,
+  PLANNING_TASKS_ASSIGN,
   PERMISSION_TOOLS_READ,
   PERMISSION_TOOLS_MANAGE,
   PERMISSION_WDD_MATCHER_READ,


### PR DESCRIPTION
- MODULE_PLANNING constant + 8 permission constants in contracts
- DB migration: planning_tasks + planning_task_comments tables, RLS, permissions, role seeding
- PlanningTasksService: list/detail/create/update/changeStatus/assign/softDelete
- Zod validations: createTaskSchema, updateTaskSchema, changeTaskStatusSchema, assignTaskSchema
- 7 server actions in app/actions/planning/index.ts
- SSR routes: /dashboard/planning, /planning/tasks (DataView), /planning/boards (placeholder)
- Sidebar registry: planning group with overview/tasks/boards (before analytics)
- i18n routing: 3 routes with Polish translations (/planowanie)
- en.json + pl.json: full planning module message keys
- checkSquare + layoutGrid icons added to IconKey and ICON_MAP
- Module config, MODULE.md, MODULE_CHECKLIST.md in src/modules/planning/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Planning dashboard section with task management capabilities
  * Tasks page with search, filtering, sorting, and pagination
  * Boards page (coming soon)
  * Multi-language support (English and Polish)

* **Documentation**
  * Added Planning module reference guide

* **Chores**
  * Configured database and access control settings for Planning features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->