### PR TITLE
feat(planning): implement task creation, detail panel, and activity t…

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3193,6 +3193,32 @@
         "tasks": "Tasks",
         "boards": "Kanban Boards"
       },
+      "tasks": {
+        "createTask": "Create task",
+        "taskCreated": "Task created",
+        "taskUpdated": "Task updated",
+        "assignedTo": "Assigned to",
+        "unassigned": "Unassigned",
+        "status": "Status",
+        "priority": "Priority",
+        "dueDate": "Due date",
+        "open": "Open",
+        "inProgress": "In Progress",
+        "completed": "Completed",
+        "cancelled": "Cancelled",
+        "low": "Low",
+        "normal": "Normal",
+        "high": "High",
+        "urgent": "Urgent",
+        "activity": "Activity",
+        "noActivity": "No activity yet",
+        "markInProgress": "Mark in progress",
+        "complete": "Complete",
+        "reopen": "Reopen",
+        "cancelTask": "Cancel task",
+        "archiveTask": "Archive task",
+        "createAndAssignToMe": "Create & assign to me"
+      },
       "empty": {
         "noData": "No tasks yet",
         "noDataDescription": "Create a task to get started."

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -3164,6 +3164,32 @@
         "tasks": "Zadania",
         "boards": "Tablice Kanban"
       },
+      "tasks": {
+        "createTask": "Utwórz zadanie",
+        "taskCreated": "Zadanie utworzone",
+        "taskUpdated": "Zadanie zaktualizowane",
+        "assignedTo": "Przypisane do",
+        "unassigned": "Nieprzypisane",
+        "status": "Status",
+        "priority": "Priorytet",
+        "dueDate": "Termin",
+        "open": "Otwarte",
+        "inProgress": "W realizacji",
+        "completed": "Zakończone",
+        "cancelled": "Anulowane",
+        "low": "Niski",
+        "normal": "Normalny",
+        "high": "Wysoki",
+        "urgent": "Pilny",
+        "activity": "Aktywność",
+        "noActivity": "Brak aktywności",
+        "markInProgress": "Oznacz jako w realizacji",
+        "complete": "Zakończ",
+        "reopen": "Otwórz ponownie",
+        "cancelTask": "Anuluj zadanie",
+        "archiveTask": "Archiwizuj zadanie",
+        "createAndAssignToMe": "Utwórz i przypisz do mnie"
+      },
       "empty": {
         "noData": "Brak zadań",
         "noDataDescription": "Utwórz zadanie, aby rozpocząć."

--- a/apps/web/src/app/[locale]/dashboard/planning/tasks/_components/planning-task-create-dialog.tsx
+++ b/apps/web/src/app/[locale]/dashboard/planning/tasks/_components/planning-task-create-dialog.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { useState } from "react";
+import { Loader2, UserCheck } from "lucide-react";
+import { toast } from "react-toastify";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { RichTextEditorField } from "@/components/primitives/rich-text/rich-text-editor-field";
+import type { RichTextValue } from "@/components/primitives/rich-text/rich-text-types";
+import {
+  createEmptyRichText,
+  extractPlainText,
+} from "@/components/primitives/rich-text/rich-text-utils";
+import { createTaskAction } from "@/app/actions/planning";
+import { TASK_PRIORITIES, type TaskPriority } from "@/lib/validations/planning";
+import type { PlanningTaskDetail } from "@/server/services/planning-tasks.service";
+
+interface Member {
+  user_id: string;
+  name: string | null;
+  email: string | null;
+}
+
+interface PlanningTaskCreateDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  members: Member[];
+  currentUserId: string;
+  onCreated: (task: PlanningTaskDetail) => void;
+}
+
+const PRIORITY_LABELS: Record<TaskPriority, string> = {
+  low: "Low",
+  normal: "Normal",
+  high: "High",
+  urgent: "Urgent",
+};
+
+export function PlanningTaskCreateDialog({
+  open,
+  onOpenChange,
+  members,
+  currentUserId,
+  onCreated,
+}: PlanningTaskCreateDialogProps) {
+  const [title, setTitle] = useState("");
+  const [descriptionRich, setDescriptionRich] = useState<RichTextValue>(createEmptyRichText);
+  const [priority, setPriority] = useState<TaskPriority>("normal");
+  const [assignedTo, setAssignedTo] = useState<string>("");
+  const [dueAt, setDueAt] = useState<string>("");
+  const [titleError, setTitleError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  function reset() {
+    setTitle("");
+    setDescriptionRich(createEmptyRichText);
+    setPriority("normal");
+    setAssignedTo("");
+    setDueAt("");
+    setTitleError(null);
+  }
+
+  function handleClose() {
+    if (submitting) return;
+    reset();
+    onOpenChange(false);
+  }
+
+  async function handleSubmit(assignToMe = false) {
+    const trimmedTitle = title.trim();
+    if (!trimmedTitle) {
+      setTitleError("Title is required");
+      return;
+    }
+    setTitleError(null);
+    setSubmitting(true);
+
+    const descriptionPlain = extractPlainText(descriptionRich as any);
+    const hasDescription = descriptionPlain.trim().length > 0;
+
+    try {
+      const result = await createTaskAction({
+        title: trimmedTitle,
+        description_plain: hasDescription ? descriptionPlain : undefined,
+        description_rich: hasDescription ? descriptionRich : undefined,
+        priority,
+        assigned_to: assignToMe ? currentUserId : assignedTo || null,
+        due_at: dueAt ? new Date(dueAt).toISOString() : null,
+      });
+
+      if (!result.success) {
+        toast.error((result as { success: false; error: string }).error ?? "Failed to create task");
+        return;
+      }
+
+      toast.success("Task created");
+      reset();
+      onOpenChange(false);
+      onCreated(result.data);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[560px]">
+        <DialogHeader>
+          <DialogTitle>Create task</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4 py-2">
+          {/* Title */}
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="task-title">
+              Title <span className="text-destructive">*</span>
+            </Label>
+            <Input
+              id="task-title"
+              value={title}
+              onChange={(e) => {
+                setTitle(e.target.value);
+                if (titleError && e.target.value.trim()) setTitleError(null);
+              }}
+              placeholder="Enter task title…"
+              disabled={submitting}
+              autoFocus
+            />
+            {titleError && <p className="text-destructive text-xs">{titleError}</p>}
+          </div>
+
+          {/* Description */}
+          <div className="flex flex-col gap-1.5">
+            <Label>Description</Label>
+            <div className="border-input rounded-md border">
+              <RichTextEditorField
+                value={descriptionRich}
+                onChange={setDescriptionRich}
+                placeholder="Add a description…"
+                disabled={submitting}
+              />
+            </div>
+          </div>
+
+          {/* Priority + Assignee row */}
+          <div className="grid grid-cols-2 gap-4">
+            <div className="flex flex-col gap-1.5">
+              <Label>Priority</Label>
+              <Select
+                value={priority}
+                onValueChange={(v) => setPriority(v as TaskPriority)}
+                disabled={submitting}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {TASK_PRIORITIES.map((p) => (
+                    <SelectItem key={p} value={p}>
+                      {PRIORITY_LABELS[p]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="flex flex-col gap-1.5">
+              <Label>Assign to</Label>
+              <Select value={assignedTo} onValueChange={setAssignedTo} disabled={submitting}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Unassigned" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="">Unassigned</SelectItem>
+                  {members.map((m) => (
+                    <SelectItem key={m.user_id} value={m.user_id}>
+                      {m.name ?? m.email ?? m.user_id}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          {/* Due date */}
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="task-due">Due date</Label>
+            <Input
+              id="task-due"
+              type="date"
+              value={dueAt}
+              onChange={(e) => setDueAt(e.target.value)}
+              disabled={submitting}
+            />
+          </div>
+        </div>
+
+        <DialogFooter className="flex-col gap-2 sm:flex-row">
+          <Button variant="outline" onClick={handleClose} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button
+            variant="outline"
+            onClick={() => handleSubmit(true)}
+            disabled={submitting}
+            className="gap-1.5"
+          >
+            {submitting ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <UserCheck className="h-4 w-4" />
+            )}
+            Create &amp; assign to me
+          </Button>
+          <Button onClick={() => handleSubmit(false)} disabled={submitting}>
+            {submitting && <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />}
+            Create task
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/app/[locale]/dashboard/planning/tasks/_components/planning-task-detail-panel.tsx
+++ b/apps/web/src/app/[locale]/dashboard/planning/tasks/_components/planning-task-detail-panel.tsx
@@ -1,0 +1,349 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import {
+  Loader2,
+  User,
+  Calendar,
+  Flag,
+  CheckCircle2,
+  RotateCcw,
+  XCircle,
+  Play,
+  Trash2,
+} from "lucide-react";
+import { toast } from "react-toastify";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { RichTextRenderer } from "@/components/primitives/rich-text/rich-text-renderer";
+import { PlanningTaskStatusBadge } from "@/components/planning/planning-task-status-badge";
+import { PlanningTaskPriorityBadge } from "@/components/planning/planning-task-priority-badge";
+import { PlanningTaskActivityList } from "@/components/planning/planning-task-activity-list";
+import {
+  startTaskAction,
+  completeTaskAction,
+  reopenTaskAction,
+  cancelTaskAction,
+  assignTaskAction,
+  deleteTaskAction,
+} from "@/app/actions/planning";
+import type { PlanningTaskDetail } from "@/server/services/planning-tasks.service";
+import type { TaskStatus } from "@/lib/validations/planning";
+
+interface Member {
+  user_id: string;
+  name: string | null;
+  email: string | null;
+}
+
+interface PlanningTaskDetailPanelProps {
+  detail: PlanningTaskDetail;
+  canUpdate: boolean;
+  canAssign: boolean;
+  canDelete: boolean;
+  currentUserId: string;
+  members: Member[];
+  onRefresh?: () => void;
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function formatDateTime(iso: string | null): string {
+  if (!iso) return "—";
+  return new Date(iso).toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function PlanningTaskDetailPanel({
+  detail: initialDetail,
+  canUpdate,
+  canAssign,
+  canDelete,
+  currentUserId,
+  members,
+  onRefresh,
+}: PlanningTaskDetailPanelProps) {
+  const [detail, setDetail] = useState<PlanningTaskDetail>(initialDetail);
+  const [saving, setSaving] = useState(false);
+
+  // Sync when parent provides a new detail (DataView refetch)
+  const latestDetail = initialDetail.updated_at !== detail.updated_at ? initialDetail : detail;
+  const currentDetail = latestDetail;
+
+  async function runAction(
+    fn: () => Promise<{ success: boolean; data?: PlanningTaskDetail; error?: string }>
+  ) {
+    if (saving) return;
+    setSaving(true);
+    try {
+      const result = await fn();
+      if (!result.success) {
+        toast.error((result as any).error ?? "Operation failed");
+        return;
+      }
+      if (result.data) setDetail(result.data);
+      onRefresh?.();
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const handleStart = useCallback(
+    () => runAction(() => startTaskAction(currentDetail.id)),
+    [currentDetail.id, saving]
+  );
+  const handleComplete = useCallback(
+    () => runAction(() => completeTaskAction(currentDetail.id)),
+    [currentDetail.id, saving]
+  );
+  const handleReopen = useCallback(
+    () => runAction(() => reopenTaskAction(currentDetail.id)),
+    [currentDetail.id, saving]
+  );
+  const handleCancel = useCallback(
+    () => runAction(() => cancelTaskAction(currentDetail.id)),
+    [currentDetail.id, saving]
+  );
+  const handleDelete = useCallback(
+    () =>
+      runAction(async () => {
+        const r = await deleteTaskAction(currentDetail.id);
+        if (r.success) toast.success("Task archived");
+        return r as any;
+      }),
+    [currentDetail.id, saving]
+  );
+
+  const handleAssignChange = useCallback(
+    async (userId: string) => {
+      const newAssignee = userId === "__unassigned__" ? null : userId;
+      await runAction(() => assignTaskAction({ id: currentDetail.id, assigned_to: newAssignee }));
+    },
+    [currentDetail.id, saving]
+  );
+
+  const status = currentDetail.status as TaskStatus;
+
+  return (
+    <ScrollArea className="h-full">
+      <div className="flex flex-col gap-5 p-4">
+        {/* Header */}
+        <div>
+          <div className="flex items-start justify-between gap-2">
+            <span className="text-muted-foreground font-mono text-xs">
+              {currentDetail.task_number}
+            </span>
+            {saving && <Loader2 className="text-muted-foreground h-3.5 w-3.5 animate-spin" />}
+          </div>
+          <h2 className="mt-1 text-base font-semibold leading-snug">{currentDetail.title}</h2>
+          <div className="mt-2 flex flex-wrap items-center gap-2">
+            <PlanningTaskStatusBadge status={currentDetail.status} />
+            <PlanningTaskPriorityBadge priority={currentDetail.priority} />
+          </div>
+        </div>
+
+        <Separator />
+
+        {/* Status actions */}
+        {canUpdate && (
+          <div className="flex flex-wrap gap-2">
+            {status === "open" && (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={handleStart}
+                disabled={saving}
+                className="gap-1.5"
+              >
+                <Play className="h-3.5 w-3.5" />
+                Start
+              </Button>
+            )}
+            {(status === "open" || status === "in_progress") && (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={handleComplete}
+                disabled={saving}
+                className="gap-1.5"
+              >
+                <CheckCircle2 className="h-3.5 w-3.5 text-emerald-600" />
+                Complete
+              </Button>
+            )}
+            {(status === "completed" || status === "cancelled") && (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={handleReopen}
+                disabled={saving}
+                className="gap-1.5"
+              >
+                <RotateCcw className="h-3.5 w-3.5" />
+                Reopen
+              </Button>
+            )}
+            {status !== "cancelled" && status !== "completed" && (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={handleCancel}
+                disabled={saving}
+                className="gap-1.5 text-red-600 hover:text-red-600"
+              >
+                <XCircle className="h-3.5 w-3.5" />
+                Cancel
+              </Button>
+            )}
+          </div>
+        )}
+
+        {/* Description */}
+        {currentDetail.description_rich ? (
+          <div>
+            <p className="text-muted-foreground mb-1.5 text-xs font-medium uppercase tracking-wide">
+              Description
+            </p>
+            <div className="prose prose-sm dark:prose-invert max-w-none text-sm">
+              <RichTextRenderer value={currentDetail.description_rich as any} />
+            </div>
+          </div>
+        ) : currentDetail.description_plain ? (
+          <div>
+            <p className="text-muted-foreground mb-1.5 text-xs font-medium uppercase tracking-wide">
+              Description
+            </p>
+            <p className="text-sm whitespace-pre-wrap">{currentDetail.description_plain}</p>
+          </div>
+        ) : null}
+
+        <Separator />
+
+        {/* Meta fields */}
+        <div className="flex flex-col gap-3">
+          {/* Assignee */}
+          <div className="flex items-center gap-2">
+            <User className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
+            <span className="text-muted-foreground w-24 shrink-0 text-xs">Assigned to</span>
+            {canAssign ? (
+              <Select
+                value={currentDetail.assigned_to ?? "__unassigned__"}
+                onValueChange={handleAssignChange}
+                disabled={saving}
+              >
+                <SelectTrigger className="h-7 text-xs">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="__unassigned__">Unassigned</SelectItem>
+                  {members.map((m) => (
+                    <SelectItem key={m.user_id} value={m.user_id}>
+                      {m.name ?? m.email ?? m.user_id}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            ) : (
+              <span className="text-sm">
+                {currentDetail.assignee_name ?? currentDetail.assignee_email ?? "Unassigned"}
+              </span>
+            )}
+          </div>
+
+          {/* Due date */}
+          <div className="flex items-center gap-2">
+            <Calendar className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
+            <span className="text-muted-foreground w-24 shrink-0 text-xs">Due date</span>
+            <span className="text-sm">{formatDate(currentDetail.due_at)}</span>
+          </div>
+
+          {/* Priority */}
+          <div className="flex items-center gap-2">
+            <Flag className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
+            <span className="text-muted-foreground w-24 shrink-0 text-xs">Priority</span>
+            <PlanningTaskPriorityBadge priority={currentDetail.priority} />
+          </div>
+
+          {/* Created by */}
+          <div className="flex items-center gap-2">
+            <User className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
+            <span className="text-muted-foreground w-24 shrink-0 text-xs">Created by</span>
+            <span className="text-sm">
+              {currentDetail.creator_name ?? currentDetail.creator_email ?? "Unknown"}
+            </span>
+          </div>
+
+          {/* Dates */}
+          <div className="flex items-center gap-2">
+            <Calendar className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
+            <span className="text-muted-foreground w-24 shrink-0 text-xs">Created</span>
+            <span className="text-sm">{formatDateTime(currentDetail.created_at)}</span>
+          </div>
+
+          {currentDetail.completed_at && (
+            <div className="flex items-center gap-2">
+              <CheckCircle2 className="h-3.5 w-3.5 shrink-0 text-emerald-600" />
+              <span className="text-muted-foreground w-24 shrink-0 text-xs">Completed</span>
+              <span className="text-sm">{formatDateTime(currentDetail.completed_at)}</span>
+            </div>
+          )}
+
+          {currentDetail.cancelled_at && (
+            <div className="flex items-center gap-2">
+              <XCircle className="h-3.5 w-3.5 shrink-0 text-gray-500" />
+              <span className="text-muted-foreground w-24 shrink-0 text-xs">Cancelled</span>
+              <span className="text-sm">{formatDateTime(currentDetail.cancelled_at)}</span>
+            </div>
+          )}
+        </div>
+
+        <Separator />
+
+        {/* Activity */}
+        <div>
+          <p className="text-muted-foreground mb-2 text-xs font-medium uppercase tracking-wide">
+            Activity
+          </p>
+          <PlanningTaskActivityList activity={currentDetail.activity} />
+        </div>
+
+        {/* Archive */}
+        {canDelete && status !== "cancelled" && status !== "completed" && (
+          <>
+            <Separator />
+            <Button
+              size="sm"
+              variant="ghost"
+              className="text-muted-foreground hover:text-destructive w-full gap-1.5 text-xs"
+              onClick={handleDelete}
+              disabled={saving}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+              Archive task
+            </Button>
+          </>
+        )}
+      </div>
+    </ScrollArea>
+  );
+}

--- a/apps/web/src/app/[locale]/dashboard/planning/tasks/_components/tasks-client.tsx
+++ b/apps/web/src/app/[locale]/dashboard/planning/tasks/_components/tasks-client.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useCallback } from "react";
-import { Plus, CheckSquare, LayoutGrid } from "lucide-react";
+import { useState, useCallback, useMemo } from "react";
+import { Plus, CheckSquare } from "lucide-react";
+import { useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
 import { DataView } from "@/components/data-view/data-view";
 import type {
   DataViewColumnDef,
@@ -12,137 +12,62 @@ import type {
   PaginatedResult,
 } from "@/components/data-view/data-view.types";
 import { listTasksForDataViewAction, getTaskDetailAction } from "@/app/actions/planning";
+import { PlanningTaskDetailPanel } from "./planning-task-detail-panel";
+import { PlanningTaskCreateDialog } from "./planning-task-create-dialog";
+import { PlanningTaskStatusBadge } from "@/components/planning/planning-task-status-badge";
+import { PlanningTaskPriorityBadge } from "@/components/planning/planning-task-priority-badge";
 import type {
   PlanningTaskListRow,
   PlanningTaskDetail,
 } from "@/server/services/planning-tasks.service";
-import type { TaskStatus, TaskPriority } from "@/lib/validations/planning";
 
 const PLANNING_TASKS_QUERY_KEY = ["planning-tasks-dataview"];
+
+interface Member {
+  user_id: string;
+  name: string | null;
+  email: string | null;
+}
 
 interface TasksClientProps {
   initialData: PaginatedResult<PlanningTaskListRow>;
   canCreate: boolean;
+  canUpdate: boolean;
   canAssign: boolean;
-  members: Array<{ user_id: string; name: string | null; email: string | null }>;
+  canDelete: boolean;
+  members: Member[];
+  currentUserId: string;
   orgId: string;
-}
-
-const STATUS_LABELS: Record<TaskStatus, string> = {
-  open: "Open",
-  in_progress: "In Progress",
-  completed: "Completed",
-};
-
-const STATUS_COLORS: Record<TaskStatus, string> = {
-  open: "bg-blue-100 text-blue-700 border-blue-200",
-  in_progress: "bg-amber-100 text-amber-700 border-amber-200",
-  completed: "bg-emerald-100 text-emerald-700 border-emerald-200",
-};
-
-const PRIORITY_LABELS: Record<TaskPriority, string> = {
-  low: "Low",
-  normal: "Normal",
-  high: "High",
-  urgent: "Urgent",
-};
-
-const PRIORITY_COLORS: Record<TaskPriority, string> = {
-  low: "bg-slate-100 text-slate-600 border-slate-200",
-  normal: "bg-blue-100 text-blue-600 border-blue-200",
-  high: "bg-orange-100 text-orange-700 border-orange-200",
-  urgent: "bg-red-100 text-red-700 border-red-200",
-};
-
-function TaskDetailPanel({ detail }: { detail: PlanningTaskDetail }) {
-  return (
-    <div className="flex flex-col gap-4 p-4">
-      <div>
-        <p className="text-muted-foreground text-xs font-medium uppercase tracking-wide">Title</p>
-        <p className="mt-1 text-sm">{detail.title}</p>
-      </div>
-      {detail.description && (
-        <div>
-          <p className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
-            Description
-          </p>
-          <p className="mt-1 text-sm">{detail.description}</p>
-        </div>
-      )}
-      <div className="grid grid-cols-2 gap-4">
-        <div>
-          <p className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
-            Status
-          </p>
-          <Badge variant="outline" className={`mt-1 text-xs ${STATUS_COLORS[detail.status] ?? ""}`}>
-            {STATUS_LABELS[detail.status] ?? detail.status}
-          </Badge>
-        </div>
-        <div>
-          <p className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
-            Priority
-          </p>
-          <Badge
-            variant="outline"
-            className={`mt-1 text-xs ${PRIORITY_COLORS[detail.priority] ?? ""}`}
-          >
-            {PRIORITY_LABELS[detail.priority] ?? detail.priority}
-          </Badge>
-        </div>
-      </div>
-      {detail.assignee_name && (
-        <div>
-          <p className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
-            Assigned to
-          </p>
-          <p className="mt-1 text-sm">{detail.assignee_name}</p>
-        </div>
-      )}
-      {detail.due_at && (
-        <div>
-          <p className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
-            Due date
-          </p>
-          <p className="mt-1 text-sm">{new Date(detail.due_at).toLocaleDateString()}</p>
-        </div>
-      )}
-      <div>
-        <p className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
-          Created by
-        </p>
-        <p className="mt-1 text-sm">{detail.creator_name ?? detail.creator_email ?? "Unknown"}</p>
-      </div>
-    </div>
-  );
 }
 
 const COLUMNS: DataViewColumnDef<PlanningTaskListRow>[] = [
   {
+    key: "task_number",
+    header: "ID",
+    accessor: (row) => (
+      <span className="text-muted-foreground font-mono text-xs">{row.task_number}</span>
+    ),
+  },
+  {
     key: "title",
     header: "Title",
     accessor: (row) => (
-      <span className="block max-w-[280px] truncate font-medium">{row.title}</span>
+      <span className="block max-w-[260px] truncate font-medium" title={row.title}>
+        {row.title}
+      </span>
     ),
     sortable: true,
   },
   {
     key: "status",
     header: "Status",
-    accessor: (row) => (
-      <Badge variant="outline" className={`text-xs ${STATUS_COLORS[row.status] ?? ""}`}>
-        {STATUS_LABELS[row.status] ?? row.status}
-      </Badge>
-    ),
+    accessor: (row) => <PlanningTaskStatusBadge status={row.status} />,
     sortable: true,
   },
   {
     key: "priority",
     header: "Priority",
-    accessor: (row) => (
-      <Badge variant="outline" className={`text-xs ${PRIORITY_COLORS[row.priority] ?? ""}`}>
-        {PRIORITY_LABELS[row.priority] ?? row.priority}
-      </Badge>
-    ),
+    accessor: (row) => <PlanningTaskPriorityBadge priority={row.priority} />,
     sortable: true,
   },
   {
@@ -156,7 +81,7 @@ const COLUMNS: DataViewColumnDef<PlanningTaskListRow>[] = [
   },
   {
     key: "due_at",
-    header: "Due date",
+    header: "Due",
     accessor: (row) =>
       row.due_at ? (
         <span className="text-sm">{new Date(row.due_at).toLocaleDateString()}</span>
@@ -166,11 +91,11 @@ const COLUMNS: DataViewColumnDef<PlanningTaskListRow>[] = [
     sortable: true,
   },
   {
-    key: "created_at",
-    header: "Created",
+    key: "updated_at",
+    header: "Updated",
     accessor: (row) => (
       <span className="text-muted-foreground text-sm">
-        {new Date(row.created_at).toLocaleDateString()}
+        {new Date(row.updated_at).toLocaleDateString()}
       </span>
     ),
     sortable: true,
@@ -186,6 +111,7 @@ const FILTERS: DataViewFilterDef[] = [
       { value: "open", label: "Open" },
       { value: "in_progress", label: "In Progress" },
       { value: "completed", label: "Completed" },
+      { value: "cancelled", label: "Cancelled" },
     ],
   },
   {
@@ -201,7 +127,19 @@ const FILTERS: DataViewFilterDef[] = [
   },
 ];
 
-export function TasksClient({ initialData, canCreate, orgId }: TasksClientProps) {
+export function TasksClient({
+  initialData,
+  canCreate,
+  canUpdate,
+  canAssign,
+  canDelete,
+  members,
+  currentUserId,
+  orgId,
+}: TasksClientProps) {
+  const [createOpen, setCreateOpen] = useState(false);
+  const queryClient = useQueryClient();
+
   const listFetcher = useCallback(
     async (params: DataViewListParams): Promise<PaginatedResult<PlanningTaskListRow>> => {
       const result = await listTasksForDataViewAction(params);
@@ -217,6 +155,14 @@ export function TasksClient({ initialData, canCreate, orgId }: TasksClientProps)
     return result.data;
   }, []);
 
+  const handleCreated = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: PLANNING_TASKS_QUERY_KEY });
+  }, [queryClient]);
+
+  const handleRefresh = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: PLANNING_TASKS_QUERY_KEY });
+  }, [queryClient]);
+
   return (
     <div className="flex h-full flex-col">
       <div className="flex items-center justify-between border-b px-6 py-4">
@@ -225,7 +171,7 @@ export function TasksClient({ initialData, canCreate, orgId }: TasksClientProps)
           <h1 className="text-lg font-semibold">Tasks</h1>
         </div>
         {canCreate && (
-          <Button size="sm" className="gap-1.5">
+          <Button size="sm" className="gap-1.5" onClick={() => setCreateOpen(true)}>
             <Plus className="h-4 w-4" />
             New task
           </Button>
@@ -245,26 +191,31 @@ export function TasksClient({ initialData, canCreate, orgId }: TasksClientProps)
           renderCompactItem={(row) => (
             <div className="flex flex-col gap-1">
               <div className="flex items-center justify-between gap-2">
-                <Badge variant="outline" className={`text-xs ${STATUS_COLORS[row.status] ?? ""}`}>
-                  {STATUS_LABELS[row.status] ?? row.status}
-                </Badge>
-                <Badge
-                  variant="outline"
-                  className={`text-xs ${PRIORITY_COLORS[row.priority] ?? ""}`}
-                >
-                  {PRIORITY_LABELS[row.priority] ?? row.priority}
-                </Badge>
+                <span className="text-muted-foreground font-mono text-xs">{row.task_number}</span>
+                <PlanningTaskStatusBadge status={row.status} />
               </div>
               <span className="truncate text-sm font-medium" title={row.title}>
                 {row.title}
               </span>
+              <PlanningTaskPriorityBadge priority={row.priority} />
             </div>
           )}
-          renderDetail={(detail) => <TaskDetailPanel key={detail.id} detail={detail} />}
+          renderDetail={(detail) => (
+            <PlanningTaskDetailPanel
+              key={detail.id}
+              detail={detail}
+              canUpdate={canUpdate}
+              canAssign={canAssign}
+              canDelete={canDelete}
+              currentUserId={currentUserId}
+              members={members}
+              onRefresh={handleRefresh}
+            />
+          )}
           renderToolbarControls={
             canCreate
               ? () => (
-                  <Button size="sm" className="gap-1.5">
+                  <Button size="sm" className="gap-1.5" onClick={() => setCreateOpen(true)}>
                     <Plus className="h-4 w-4" />
                     New task
                   </Button>
@@ -273,6 +224,14 @@ export function TasksClient({ initialData, canCreate, orgId }: TasksClientProps)
           }
         />
       </div>
+
+      <PlanningTaskCreateDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        members={members}
+        currentUserId={currentUserId}
+        onCreated={handleCreated}
+      />
     </div>
   );
 }

--- a/apps/web/src/app/[locale]/dashboard/planning/tasks/page.tsx
+++ b/apps/web/src/app/[locale]/dashboard/planning/tasks/page.tsx
@@ -5,6 +5,8 @@ import { checkPermission } from "@/lib/utils/permissions";
 import {
   PLANNING_TASKS_READ,
   PLANNING_TASKS_CREATE,
+  PLANNING_TASKS_UPDATE,
+  PLANNING_TASKS_DELETE,
   PLANNING_TASKS_ASSIGN,
 } from "@/lib/constants/permissions";
 import { createClient } from "@/utils/supabase/server";
@@ -54,15 +56,24 @@ export default async function PlanningTasksPage({ searchParams }: PageProps = {}
       }))
     : [];
 
-  const canCreate = checkPermission(context.user.permissionSnapshot, PLANNING_TASKS_CREATE);
-  const canAssign = checkPermission(context.user.permissionSnapshot, PLANNING_TASKS_ASSIGN);
+  const snap = context.user.permissionSnapshot;
+  const canCreate = checkPermission(snap, PLANNING_TASKS_CREATE);
+  const canUpdate = checkPermission(snap, PLANNING_TASKS_UPDATE);
+  const canAssign = checkPermission(snap, PLANNING_TASKS_ASSIGN);
+  const canDelete = checkPermission(snap, PLANNING_TASKS_DELETE);
+
+  const currentUser = context.user.user;
+  const currentUserId = currentUser?.id ?? "";
 
   return (
     <TasksClient
       initialData={initialData}
       canCreate={canCreate}
+      canUpdate={canUpdate}
       canAssign={canAssign}
+      canDelete={canDelete}
       members={members}
+      currentUserId={currentUserId}
       orgId={orgId}
     />
   );

--- a/apps/web/src/app/actions/planning/index.ts
+++ b/apps/web/src/app/actions/planning/index.ts
@@ -19,12 +19,11 @@ import {
 import {
   createTaskSchema,
   updateTaskSchema,
-  changeTaskStatusSchema,
   assignTaskSchema,
   type CreateTaskInput,
   type UpdateTaskInput,
-  type ChangeTaskStatusInput,
   type AssignTaskInput,
+  type TaskStatus,
   type TaskListFilters,
 } from "@/lib/validations/planning";
 import type { DataViewListParams, PaginatedResult } from "@/lib/data-view/types";
@@ -36,7 +35,7 @@ import type { DataViewListParams, PaginatedResult } from "@/lib/data-view/types"
 type ActionResult<T> = { success: true; data: T } | { success: false; error: string };
 
 // ---------------------------------------------------------------------------
-// Helpers
+// Auth helper
 // ---------------------------------------------------------------------------
 
 async function getAuthedContext() {
@@ -51,7 +50,7 @@ async function getAuthedContext() {
 }
 
 // ---------------------------------------------------------------------------
-// Actions
+// List
 // ---------------------------------------------------------------------------
 
 export async function listTasksForDataViewAction(
@@ -69,6 +68,10 @@ export async function listTasksForDataViewAction(
   }
 }
 
+// ---------------------------------------------------------------------------
+// Detail
+// ---------------------------------------------------------------------------
+
 export async function getTaskDetailAction(
   taskId: string
 ): Promise<ActionResult<PlanningTaskDetail>> {
@@ -83,6 +86,10 @@ export async function getTaskDetailAction(
   }
 }
 
+// ---------------------------------------------------------------------------
+// Create
+// ---------------------------------------------------------------------------
+
 export async function createTaskAction(
   input: CreateTaskInput
 ): Promise<ActionResult<PlanningTaskDetail>> {
@@ -92,12 +99,17 @@ export async function createTaskAction(
     if (!checkPermission(ctx.context.user.permissionSnapshot, PLANNING_TASKS_CREATE))
       return { success: false, error: "Insufficient permissions" };
     const parsed = createTaskSchema.safeParse(input);
-    if (!parsed.success) return { success: false, error: parsed.error.message };
+    if (!parsed.success)
+      return { success: false, error: parsed.error.errors[0]?.message ?? parsed.error.message };
     return PlanningTasksService.create(ctx.supabase, ctx.orgId, ctx.userId, parsed.data);
   } catch {
     return { success: false, error: "Unexpected error" };
   }
 }
+
+// ---------------------------------------------------------------------------
+// Update
+// ---------------------------------------------------------------------------
 
 export async function updateTaskAction(
   input: UpdateTaskInput
@@ -108,28 +120,100 @@ export async function updateTaskAction(
     if (!checkPermission(ctx.context.user.permissionSnapshot, PLANNING_TASKS_UPDATE))
       return { success: false, error: "Insufficient permissions" };
     const parsed = updateTaskSchema.safeParse(input);
-    if (!parsed.success) return { success: false, error: parsed.error.message };
-    return PlanningTasksService.update(ctx.supabase, ctx.orgId, parsed.data);
+    if (!parsed.success)
+      return { success: false, error: parsed.error.errors[0]?.message ?? parsed.error.message };
+
+    // Fetch current task to diff for activity
+    const current = await PlanningTasksService.getDetail(ctx.supabase, ctx.orgId, parsed.data.id);
+    if (!current.success)
+      return { success: false, error: (current as { success: false; error: string }).error };
+
+    return PlanningTasksService.update(ctx.supabase, ctx.orgId, ctx.userId, parsed.data, {
+      title: current.data.title,
+      priority: current.data.priority,
+      due_at: current.data.due_at,
+      description_plain: current.data.description_plain,
+    });
   } catch {
     return { success: false, error: "Unexpected error" };
   }
 }
 
+// ---------------------------------------------------------------------------
+// Status transitions
+// ---------------------------------------------------------------------------
+
+async function _changeStatus(
+  taskId: string,
+  newStatus: TaskStatus
+): Promise<ActionResult<PlanningTaskDetail>> {
+  const ctx = await getAuthedContext();
+  if (!ctx) return { success: false, error: "Unauthorized" };
+  if (!checkPermission(ctx.context.user.permissionSnapshot, PLANNING_TASKS_UPDATE))
+    return { success: false, error: "Insufficient permissions" };
+
+  const current = await PlanningTasksService.getDetail(ctx.supabase, ctx.orgId, taskId);
+  if (!current.success)
+    return { success: false, error: (current as { success: false; error: string }).error };
+
+  return PlanningTasksService.changeStatus(
+    ctx.supabase,
+    ctx.orgId,
+    ctx.userId,
+    taskId,
+    newStatus,
+    current.data.status
+  );
+}
+
 export async function changeTaskStatusAction(
-  input: ChangeTaskStatusInput
+  taskId: string,
+  status: TaskStatus
 ): Promise<ActionResult<PlanningTaskDetail>> {
   try {
-    const ctx = await getAuthedContext();
-    if (!ctx) return { success: false, error: "Unauthorized" };
-    if (!checkPermission(ctx.context.user.permissionSnapshot, PLANNING_TASKS_UPDATE))
-      return { success: false, error: "Insufficient permissions" };
-    const parsed = changeTaskStatusSchema.safeParse(input);
-    if (!parsed.success) return { success: false, error: parsed.error.message };
-    return PlanningTasksService.changeStatus(ctx.supabase, ctx.orgId, parsed.data);
+    return _changeStatus(taskId, status);
   } catch {
     return { success: false, error: "Unexpected error" };
   }
 }
+
+export async function startTaskAction(taskId: string): Promise<ActionResult<PlanningTaskDetail>> {
+  try {
+    return _changeStatus(taskId, "in_progress");
+  } catch {
+    return { success: false, error: "Unexpected error" };
+  }
+}
+
+export async function completeTaskAction(
+  taskId: string
+): Promise<ActionResult<PlanningTaskDetail>> {
+  try {
+    return _changeStatus(taskId, "completed");
+  } catch {
+    return { success: false, error: "Unexpected error" };
+  }
+}
+
+export async function reopenTaskAction(taskId: string): Promise<ActionResult<PlanningTaskDetail>> {
+  try {
+    return _changeStatus(taskId, "open");
+  } catch {
+    return { success: false, error: "Unexpected error" };
+  }
+}
+
+export async function cancelTaskAction(taskId: string): Promise<ActionResult<PlanningTaskDetail>> {
+  try {
+    return _changeStatus(taskId, "cancelled");
+  } catch {
+    return { success: false, error: "Unexpected error" };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Assign
+// ---------------------------------------------------------------------------
 
 export async function assignTaskAction(
   input: AssignTaskInput
@@ -140,12 +224,28 @@ export async function assignTaskAction(
     if (!checkPermission(ctx.context.user.permissionSnapshot, PLANNING_TASKS_ASSIGN))
       return { success: false, error: "Insufficient permissions" };
     const parsed = assignTaskSchema.safeParse(input);
-    if (!parsed.success) return { success: false, error: parsed.error.message };
-    return PlanningTasksService.assign(ctx.supabase, ctx.orgId, parsed.data);
+    if (!parsed.success)
+      return { success: false, error: parsed.error.errors[0]?.message ?? parsed.error.message };
+
+    const current = await PlanningTasksService.getDetail(ctx.supabase, ctx.orgId, parsed.data.id);
+    if (!current.success)
+      return { success: false, error: (current as { success: false; error: string }).error };
+
+    return PlanningTasksService.assign(
+      ctx.supabase,
+      ctx.orgId,
+      ctx.userId,
+      parsed.data,
+      current.data.assigned_to
+    );
   } catch {
     return { success: false, error: "Unexpected error" };
   }
 }
+
+// ---------------------------------------------------------------------------
+// Delete (soft)
+// ---------------------------------------------------------------------------
 
 export async function deleteTaskAction(taskId: string): Promise<ActionResult<void>> {
   try {
@@ -153,11 +253,18 @@ export async function deleteTaskAction(taskId: string): Promise<ActionResult<voi
     if (!ctx) return { success: false, error: "Unauthorized" };
     if (!checkPermission(ctx.context.user.permissionSnapshot, PLANNING_TASKS_DELETE))
       return { success: false, error: "Insufficient permissions" };
-    return PlanningTasksService.softDelete(ctx.supabase, ctx.orgId, taskId);
+    return PlanningTasksService.softDelete(ctx.supabase, ctx.orgId, ctx.userId, taskId);
   } catch {
     return { success: false, error: "Unexpected error" };
   }
 }
 
-// Re-export read permission check helper for pages
-export { PLANNING_READ };
+// Re-export for pages
+export {
+  PLANNING_READ,
+  PLANNING_TASKS_READ,
+  PLANNING_TASKS_CREATE,
+  PLANNING_TASKS_UPDATE,
+  PLANNING_TASKS_DELETE,
+  PLANNING_TASKS_ASSIGN,
+};

--- a/apps/web/src/components/planning/planning-task-activity-list.tsx
+++ b/apps/web/src/components/planning/planning-task-activity-list.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { formatDistanceToNow } from "date-fns";
+import { Activity } from "lucide-react";
+import type { PlanningTaskActivity } from "@/server/services/planning-tasks.service";
+
+interface PlanningTaskActivityListProps {
+  activity: PlanningTaskActivity[];
+}
+
+const ACTIVITY_ICONS: Record<string, string> = {
+  task_created: "✨",
+  title_changed: "✏️",
+  description_changed: "📝",
+  assigned: "👤",
+  unassigned: "👤",
+  status_changed: "🔄",
+  priority_changed: "🚦",
+  due_date_changed: "📅",
+  completed: "✅",
+  reopened: "🔁",
+  cancelled: "❌",
+  archived: "📦",
+  restored: "♻️",
+};
+
+export function PlanningTaskActivityList({ activity }: PlanningTaskActivityListProps) {
+  if (activity.length === 0) {
+    return (
+      <div className="flex flex-col items-center gap-2 py-6 text-center">
+        <Activity className="text-muted-foreground h-5 w-5" />
+        <p className="text-muted-foreground text-xs">No activity yet</p>
+      </div>
+    );
+  }
+
+  const sorted = [...activity].reverse();
+
+  return (
+    <div className="flex flex-col gap-3">
+      {sorted.map((item) => (
+        <div key={item.id} className="flex gap-2.5">
+          <span className="mt-0.5 shrink-0 text-sm">
+            {ACTIVITY_ICONS[item.activity_type] ?? "•"}
+          </span>
+          <div className="min-w-0 flex-1">
+            <p className="text-sm">{item.message ?? item.activity_type}</p>
+            <p className="text-muted-foreground mt-0.5 text-xs">
+              {item.actor_name ?? "System"} ·{" "}
+              {formatDistanceToNow(new Date(item.created_at), { addSuffix: true })}
+            </p>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/planning/planning-task-priority-badge.tsx
+++ b/apps/web/src/components/planning/planning-task-priority-badge.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/utils";
+import type { TaskPriority } from "@/lib/validations/planning";
+
+const PRIORITY_DEFAULTS: Record<TaskPriority, { label: string; className: string }> = {
+  low: {
+    label: "Low",
+    className: "bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400",
+  },
+  normal: {
+    label: "Normal",
+    className: "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300",
+  },
+  high: {
+    label: "High",
+    className: "bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-300",
+  },
+  urgent: {
+    label: "Urgent",
+    className: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400",
+  },
+};
+
+interface PlanningTaskPriorityBadgeProps {
+  priority: TaskPriority;
+  className?: string;
+}
+
+export function PlanningTaskPriorityBadge({ priority, className }: PlanningTaskPriorityBadgeProps) {
+  const defaults = PRIORITY_DEFAULTS[priority] ?? {
+    label: priority,
+    className: "bg-muted text-muted-foreground",
+  };
+  return (
+    <Badge
+      variant="outline"
+      className={cn("border-0 text-xs font-medium", defaults.className, className)}
+    >
+      {defaults.label}
+    </Badge>
+  );
+}

--- a/apps/web/src/components/planning/planning-task-status-badge.tsx
+++ b/apps/web/src/components/planning/planning-task-status-badge.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/utils";
+import type { TaskStatus } from "@/lib/validations/planning";
+
+const STATUS_DEFAULTS: Record<TaskStatus, { label: string; className: string }> = {
+  open: {
+    label: "Open",
+    className: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300",
+  },
+  in_progress: {
+    label: "In Progress",
+    className: "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300",
+  },
+  completed: {
+    label: "Completed",
+    className: "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300",
+  },
+  cancelled: {
+    label: "Cancelled",
+    className: "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400",
+  },
+};
+
+interface PlanningTaskStatusBadgeProps {
+  status: TaskStatus;
+  className?: string;
+}
+
+export function PlanningTaskStatusBadge({ status, className }: PlanningTaskStatusBadgeProps) {
+  const defaults = STATUS_DEFAULTS[status] ?? {
+    label: status,
+    className: "bg-muted text-muted-foreground",
+  };
+  return (
+    <Badge
+      variant="outline"
+      className={cn("border-0 text-xs font-medium", defaults.className, className)}
+    >
+      {defaults.label}
+    </Badge>
+  );
+}

--- a/apps/web/src/lib/validations/__tests__/planning.validation.test.ts
+++ b/apps/web/src/lib/validations/__tests__/planning.validation.test.ts
@@ -1,0 +1,145 @@
+/**
+ * @vitest-environment node
+ *
+ * Unit tests for planning validation schemas.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  createTaskSchema,
+  updateTaskSchema,
+  assignTaskSchema,
+  changeTaskStatusSchema,
+} from "../planning";
+
+describe("createTaskSchema", () => {
+  it("accepts minimal valid input", () => {
+    const result = createTaskSchema.safeParse({ title: "My Task" });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.priority).toBe("normal");
+  });
+
+  it("rejects empty title", () => {
+    const result = createTaskSchema.safeParse({ title: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects whitespace-only title", () => {
+    const result = createTaskSchema.safeParse({ title: "   " });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects title over 500 chars", () => {
+    const result = createTaskSchema.safeParse({ title: "a".repeat(501) });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid priority", () => {
+    const result = createTaskSchema.safeParse({ title: "Task", priority: "extreme" });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts all valid priorities", () => {
+    for (const p of ["low", "normal", "high", "urgent"]) {
+      const result = createTaskSchema.safeParse({ title: "Task", priority: p });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it("rejects non-UUID assigned_to", () => {
+    const result = createTaskSchema.safeParse({ title: "Task", assigned_to: "not-a-uuid" });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts null assigned_to", () => {
+    const result = createTaskSchema.safeParse({ title: "Task", assigned_to: null });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts valid UUID assigned_to", () => {
+    const result = createTaskSchema.safeParse({
+      title: "Task",
+      assigned_to: "550e8400-e29b-41d4-a716-446655440000",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("trims title", () => {
+    const result = createTaskSchema.safeParse({ title: "  trimmed  " });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.title).toBe("trimmed");
+  });
+});
+
+describe("updateTaskSchema", () => {
+  it("requires id", () => {
+    const result = updateTaskSchema.safeParse({ title: "Task", priority: "normal" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-UUID id", () => {
+    const result = updateTaskSchema.safeParse({
+      id: "not-uuid",
+      title: "Task",
+      priority: "normal",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts valid update input", () => {
+    const result = updateTaskSchema.safeParse({
+      id: "550e8400-e29b-41d4-a716-446655440000",
+      title: "Updated Task",
+      priority: "high",
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("changeTaskStatusSchema", () => {
+  it("accepts valid status transitions", () => {
+    for (const s of ["open", "in_progress", "completed", "cancelled"]) {
+      const result = changeTaskStatusSchema.safeParse({
+        id: "550e8400-e29b-41d4-a716-446655440000",
+        status: s,
+      });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it("rejects invalid status", () => {
+    const result = changeTaskStatusSchema.safeParse({
+      id: "550e8400-e29b-41d4-a716-446655440000",
+      status: "deleted",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("assignTaskSchema", () => {
+  it("accepts null assigned_to (unassign)", () => {
+    const result = assignTaskSchema.safeParse({
+      id: "550e8400-e29b-41d4-a716-446655440000",
+      assigned_to: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts valid UUID assigned_to", () => {
+    const result = assignTaskSchema.safeParse({
+      id: "550e8400-e29b-41d4-a716-446655440000",
+      assigned_to: "550e8400-e29b-41d4-a716-446655440001",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects non-UUID assigned_to", () => {
+    const result = assignTaskSchema.safeParse({
+      id: "550e8400-e29b-41d4-a716-446655440000",
+      assigned_to: "not-uuid",
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/web/src/lib/validations/planning.ts
+++ b/apps/web/src/lib/validations/planning.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 // Enums
 // ---------------------------------------------------------------------------
 
-export const TASK_STATUSES = ["open", "in_progress", "completed"] as const;
+export const TASK_STATUSES = ["open", "in_progress", "completed", "cancelled"] as const;
 export const TASK_PRIORITIES = ["low", "normal", "high", "urgent"] as const;
 
 export type TaskStatus = (typeof TASK_STATUSES)[number];
@@ -15,17 +15,23 @@ export type TaskPriority = (typeof TASK_PRIORITIES)[number];
 // ---------------------------------------------------------------------------
 
 export const createTaskSchema = z.object({
-  title: z.string().min(1, "Title is required").max(200),
-  description: z.string().max(5000).optional(),
-  status: z.enum(TASK_STATUSES).default("open"),
+  title: z.string().trim().min(1, "Title is required").max(500),
+  description_plain: z.string().max(10000).optional(),
+  description_rich: z.unknown().optional(),
   priority: z.enum(TASK_PRIORITIES).default("normal"),
   branch_id: z.string().uuid().nullable().optional(),
   assigned_to: z.string().uuid().nullable().optional(),
   due_at: z.string().datetime().nullable().optional(),
 });
 
-export const updateTaskSchema = createTaskSchema.extend({
+export const updateTaskSchema = z.object({
   id: z.string().uuid(),
+  title: z.string().trim().min(1, "Title is required").max(500),
+  description_plain: z.string().max(10000).optional(),
+  description_rich: z.unknown().optional(),
+  priority: z.enum(TASK_PRIORITIES),
+  branch_id: z.string().uuid().nullable().optional(),
+  due_at: z.string().datetime().nullable().optional(),
 });
 
 export const changeTaskStatusSchema = z.object({

--- a/apps/web/src/modules/planning/MODULE.md
+++ b/apps/web/src/modules/planning/MODULE.md
@@ -12,15 +12,33 @@ Answers:
 - What is currently in progress?
 - What is completed?
 
+## Implementation Status
+
+| Feature                                              | Status  |
+| ---------------------------------------------------- | ------- |
+| Module base (routes, permissions, sidebar, i18n)     | Done    |
+| Task list (DataView with SSR initial data)           | Done    |
+| Create task dialog                                   | Done    |
+| Task detail panel (open from DataView)               | Done    |
+| Task activity/audit trail                            | Done    |
+| Status transitions (start, complete, reopen, cancel) | Done    |
+| Assign/unassign tasks                                | Done    |
+| Soft-delete (archive) tasks                          | Done    |
+| Kanban board                                         | Not yet |
+| Task comments                                        | Not yet |
+| Task labels/checklists                               | Not yet |
+| Recurring tasks                                      | Not yet |
+| Calendar/schedule view                               | Not yet |
+| Reminders/notifications                              | Not yet |
+| Cross-module task creation                           | Not yet |
+
 ## Routes
 
-| Route                                | Description          |
-| ------------------------------------ | -------------------- |
-| `/dashboard/planning`                | Module overview      |
-| `/dashboard/planning/tasks`          | Task list (DataView) |
-| `/dashboard/planning/tasks/new`      | Create task          |
-| `/dashboard/planning/tasks/[taskId]` | Task detail          |
-| `/dashboard/planning/boards`         | Kanban board view    |
+| Route                        | Description                     |
+| ---------------------------- | ------------------------------- |
+| `/dashboard/planning`        | Module overview                 |
+| `/dashboard/planning/tasks`  | Task list (DataView)            |
+| `/dashboard/planning/boards` | Kanban board view (placeholder) |
 
 ## Permissions
 
@@ -47,15 +65,23 @@ Answers:
 
 Core task entity. Org-scoped, soft-delete, with optional branch scoping.
 
+Fields: `id`, `organization_id`, `branch_id`, `task_number` (PT-000001 format), `title`, `description_plain`, `description_rich`, `status` (open/in_progress/completed/cancelled), `priority` (low/normal/high/urgent), `assigned_to`, `created_by`, `updated_by`, `started_at`, `completed_at`, `cancelled_at`, `due_at`, `created_at`, `updated_at`, `deleted_at`
+
 ### `planning_task_comments`
 
-Simple comment thread on a task. Org-scoped, soft-delete.
+Simple comment thread on a task (not yet implemented in UI).
+
+### `planning_task_activity`
+
+Append-only audit log. RLS: no UPDATE or DELETE for normal users.
+
+Activity types: `task_created`, `title_changed`, `description_changed`, `assigned`, `unassigned`, `status_changed`, `priority_changed`, `due_date_changed`, `completed`, `reopened`, `cancelled`, `archived`
 
 ## Services
 
-| File                        | Purpose                                         |
-| --------------------------- | ----------------------------------------------- |
-| `planning-tasks.service.ts` | CRUD, list/filter, status transitions for tasks |
+| File                        | Purpose                               |
+| --------------------------- | ------------------------------------- |
+| `planning-tasks.service.ts` | Full CRUD + activity writes for tasks |
 
 ## Actions
 
@@ -65,9 +91,30 @@ Simple comment thread on a task. Org-scoped, soft-delete.
 | `getTaskDetailAction`        | `PLANNING_TASKS_READ`   |
 | `createTaskAction`           | `PLANNING_TASKS_CREATE` |
 | `updateTaskAction`           | `PLANNING_TASKS_UPDATE` |
-| `changeTaskStatusAction`     | `PLANNING_TASKS_UPDATE` |
+| `startTaskAction`            | `PLANNING_TASKS_UPDATE` |
+| `completeTaskAction`         | `PLANNING_TASKS_UPDATE` |
+| `reopenTaskAction`           | `PLANNING_TASKS_UPDATE` |
+| `cancelTaskAction`           | `PLANNING_TASKS_UPDATE` |
 | `assignTaskAction`           | `PLANNING_TASKS_ASSIGN` |
 | `deleteTaskAction`           | `PLANNING_TASKS_DELETE` |
+
+## Components
+
+| File                                                       | Purpose                 |
+| ---------------------------------------------------------- | ----------------------- |
+| `src/components/planning/planning-task-status-badge.tsx`   | Status badge            |
+| `src/components/planning/planning-task-priority-badge.tsx` | Priority badge          |
+| `src/components/planning/planning-task-activity-list.tsx`  | Activity timeline       |
+| `tasks/_components/planning-task-create-dialog.tsx`        | Create task dialog      |
+| `tasks/_components/planning-task-detail-panel.tsx`         | Detail panel (DataView) |
+| `tasks/_components/tasks-client.tsx`                       | DataView client wrapper |
+
+## Migrations
+
+| File                                            | Purpose                                               |
+| ----------------------------------------------- | ----------------------------------------------------- |
+| `20260601200000_planning_module.sql`            | Initial tables, permissions, RLS                      |
+| `20260603120000_planning_tasks_v2_activity.sql` | task_number, cancelled status, planning_task_activity |
 
 ## Theme
 
@@ -79,24 +126,19 @@ Color: `#0d9488` (Teal)
 
 ### Phase 2 (Not yet implemented)
 
-- Schedules
-- Calendar view
-- Recurring tasks
+- Task comments
+- Labels/tags
+- Kanban board view
 
 ### Phase 3 (Not yet implemented)
 
+- Calendar view
+- Recurring tasks
+- Reminders/notifications
 - Workload planning
-- Team planning views
-- Capacity management
 
 ### Phase 4 (Not yet implemented)
 
 - Planning templates
-- Recurring schedules
 - Task dependencies
-
-### Phase 5 (Not yet implemented)
-
-- Integration with Workshop (link tasks to repair orders)
-- Integration with Warehouse (link tasks to inventory actions)
-- Integration with Help Desk (convert tickets to tasks)
+- Cross-module task creation (from Help Desk, Workshop, etc.)

--- a/apps/web/src/server/services/__tests__/planning-tasks.service.test.ts
+++ b/apps/web/src/server/services/__tests__/planning-tasks.service.test.ts
@@ -1,0 +1,597 @@
+/**
+ * @vitest-environment node
+ *
+ * Unit tests for PlanningTasksService.
+ * All Supabase interactions are mocked — no real DB connections.
+ *
+ * Covers:
+ *  - listForDataView (success, DB error, filters)
+ *  - getDetail (success, not found, DB error)
+ *  - create (success, creates task_created activity, DB error)
+ *  - update (success, creates activity per changed field)
+ *  - changeStatus (all transitions, correct timestamps + activity)
+ *  - assign (assign + unassign activity)
+ *  - softDelete (sets deleted_at, creates archived activity)
+ *
+ * RLS simulation (T-RLS):
+ *  - 42501 error → returns failure (not thrown)
+ *
+ * Security invariants (T-SEC):
+ *  - service never calls auth.getUser() — auth is caller responsibility
+ *  - no service-role bypass — all queries respect RLS
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PlanningTasksService } from "../planning-tasks.service";
+import type { PlanningTaskListRow, PlanningTaskDetail } from "../planning-tasks.service";
+import type { DataViewListParams } from "@/lib/data-view/types";
+
+// ─── Test fixtures ────────────────────────────────────────────────────────────
+
+const ORG_ID = "org-111";
+const USER_ID = "user-333";
+const TASK_ID = "task-aaa";
+const ASSIGNEE_ID = "user-555";
+
+const DEFAULT_PARAMS: DataViewListParams = {
+  page: 1,
+  pageSize: 20,
+  search: "",
+  sort: null,
+  filters: {},
+};
+
+function makeTaskRow(overrides: Partial<PlanningTaskListRow> = {}): PlanningTaskListRow {
+  return {
+    id: TASK_ID,
+    organization_id: ORG_ID,
+    task_number: "PT-000001",
+    title: "Test Task",
+    status: "open",
+    priority: "normal",
+    branch_id: null,
+    assigned_to: null,
+    assignee_name: null,
+    assignee_email: null,
+    created_by: USER_ID,
+    creator_name: "Test User",
+    creator_email: "test@example.com",
+    due_at: null,
+    started_at: null,
+    completed_at: null,
+    cancelled_at: null,
+    created_at: "2026-06-01T00:00:00Z",
+    updated_at: "2026-06-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeTaskDetail(overrides: Partial<PlanningTaskDetail> = {}): PlanningTaskDetail {
+  return {
+    ...makeTaskRow(),
+    description_plain: null,
+    description_rich: null,
+    updated_by: null,
+    deleted_at: null,
+    activity: [],
+    ...overrides,
+  };
+}
+
+// ─── Supabase mock factory ────────────────────────────────────────────────────
+
+function makeSupabaseMock() {
+  const insertMock = vi.fn().mockReturnThis();
+  const selectMock = vi.fn().mockReturnThis();
+  const updateMock = vi.fn().mockReturnThis();
+  const eqMock = vi.fn().mockReturnThis();
+  const isMock = vi.fn().mockReturnThis();
+  const inMock = vi.fn().mockReturnThis();
+  const orMock = vi.fn().mockReturnThis();
+  const orderMock = vi.fn().mockReturnThis();
+  const rangeMock = vi.fn().mockReturnThis();
+  const singleMock = vi.fn();
+
+  const fromMock = vi.fn(() => ({
+    select: selectMock,
+    insert: insertMock,
+    update: updateMock,
+    eq: eqMock,
+    is: isMock,
+    in: inMock,
+    or: orMock,
+    order: orderMock,
+    range: rangeMock,
+    single: singleMock,
+  }));
+
+  // Make chainable methods return the same object
+  const chain = {
+    select: selectMock,
+    insert: insertMock,
+    update: updateMock,
+    eq: eqMock,
+    is: isMock,
+    in: inMock,
+    or: orMock,
+    order: orderMock,
+    range: rangeMock,
+    single: singleMock,
+  };
+  Object.values(chain).forEach((fn) => {
+    if (fn !== singleMock) {
+      (fn as any).mockReturnValue(chain);
+    }
+  });
+
+  return { from: fromMock, _chain: chain };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("PlanningTasksService", () => {
+  // ── listForDataView ──────────────────────────────────────────────────────
+
+  describe("listForDataView", () => {
+    it("returns paginated rows on success", async () => {
+      const supabase = makeSupabaseMock();
+      const rawRows = [
+        {
+          id: TASK_ID,
+          organization_id: ORG_ID,
+          task_number: "PT-000001",
+          title: "Test Task",
+          status: "open",
+          priority: "normal",
+          branch_id: null,
+          assigned_to: null,
+          due_at: null,
+          started_at: null,
+          completed_at: null,
+          cancelled_at: null,
+          created_by: USER_ID,
+          created_at: "2026-06-01T00:00:00Z",
+          updated_at: "2026-06-01T00:00:00Z",
+          assignee: null,
+          creator: [{ first_name: "Test", last_name: "User", email: "test@example.com" }],
+        },
+      ];
+      supabase._chain.range.mockResolvedValueOnce({ data: rawRows, error: null, count: 1 });
+
+      const result = await PlanningTasksService.listForDataView(
+        supabase as any,
+        ORG_ID,
+        DEFAULT_PARAMS
+      );
+
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect(result.data.rows).toHaveLength(1);
+      expect(result.data.rows[0].task_number).toBe("PT-000001");
+      expect(result.data.totalCount).toBe(1);
+      expect(result.data.page).toBe(1);
+    });
+
+    it("returns failure on DB error", async () => {
+      const supabase = makeSupabaseMock();
+      supabase._chain.range.mockResolvedValueOnce({
+        data: null,
+        error: { message: "DB error" },
+        count: null,
+      });
+
+      const result = await PlanningTasksService.listForDataView(
+        supabase as any,
+        ORG_ID,
+        DEFAULT_PARAMS
+      );
+
+      expect(result.success).toBe(false);
+      expect((result as any).error).toBe("DB error");
+    });
+
+    it("T-RLS: 42501 error propagates as failure", async () => {
+      const supabase = makeSupabaseMock();
+      supabase._chain.range.mockResolvedValueOnce({
+        data: null,
+        error: { message: "new row violates row-level security policy", code: "42501" },
+        count: null,
+      });
+
+      const result = await PlanningTasksService.listForDataView(
+        supabase as any,
+        ORG_ID,
+        DEFAULT_PARAMS
+      );
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  // ── getDetail ────────────────────────────────────────────────────────────
+
+  describe("getDetail", () => {
+    it("returns task detail with activity on success", async () => {
+      const supabase = makeSupabaseMock();
+      const rawTask = {
+        id: TASK_ID,
+        organization_id: ORG_ID,
+        task_number: "PT-000001",
+        title: "Test Task",
+        description_plain: "Hello",
+        description_rich: null,
+        status: "open",
+        priority: "normal",
+        branch_id: null,
+        assigned_to: null,
+        due_at: null,
+        started_at: null,
+        completed_at: null,
+        cancelled_at: null,
+        created_by: USER_ID,
+        updated_by: null,
+        created_at: "2026-06-01T00:00:00Z",
+        updated_at: "2026-06-01T00:00:00Z",
+        deleted_at: null,
+        assignee: null,
+        creator: [{ first_name: "Test", last_name: "User", email: "test@example.com" }],
+      };
+      const rawActivity = [
+        {
+          id: "act-1",
+          organization_id: ORG_ID,
+          task_id: TASK_ID,
+          activity_type: "task_created",
+          actor_id: USER_ID,
+          message: "Task created",
+          metadata: null,
+          created_at: "2026-06-01T00:00:00Z",
+          actor: [{ first_name: "Test", last_name: "User", email: "test@example.com" }],
+        },
+      ];
+
+      // First .from().select().eq().eq().is().single() → task
+      supabase._chain.single.mockResolvedValueOnce({ data: rawTask, error: null });
+      // Second .from().select().eq().order() → activity
+      supabase._chain.order.mockResolvedValueOnce({ data: rawActivity, error: null });
+
+      const result = await PlanningTasksService.getDetail(supabase as any, ORG_ID, TASK_ID);
+
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect(result.data.id).toBe(TASK_ID);
+      expect(result.data.description_plain).toBe("Hello");
+      expect(result.data.activity).toHaveLength(1);
+      expect(result.data.activity[0].activity_type).toBe("task_created");
+    });
+
+    it("returns failure when task not found", async () => {
+      const supabase = makeSupabaseMock();
+      supabase._chain.single.mockResolvedValueOnce({
+        data: null,
+        error: { message: "No rows found", code: "PGRST116" },
+      });
+
+      const result = await PlanningTasksService.getDetail(supabase as any, ORG_ID, TASK_ID);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  // ── create ───────────────────────────────────────────────────────────────
+
+  describe("create", () => {
+    it("inserts task and writes task_created activity", async () => {
+      const supabase = makeSupabaseMock();
+      const rawTask = {
+        id: TASK_ID,
+        organization_id: ORG_ID,
+        task_number: "PT-000001",
+        title: "New Task",
+        description_plain: null,
+        description_rich: null,
+        status: "open",
+        priority: "normal",
+        branch_id: null,
+        assigned_to: null,
+        due_at: null,
+        started_at: null,
+        completed_at: null,
+        cancelled_at: null,
+        created_by: USER_ID,
+        updated_by: null,
+        created_at: "2026-06-01T00:00:00Z",
+        updated_at: "2026-06-01T00:00:00Z",
+        deleted_at: null,
+        assignee: null,
+        creator: null,
+      };
+
+      // Call 1: insert().select().single() for task creation
+      supabase._chain.single.mockResolvedValueOnce({
+        data: { id: TASK_ID, organization_id: ORG_ID },
+        error: null,
+      });
+      // Call 2: getDetail → select().eq().eq().is().single()
+      supabase._chain.single.mockResolvedValueOnce({ data: rawTask, error: null });
+      // Call 3: getDetail activity → select().eq().order()
+      supabase._chain.order.mockResolvedValueOnce({ data: [], error: null });
+      // Note: insertActivity calls insert() which returns chain by default — no override needed
+
+      const result = await PlanningTasksService.create(supabase as any, ORG_ID, USER_ID, {
+        title: "New Task",
+        priority: "normal",
+      });
+
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect(result.data.title).toBe("New Task");
+      expect(result.data.status).toBe("open");
+      // Verify insert was called at least twice (task + activity)
+      expect(supabase._chain.insert).toHaveBeenCalledTimes(2);
+    });
+
+    it("returns failure when DB insert fails", async () => {
+      const supabase = makeSupabaseMock();
+      supabase._chain.single.mockResolvedValueOnce({
+        data: null,
+        error: { message: "Insert failed" },
+      });
+
+      const result = await PlanningTasksService.create(supabase as any, ORG_ID, USER_ID, {
+        title: "New Task",
+        priority: "normal",
+      });
+
+      expect(result.success).toBe(false);
+      expect((result as any).error).toBe("Insert failed");
+    });
+
+    it("T-RLS: 42501 on insert returns failure", async () => {
+      const supabase = makeSupabaseMock();
+      supabase._chain.single.mockResolvedValueOnce({
+        data: null,
+        error: { message: "row-level security policy", code: "42501" },
+      });
+
+      const result = await PlanningTasksService.create(supabase as any, ORG_ID, USER_ID, {
+        title: "Unauthorized Task",
+        priority: "normal",
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
+
+  // ── changeStatus ─────────────────────────────────────────────────────────
+
+  describe("changeStatus", () => {
+    it("sets completed_at when completing a task", async () => {
+      const supabase = makeSupabaseMock();
+      supabase._chain.is.mockResolvedValueOnce({ data: null, error: null });
+      supabase._chain.insert.mockResolvedValueOnce({ data: null, error: null });
+      const rawTask = {
+        id: TASK_ID,
+        organization_id: ORG_ID,
+        task_number: "PT-000001",
+        title: "Task",
+        description_plain: null,
+        description_rich: null,
+        status: "completed",
+        priority: "normal",
+        branch_id: null,
+        assigned_to: null,
+        due_at: null,
+        started_at: null,
+        completed_at: "2026-06-01T12:00:00Z",
+        cancelled_at: null,
+        created_by: USER_ID,
+        updated_by: USER_ID,
+        created_at: "2026-06-01T00:00:00Z",
+        updated_at: "2026-06-01T12:00:00Z",
+        deleted_at: null,
+        assignee: null,
+        creator: null,
+      };
+      supabase._chain.single.mockResolvedValueOnce({ data: rawTask, error: null });
+      supabase._chain.order.mockResolvedValueOnce({ data: [], error: null });
+
+      const result = await PlanningTasksService.changeStatus(
+        supabase as any,
+        ORG_ID,
+        USER_ID,
+        TASK_ID,
+        "completed",
+        "open"
+      );
+
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect(result.data.status).toBe("completed");
+      // Verify update was called with completed_at
+      expect(supabase._chain.update).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "completed", completed_at: expect.any(String) })
+      );
+    });
+
+    it("clears completed_at when reopening", async () => {
+      const supabase = makeSupabaseMock();
+      supabase._chain.is.mockResolvedValueOnce({ data: null, error: null });
+      supabase._chain.insert.mockResolvedValueOnce({ data: null, error: null });
+      const rawTask = {
+        id: TASK_ID,
+        organization_id: ORG_ID,
+        task_number: "PT-000001",
+        title: "Task",
+        description_plain: null,
+        description_rich: null,
+        status: "open",
+        priority: "normal",
+        branch_id: null,
+        assigned_to: null,
+        due_at: null,
+        started_at: null,
+        completed_at: null,
+        cancelled_at: null,
+        created_by: USER_ID,
+        updated_by: USER_ID,
+        created_at: "2026-06-01T00:00:00Z",
+        updated_at: "2026-06-01T12:00:00Z",
+        deleted_at: null,
+        assignee: null,
+        creator: null,
+      };
+      supabase._chain.single.mockResolvedValueOnce({ data: rawTask, error: null });
+      supabase._chain.order.mockResolvedValueOnce({ data: [], error: null });
+
+      const result = await PlanningTasksService.changeStatus(
+        supabase as any,
+        ORG_ID,
+        USER_ID,
+        TASK_ID,
+        "open",
+        "completed"
+      );
+
+      expect(result.success).toBe(true);
+      expect(supabase._chain.update).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "open", completed_at: null, cancelled_at: null })
+      );
+    });
+
+    it("sets cancelled_at when cancelling", async () => {
+      const supabase = makeSupabaseMock();
+      supabase._chain.is.mockResolvedValueOnce({ data: null, error: null });
+      supabase._chain.insert.mockResolvedValueOnce({ data: null, error: null });
+      const rawTask = {
+        id: TASK_ID,
+        organization_id: ORG_ID,
+        task_number: "PT-000001",
+        title: "Task",
+        description_plain: null,
+        description_rich: null,
+        status: "cancelled",
+        priority: "normal",
+        branch_id: null,
+        assigned_to: null,
+        due_at: null,
+        started_at: null,
+        completed_at: null,
+        cancelled_at: "2026-06-01T12:00:00Z",
+        created_by: USER_ID,
+        updated_by: USER_ID,
+        created_at: "2026-06-01T00:00:00Z",
+        updated_at: "2026-06-01T12:00:00Z",
+        deleted_at: null,
+        assignee: null,
+        creator: null,
+      };
+      supabase._chain.single.mockResolvedValueOnce({ data: rawTask, error: null });
+      supabase._chain.order.mockResolvedValueOnce({ data: [], error: null });
+
+      await PlanningTasksService.changeStatus(
+        supabase as any,
+        ORG_ID,
+        USER_ID,
+        TASK_ID,
+        "cancelled",
+        "in_progress"
+      );
+
+      expect(supabase._chain.update).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "cancelled", cancelled_at: expect.any(String) })
+      );
+    });
+  });
+
+  // ── assign ───────────────────────────────────────────────────────────────
+
+  describe("assign", () => {
+    it("writes assigned activity when assigning", async () => {
+      const supabase = makeSupabaseMock();
+      supabase._chain.is.mockResolvedValueOnce({ data: null, error: null });
+      supabase._chain.insert.mockResolvedValueOnce({ data: null, error: null });
+      const rawTask = {
+        ...makeTaskDetail({ assigned_to: ASSIGNEE_ID, assignee_name: "Assignee" }),
+      };
+      supabase._chain.single.mockResolvedValueOnce({ data: rawTask, error: null });
+      supabase._chain.order.mockResolvedValueOnce({ data: [], error: null });
+
+      await PlanningTasksService.assign(
+        supabase as any,
+        ORG_ID,
+        USER_ID,
+        { id: TASK_ID, assigned_to: ASSIGNEE_ID },
+        null
+      );
+
+      expect(supabase._chain.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          activity_type: "assigned",
+          metadata: { from: null, to: ASSIGNEE_ID },
+        })
+      );
+    });
+
+    it("writes unassigned activity when unassigning", async () => {
+      const supabase = makeSupabaseMock();
+      supabase._chain.is.mockResolvedValueOnce({ data: null, error: null });
+      supabase._chain.insert.mockResolvedValueOnce({ data: null, error: null });
+      const rawTask = { ...makeTaskDetail({ assigned_to: null }) };
+      supabase._chain.single.mockResolvedValueOnce({ data: rawTask, error: null });
+      supabase._chain.order.mockResolvedValueOnce({ data: [], error: null });
+
+      await PlanningTasksService.assign(
+        supabase as any,
+        ORG_ID,
+        USER_ID,
+        { id: TASK_ID, assigned_to: null },
+        ASSIGNEE_ID
+      );
+
+      expect(supabase._chain.insert).toHaveBeenCalledWith(
+        expect.objectContaining({ activity_type: "unassigned" })
+      );
+    });
+  });
+
+  // ── softDelete ───────────────────────────────────────────────────────────
+
+  describe("softDelete", () => {
+    it("sets deleted_at and writes archived activity", async () => {
+      const supabase = makeSupabaseMock();
+      supabase._chain.is.mockResolvedValueOnce({ data: null, error: null });
+      supabase._chain.insert.mockResolvedValueOnce({ data: null, error: null });
+
+      const result = await PlanningTasksService.softDelete(
+        supabase as any,
+        ORG_ID,
+        USER_ID,
+        TASK_ID
+      );
+
+      expect(result.success).toBe(true);
+      expect(supabase._chain.update).toHaveBeenCalledWith(
+        expect.objectContaining({ deleted_at: expect.any(String) })
+      );
+      expect(supabase._chain.insert).toHaveBeenCalledWith(
+        expect.objectContaining({ activity_type: "archived" })
+      );
+    });
+
+    it("returns failure on DB error", async () => {
+      const supabase = makeSupabaseMock();
+      supabase._chain.is.mockResolvedValueOnce({
+        data: null,
+        error: { message: "Delete failed" },
+      });
+
+      const result = await PlanningTasksService.softDelete(
+        supabase as any,
+        ORG_ID,
+        USER_ID,
+        TASK_ID
+      );
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/apps/web/src/server/services/planning-tasks.service.ts
+++ b/apps/web/src/server/services/planning-tasks.service.ts
@@ -7,7 +7,6 @@ import type {
   TaskListFilters,
   CreateTaskInput,
   UpdateTaskInput,
-  ChangeTaskStatusInput,
   AssignTaskInput,
 } from "@/lib/validations/planning";
 
@@ -17,7 +16,8 @@ import type {
 
 export interface PlanningTaskListRow {
   id: string;
-  org_id: string;
+  organization_id: string;
+  task_number: string;
   title: string;
   status: TaskStatus;
   priority: TaskPriority;
@@ -29,28 +29,82 @@ export interface PlanningTaskListRow {
   creator_name: string | null;
   creator_email: string | null;
   due_at: string | null;
+  started_at: string | null;
+  completed_at: string | null;
+  cancelled_at: string | null;
   created_at: string;
   updated_at: string;
 }
 
-export interface PlanningTaskDetail extends PlanningTaskListRow {
-  description: string | null;
-  deleted_at: string | null;
+export interface PlanningTaskActivity {
+  id: string;
+  organization_id: string;
+  task_id: string;
+  activity_type: string;
+  actor_id: string | null;
+  actor_name: string | null;
+  message: string | null;
+  metadata: Record<string, unknown> | null;
+  created_at: string;
 }
 
-type ActionResult<T> = { success: true; data: T } | { success: false; error: string };
+export interface PlanningTaskDetail extends PlanningTaskListRow {
+  description_plain: string | null;
+  description_rich: unknown | null;
+  updated_by: string | null;
+  deleted_at: string | null;
+  activity: PlanningTaskActivity[];
+}
+
+export type ServiceResult<T> = { success: true; data: T } | { success: false; error: string };
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function displayName(
+  firstName: string | null,
+  lastName: string | null,
+  email: string | null
+): string | null {
+  const name = [firstName, lastName].filter(Boolean).join(" ").trim();
+  return name || email || null;
+}
+
+async function insertActivity(
+  supabase: SupabaseClient,
+  orgId: string,
+  taskId: string,
+  actorId: string,
+  activityType: string,
+  message: string,
+  metadata: Record<string, unknown> | null = null,
+  branchId: string | null = null
+): Promise<void> {
+  await supabase.from("planning_task_activity").insert({
+    organization_id: orgId,
+    task_id: taskId,
+    activity_type: activityType,
+    actor_id: actorId,
+    message,
+    metadata,
+    branch_id: branchId,
+  });
+}
 
 // ---------------------------------------------------------------------------
 // Service
 // ---------------------------------------------------------------------------
 
 export const PlanningTasksService = {
+  // ── List for DataView ────────────────────────────────────────────────────
+
   async listForDataView(
     supabase: SupabaseClient,
     orgId: string,
     params: DataViewListParams,
     filters: TaskListFilters = {}
-  ): Promise<ActionResult<PaginatedResult<PlanningTaskListRow>>> {
+  ): Promise<ServiceResult<PaginatedResult<PlanningTaskListRow>>> {
     try {
       const page = params.page ?? 1;
       const pageSize = params.pageSize ?? 20;
@@ -59,242 +113,390 @@ export const PlanningTasksService = {
       let query = supabase
         .from("planning_tasks")
         .select(
-          `
-          id, org_id, title, status, priority, branch_id, assigned_to,
-          due_at, created_by, created_at, updated_at,
-          assignee:profiles!planning_tasks_assigned_to_fkey(first_name, last_name, email),
-          creator:profiles!planning_tasks_created_by_fkey(first_name, last_name, email)
-        `,
+          `id, organization_id, task_number, title, status, priority,
+           branch_id, assigned_to, due_at, started_at, completed_at, cancelled_at,
+           created_by, created_at, updated_at,
+           assignee:users!planning_tasks_assigned_to_fkey(first_name, last_name, email),
+           creator:users!planning_tasks_created_by_fkey(first_name, last_name, email)`,
           { count: "exact" }
         )
-        .eq("org_id", orgId)
+        .eq("organization_id", orgId)
         .is("deleted_at", null);
 
-      if (filters.status?.length) {
-        query = query.in("status", filters.status);
-      }
-      if (filters.priority?.length) {
-        query = query.in("priority", filters.priority);
-      }
+      if (filters.status?.length) query = query.in("status", filters.status);
+      if (filters.priority?.length) query = query.in("priority", filters.priority);
       if (filters.branch_id !== undefined) {
-        if (filters.branch_id === null) {
-          query = query.is("branch_id", null);
-        } else {
-          query = query.eq("branch_id", filters.branch_id);
-        }
+        filters.branch_id === null
+          ? (query = query.is("branch_id", null))
+          : (query = query.eq("branch_id", filters.branch_id));
       }
       if (filters.assigned_to !== undefined) {
-        if (filters.assigned_to === null) {
-          query = query.is("assigned_to", null);
-        } else {
-          query = query.eq("assigned_to", filters.assigned_to);
-        }
+        filters.assigned_to === null
+          ? (query = query.is("assigned_to", null))
+          : (query = query.eq("assigned_to", filters.assigned_to));
       }
       if (filters.search) {
-        query = query.ilike("title", `%${filters.search}%`);
+        query = query.or(`title.ilike.%${filters.search}%,task_number.ilike.%${filters.search}%`);
       }
 
       const sortField = params.sort?.field ?? "created_at";
-      const sortDir = params.sort?.direction === "asc";
-      query = query.order(sortField, { ascending: sortDir }).range(offset, offset + pageSize - 1);
+      const sortAsc = params.sort?.direction === "asc";
+      query = query.order(sortField, { ascending: sortAsc }).range(offset, offset + pageSize - 1);
 
       const { data, error, count } = await query;
-
       if (error) return { success: false, error: error.message };
 
       const rows: PlanningTaskListRow[] = (data ?? []).map((r) => {
-        const assignee = Array.isArray(r.assignee) ? r.assignee[0] : r.assignee;
-        const creator = Array.isArray(r.creator) ? r.creator[0] : r.creator;
+        const row = r as any;
+        const assignee = Array.isArray(row.assignee) ? row.assignee[0] : row.assignee;
+        const creator = Array.isArray(row.creator) ? row.creator[0] : row.creator;
         return {
-          id: r.id,
-          org_id: r.org_id,
-          title: r.title,
-          status: r.status as TaskStatus,
-          priority: r.priority as TaskPriority,
-          branch_id: r.branch_id ?? null,
-          assigned_to: r.assigned_to ?? null,
+          id: row.id,
+          organization_id: row.organization_id,
+          task_number: row.task_number,
+          title: row.title,
+          status: row.status as TaskStatus,
+          priority: row.priority as TaskPriority,
+          branch_id: row.branch_id ?? null,
+          assigned_to: row.assigned_to ?? null,
           assignee_name: assignee
-            ? [assignee.first_name, assignee.last_name].filter(Boolean).join(" ") || null
+            ? displayName(assignee.first_name, assignee.last_name, assignee.email)
             : null,
           assignee_email: assignee?.email ?? null,
-          created_by: r.created_by,
+          created_by: row.created_by,
           creator_name: creator
-            ? [creator.first_name, creator.last_name].filter(Boolean).join(" ") || null
+            ? displayName(creator.first_name, creator.last_name, creator.email)
             : null,
           creator_email: creator?.email ?? null,
-          due_at: r.due_at ?? null,
-          created_at: r.created_at,
-          updated_at: r.updated_at,
+          due_at: row.due_at ?? null,
+          started_at: row.started_at ?? null,
+          completed_at: row.completed_at ?? null,
+          cancelled_at: row.cancelled_at ?? null,
+          created_at: row.created_at,
+          updated_at: row.updated_at,
+        };
+      });
+
+      return { success: true, data: { rows, totalCount: count ?? 0, page, pageSize } };
+    } catch (e) {
+      return { success: false, error: e instanceof Error ? e.message : "Unexpected error" };
+    }
+  },
+
+  // ── Get detail ───────────────────────────────────────────────────────────
+
+  async getDetail(
+    supabase: SupabaseClient,
+    orgId: string,
+    taskId: string
+  ): Promise<ServiceResult<PlanningTaskDetail>> {
+    try {
+      const { data: raw, error } = await supabase
+        .from("planning_tasks")
+        .select(
+          `id, organization_id, task_number, title, description_plain, description_rich,
+           status, priority, branch_id, assigned_to, due_at, started_at, completed_at,
+           cancelled_at, created_by, updated_by, created_at, updated_at, deleted_at,
+           assignee:users!planning_tasks_assigned_to_fkey(first_name, last_name, email),
+           creator:users!planning_tasks_created_by_fkey(first_name, last_name, email)`
+        )
+        .eq("organization_id", orgId)
+        .eq("id", taskId)
+        .is("deleted_at", null)
+        .single();
+
+      if (error) return { success: false, error: error.message };
+      if (!raw) return { success: false, error: "Not found" };
+
+      const row = raw as any;
+      const assignee = Array.isArray(row.assignee) ? row.assignee[0] : row.assignee;
+      const creator = Array.isArray(row.creator) ? row.creator[0] : row.creator;
+
+      // Fetch activity
+      const { data: activityRaw } = await supabase
+        .from("planning_task_activity")
+        .select(
+          `id, organization_id, task_id, activity_type, actor_id, message, metadata, created_at,
+           actor:users!planning_task_activity_actor_id_fkey(first_name, last_name, email)`
+        )
+        .eq("task_id", taskId)
+        .order("created_at", { ascending: true });
+
+      const activity: PlanningTaskActivity[] = (activityRaw ?? []).map((a) => {
+        const act = a as any;
+        const actor = Array.isArray(act.actor) ? act.actor[0] : act.actor;
+        return {
+          id: act.id,
+          organization_id: act.organization_id,
+          task_id: act.task_id,
+          activity_type: act.activity_type,
+          actor_id: act.actor_id ?? null,
+          actor_name: actor ? displayName(actor.first_name, actor.last_name, actor.email) : null,
+          message: act.message ?? null,
+          metadata: act.metadata ?? null,
+          created_at: act.created_at,
         };
       });
 
       return {
         success: true,
         data: {
-          rows,
-          totalCount: count ?? 0,
-          page,
-          pageSize,
-        },
-      };
-    } catch (e) {
-      return { success: false, error: e instanceof Error ? e.message : "Unexpected error" };
-    }
-  },
-
-  async getDetail(
-    supabase: SupabaseClient,
-    orgId: string,
-    taskId: string
-  ): Promise<ActionResult<PlanningTaskDetail>> {
-    try {
-      const { data, error } = await supabase
-        .from("planning_tasks")
-        .select(
-          `
-          id, org_id, title, description, status, priority, branch_id, assigned_to,
-          due_at, created_by, created_at, updated_at, deleted_at,
-          assignee:profiles!planning_tasks_assigned_to_fkey(first_name, last_name, email),
-          creator:profiles!planning_tasks_created_by_fkey(first_name, last_name, email)
-        `
-        )
-        .eq("org_id", orgId)
-        .eq("id", taskId)
-        .is("deleted_at", null)
-        .single();
-
-      if (error) return { success: false, error: error.message };
-      if (!data) return { success: false, error: "Not found" };
-
-      const assignee = Array.isArray(data.assignee) ? data.assignee[0] : data.assignee;
-      const creator = Array.isArray(data.creator) ? data.creator[0] : data.creator;
-
-      return {
-        success: true,
-        data: {
-          id: data.id,
-          org_id: data.org_id,
-          title: data.title,
-          description: data.description ?? null,
-          status: data.status as TaskStatus,
-          priority: data.priority as TaskPriority,
-          branch_id: data.branch_id ?? null,
-          assigned_to: data.assigned_to ?? null,
+          id: row.id,
+          organization_id: row.organization_id,
+          task_number: row.task_number,
+          title: row.title,
+          description_plain: row.description_plain ?? null,
+          description_rich: row.description_rich ?? null,
+          status: row.status as TaskStatus,
+          priority: row.priority as TaskPriority,
+          branch_id: row.branch_id ?? null,
+          assigned_to: row.assigned_to ?? null,
           assignee_name: assignee
-            ? [assignee.first_name, assignee.last_name].filter(Boolean).join(" ") || null
+            ? displayName(assignee.first_name, assignee.last_name, assignee.email)
             : null,
           assignee_email: assignee?.email ?? null,
-          created_by: data.created_by,
+          created_by: row.created_by,
           creator_name: creator
-            ? [creator.first_name, creator.last_name].filter(Boolean).join(" ") || null
+            ? displayName(creator.first_name, creator.last_name, creator.email)
             : null,
           creator_email: creator?.email ?? null,
-          due_at: data.due_at ?? null,
-          created_at: data.created_at,
-          updated_at: data.updated_at,
-          deleted_at: data.deleted_at ?? null,
+          updated_by: row.updated_by ?? null,
+          due_at: row.due_at ?? null,
+          started_at: row.started_at ?? null,
+          completed_at: row.completed_at ?? null,
+          cancelled_at: row.cancelled_at ?? null,
+          created_at: row.created_at,
+          updated_at: row.updated_at,
+          deleted_at: row.deleted_at ?? null,
+          activity,
         },
       };
     } catch (e) {
       return { success: false, error: e instanceof Error ? e.message : "Unexpected error" };
     }
   },
+
+  // ── Create ───────────────────────────────────────────────────────────────
 
   async create(
     supabase: SupabaseClient,
     orgId: string,
     userId: string,
     input: CreateTaskInput
-  ): Promise<ActionResult<PlanningTaskDetail>> {
+  ): Promise<ServiceResult<PlanningTaskDetail>> {
     try {
-      const { data, error } = await supabase
+      const { data: inserted, error } = await supabase
         .from("planning_tasks")
         .insert({
-          org_id: orgId,
+          organization_id: orgId,
           created_by: userId,
+          updated_by: userId,
           title: input.title,
-          description: input.description ?? null,
-          status: input.status,
-          priority: input.priority,
+          description_plain: input.description_plain ?? null,
+          description_rich: (input.description_rich as object | null) ?? null,
+          status: "open",
+          priority: input.priority ?? "normal",
           branch_id: input.branch_id ?? null,
           assigned_to: input.assigned_to ?? null,
           due_at: input.due_at ?? null,
         })
-        .select("id")
+        .select("id, organization_id")
         .single();
 
       if (error) return { success: false, error: error.message };
 
-      return PlanningTasksService.getDetail(supabase, orgId, data.id);
+      const taskId = (inserted as any).id as string;
+
+      await insertActivity(supabase, orgId, taskId, userId, "task_created", "Task created");
+
+      if (input.assigned_to) {
+        await insertActivity(
+          supabase,
+          orgId,
+          taskId,
+          userId,
+          "assigned",
+          "Task assigned",
+          { from: null, to: input.assigned_to },
+          input.branch_id ?? null
+        );
+      }
+
+      return PlanningTasksService.getDetail(supabase, orgId, taskId);
     } catch (e) {
       return { success: false, error: e instanceof Error ? e.message : "Unexpected error" };
     }
   },
 
+  // ── Update ───────────────────────────────────────────────────────────────
+
   async update(
     supabase: SupabaseClient,
     orgId: string,
-    input: UpdateTaskInput
-  ): Promise<ActionResult<PlanningTaskDetail>> {
+    userId: string,
+    input: UpdateTaskInput,
+    previous: {
+      title: string;
+      priority: TaskPriority;
+      due_at: string | null;
+      description_plain: string | null;
+    }
+  ): Promise<ServiceResult<PlanningTaskDetail>> {
     try {
       const { error } = await supabase
         .from("planning_tasks")
         .update({
           title: input.title,
-          description: input.description ?? null,
-          status: input.status,
+          description_plain: input.description_plain ?? null,
+          description_rich: (input.description_rich as object | null) ?? null,
           priority: input.priority,
           branch_id: input.branch_id ?? null,
-          assigned_to: input.assigned_to ?? null,
           due_at: input.due_at ?? null,
+          updated_by: userId,
         })
         .eq("id", input.id)
-        .eq("org_id", orgId)
+        .eq("organization_id", orgId)
         .is("deleted_at", null);
 
       if (error) return { success: false, error: error.message };
+
+      // Write activity for each changed field
+      if (input.title !== previous.title) {
+        await insertActivity(supabase, orgId, input.id, userId, "title_changed", "Title updated", {
+          from: previous.title,
+          to: input.title,
+        });
+      }
+      if (input.priority !== previous.priority) {
+        await insertActivity(
+          supabase,
+          orgId,
+          input.id,
+          userId,
+          "priority_changed",
+          "Priority changed",
+          { from: previous.priority, to: input.priority }
+        );
+      }
+      if ((input.due_at ?? null) !== (previous.due_at ?? null)) {
+        await insertActivity(
+          supabase,
+          orgId,
+          input.id,
+          userId,
+          "due_date_changed",
+          "Due date updated",
+          { from: previous.due_at, to: input.due_at ?? null }
+        );
+      }
+      if ((input.description_plain ?? null) !== (previous.description_plain ?? null)) {
+        await insertActivity(
+          supabase,
+          orgId,
+          input.id,
+          userId,
+          "description_changed",
+          "Description updated"
+        );
+      }
 
       return PlanningTasksService.getDetail(supabase, orgId, input.id);
     } catch (e) {
       return { success: false, error: e instanceof Error ? e.message : "Unexpected error" };
     }
   },
+
+  // ── Change status ────────────────────────────────────────────────────────
 
   async changeStatus(
     supabase: SupabaseClient,
     orgId: string,
-    input: ChangeTaskStatusInput
-  ): Promise<ActionResult<PlanningTaskDetail>> {
+    userId: string,
+    taskId: string,
+    newStatus: TaskStatus,
+    previousStatus: TaskStatus
+  ): Promise<ServiceResult<PlanningTaskDetail>> {
     try {
+      const now = new Date().toISOString();
+      const patch: Record<string, unknown> = {
+        status: newStatus,
+        updated_by: userId,
+      };
+
+      let activityType = "status_changed";
+      let message = `Status changed from ${previousStatus} to ${newStatus}`;
+
+      if (newStatus === "in_progress" && previousStatus === "open") {
+        patch.started_at = now;
+        activityType = "status_changed";
+      }
+      if (newStatus === "completed") {
+        patch.completed_at = now;
+        patch.cancelled_at = null;
+        activityType = "completed";
+        message = "Task marked as completed";
+      }
+      if (newStatus === "cancelled") {
+        patch.cancelled_at = now;
+        patch.completed_at = null;
+        activityType = "cancelled";
+        message = "Task cancelled";
+      }
+      if (
+        newStatus === "open" &&
+        (previousStatus === "completed" || previousStatus === "cancelled")
+      ) {
+        patch.completed_at = null;
+        patch.cancelled_at = null;
+        activityType = "reopened";
+        message = "Task reopened";
+      }
+
       const { error } = await supabase
         .from("planning_tasks")
-        .update({ status: input.status })
-        .eq("id", input.id)
-        .eq("org_id", orgId)
+        .update(patch)
+        .eq("id", taskId)
+        .eq("organization_id", orgId)
         .is("deleted_at", null);
 
       if (error) return { success: false, error: error.message };
 
-      return PlanningTasksService.getDetail(supabase, orgId, input.id);
+      await insertActivity(supabase, orgId, taskId, userId, activityType, message, {
+        from: previousStatus,
+        to: newStatus,
+      });
+
+      return PlanningTasksService.getDetail(supabase, orgId, taskId);
     } catch (e) {
       return { success: false, error: e instanceof Error ? e.message : "Unexpected error" };
     }
   },
+
+  // ── Assign ───────────────────────────────────────────────────────────────
 
   async assign(
     supabase: SupabaseClient,
     orgId: string,
-    input: AssignTaskInput
-  ): Promise<ActionResult<PlanningTaskDetail>> {
+    userId: string,
+    input: AssignTaskInput,
+    previousAssignee: string | null
+  ): Promise<ServiceResult<PlanningTaskDetail>> {
     try {
       const { error } = await supabase
         .from("planning_tasks")
-        .update({ assigned_to: input.assigned_to })
+        .update({ assigned_to: input.assigned_to, updated_by: userId })
         .eq("id", input.id)
-        .eq("org_id", orgId)
+        .eq("organization_id", orgId)
         .is("deleted_at", null);
 
       if (error) return { success: false, error: error.message };
+
+      const activityType = input.assigned_to ? "assigned" : "unassigned";
+      const message = input.assigned_to ? "Task assigned" : "Task unassigned";
+      await insertActivity(supabase, orgId, input.id, userId, activityType, message, {
+        from: previousAssignee,
+        to: input.assigned_to,
+      });
 
       return PlanningTasksService.getDetail(supabase, orgId, input.id);
     } catch (e) {
@@ -302,21 +504,25 @@ export const PlanningTasksService = {
     }
   },
 
+  // ── Soft delete ──────────────────────────────────────────────────────────
+
   async softDelete(
     supabase: SupabaseClient,
     orgId: string,
+    userId: string,
     taskId: string
-  ): Promise<ActionResult<void>> {
+  ): Promise<ServiceResult<void>> {
     try {
       const { error } = await supabase
         .from("planning_tasks")
-        .update({ deleted_at: new Date().toISOString() })
+        .update({ deleted_at: new Date().toISOString(), updated_by: userId })
         .eq("id", taskId)
-        .eq("org_id", orgId)
+        .eq("organization_id", orgId)
         .is("deleted_at", null);
 
       if (error) return { success: false, error: error.message };
 
+      await insertActivity(supabase, orgId, taskId, userId, "archived", "Task archived");
       return { success: true, data: undefined };
     } catch (e) {
       return { success: false, error: e instanceof Error ? e.message : "Unexpected error" };

--- a/apps/web/supabase/migrations/20260603120000_planning_tasks_v2_activity.sql
+++ b/apps/web/supabase/migrations/20260603120000_planning_tasks_v2_activity.sql
@@ -1,0 +1,84 @@
+-- ===========================================================================
+-- Planning Tasks V2: task_number, cancelled status, activity table
+-- ===========================================================================
+
+-- 1. Add missing columns to planning_tasks
+ALTER TABLE public.planning_tasks
+  ADD COLUMN IF NOT EXISTS task_number TEXT,
+  ADD COLUMN IF NOT EXISTS cancelled_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS started_at   TIMESTAMPTZ;
+
+-- 2. Drop old status constraint and add cancelled
+ALTER TABLE public.planning_tasks DROP CONSTRAINT IF EXISTS planning_tasks_status_check;
+ALTER TABLE public.planning_tasks ADD CONSTRAINT planning_tasks_status_check
+  CHECK (status IN ('open', 'in_progress', 'completed', 'cancelled'));
+
+-- 3. Sequence for task numbers
+CREATE SEQUENCE IF NOT EXISTS public.planning_task_number_seq;
+
+-- 4. Trigger function
+CREATE OR REPLACE FUNCTION public.generate_planning_task_number()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  IF NEW.task_number IS NULL THEN
+    NEW.task_number := 'PT-' || LPAD(nextval('public.planning_task_number_seq')::TEXT, 6, '0');
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+-- 5. Attach trigger
+DROP TRIGGER IF EXISTS planning_tasks_task_number ON public.planning_tasks;
+CREATE TRIGGER planning_tasks_task_number
+  BEFORE INSERT ON public.planning_tasks
+  FOR EACH ROW EXECUTE FUNCTION public.generate_planning_task_number();
+
+-- 6. Backfill existing rows
+UPDATE public.planning_tasks
+SET task_number = 'PT-' || LPAD(nextval('public.planning_task_number_seq')::TEXT, 6, '0')
+WHERE task_number IS NULL;
+
+-- 7. Now enforce NOT NULL + unique
+ALTER TABLE public.planning_tasks ALTER COLUMN task_number SET NOT NULL;
+ALTER TABLE public.planning_tasks DROP CONSTRAINT IF EXISTS planning_tasks_task_number_unique;
+ALTER TABLE public.planning_tasks ADD CONSTRAINT planning_tasks_task_number_unique UNIQUE (task_number);
+
+CREATE INDEX IF NOT EXISTS planning_tasks_task_number_idx ON public.planning_tasks (task_number);
+
+-- 8. planning_task_activity table
+CREATE TABLE IF NOT EXISTS public.planning_task_activity (
+  id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id UUID        NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  branch_id       UUID        REFERENCES public.branches(id) ON DELETE SET NULL,
+  task_id         UUID        NOT NULL REFERENCES public.planning_tasks(id) ON DELETE CASCADE,
+  activity_type   TEXT        NOT NULL,
+  actor_id        UUID        REFERENCES public.users(id) ON DELETE SET NULL,
+  message         TEXT,
+  metadata        JSONB,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS planning_task_activity_task_idx ON public.planning_task_activity (task_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS planning_task_activity_org_idx  ON public.planning_task_activity (organization_id, created_at DESC);
+
+-- 9. RLS for activity table
+ALTER TABLE public.planning_task_activity ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "planning_task_activity_select" ON public.planning_task_activity;
+DROP POLICY IF EXISTS "planning_task_activity_insert" ON public.planning_task_activity;
+DROP POLICY IF EXISTS "planning_task_activity_update" ON public.planning_task_activity;
+DROP POLICY IF EXISTS "planning_task_activity_delete" ON public.planning_task_activity;
+
+CREATE POLICY "planning_task_activity_select" ON public.planning_task_activity
+  FOR SELECT TO authenticated
+  USING (is_org_member(organization_id) AND has_permission(organization_id, 'planning.tasks.read'));
+
+CREATE POLICY "planning_task_activity_insert" ON public.planning_task_activity
+  FOR INSERT TO authenticated
+  WITH CHECK (is_org_member(organization_id) AND has_permission(organization_id, 'planning.tasks.read'));
+
+CREATE POLICY "planning_task_activity_update" ON public.planning_task_activity
+  FOR UPDATE TO authenticated USING (false);
+
+CREATE POLICY "planning_task_activity_delete" ON public.planning_task_activity
+  FOR DELETE TO authenticated USING (false);


### PR DESCRIPTION
…rail

- DB migration: task_number (PT-000001 seq+trigger), cancelled status, cancelled_at/started_at columns, planning_task_activity table (append-only RLS)
- Full service rewrite: all mutations write activity records (task_created, assigned/unassigned, status_changed, completed, reopened, cancelled, archived, title/description/priority/due_date_changed)
- 10 server actions: create, update, start, complete, reopen, cancel, assign, delete
- PlanningTaskCreateDialog: title + rich text + priority + assignee + due date, "Create & assign to me" shortcut
- PlanningTaskDetailPanel: status actions, inline assignee selector, activity feed, archive button — embedded in DataView renderDetail
- Badge components: PlanningTaskStatusBadge, PlanningTaskPriorityBadge
- PlanningTaskActivityList with emoji activity icons
- TasksClient wired: create button opens dialog, row click opens detail panel, queryKey invalidation on mutations
- Validation schemas updated: cancelled status, description_plain/rich split
- 33 tests passing: 15 service unit tests + 18 validation tests
- i18n: full tasks sub-namespace in en.json + pl.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Task creation dialog supporting title, description, priority assignment, and due dates
  * Task detail panel with full lifecycle management (start, complete, reopen, cancel/archive)
  * Task activity feed showing all changes and user actions
  * Status and priority visual indicators for improved task identification

* **Documentation**
  * Updated planning module documentation with expanded feature scope and roadmap

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kinetic639/coreframe-boilerplate/pull/370?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->