### PR TITLE
fix(planning): 500 errors, create dialog, settings page, QR assignment

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3173,7 +3173,8 @@
       "items": {
         "overview": "Overview",
         "tasks": "Tasks",
-        "boards": "Boards"
+        "boards": "Boards",
+        "settings": "Settings"
       },
       "pages": {
         "overview": {

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -3144,7 +3144,8 @@
       "items": {
         "overview": "Przegląd",
         "tasks": "Zadania",
-        "boards": "Tablice"
+        "boards": "Tablice",
+        "settings": "Ustawienia"
       },
       "pages": {
         "overview": {

--- a/apps/web/src/app/[locale]/dashboard/planning/settings/_components/planning-settings-client.tsx
+++ b/apps/web/src/app/[locale]/dashboard/planning/settings/_components/planning-settings-client.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { toast } from "react-toastify";
+import { Save } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
+import { PlanningTaskStatusBadge } from "@/components/planning/planning-task-status-badge";
+import { PlanningTaskPriorityBadge } from "@/components/planning/planning-task-priority-badge";
+import { savePlanningSettingsAction } from "@/app/actions/planning";
+import { TASK_STATUSES, TASK_PRIORITIES } from "@/lib/validations/planning";
+import type { TaskStatus, TaskPriority } from "@/lib/validations/planning";
+import type {
+  PlanningSettingsRow,
+  PlanningBadgeConfig,
+} from "@/server/services/planning-settings.service";
+
+const DEFAULT_STATUS_COLORS: Record<TaskStatus, string> = {
+  open: "#3b82f6",
+  in_progress: "#f59e0b",
+  completed: "#10b981",
+  cancelled: "#6b7280",
+};
+
+const DEFAULT_STATUS_LABELS: Record<TaskStatus, string> = {
+  open: "Open",
+  in_progress: "In Progress",
+  completed: "Completed",
+  cancelled: "Cancelled",
+};
+
+const DEFAULT_PRIORITY_COLORS: Record<TaskPriority, string> = {
+  low: "#6b7280",
+  normal: "#3b82f6",
+  high: "#f97316",
+  urgent: "#ef4444",
+};
+
+const DEFAULT_PRIORITY_LABELS: Record<TaskPriority, string> = {
+  low: "Low",
+  normal: "Normal",
+  high: "High",
+  urgent: "Urgent",
+};
+
+interface PlanningSettingsClientProps {
+  settings: PlanningSettingsRow | null;
+}
+
+export function PlanningSettingsClient({ settings }: PlanningSettingsClientProps) {
+  const [isPending, startTransition] = useTransition();
+
+  const [statusConfigs, setStatusConfigs] = useState<Record<string, PlanningBadgeConfig>>(() => {
+    const saved = settings?.status_configs ?? {};
+    return Object.fromEntries(
+      TASK_STATUSES.map((s) => [
+        s,
+        {
+          label: saved[s]?.label ?? DEFAULT_STATUS_LABELS[s as TaskStatus],
+          color: saved[s]?.color ?? DEFAULT_STATUS_COLORS[s as TaskStatus],
+        },
+      ])
+    );
+  });
+
+  const [priorityConfigs, setPriorityConfigs] = useState<Record<string, PlanningBadgeConfig>>(
+    () => {
+      const saved = settings?.priority_configs ?? {};
+      return Object.fromEntries(
+        TASK_PRIORITIES.map((p) => [
+          p,
+          {
+            label: saved[p]?.label ?? DEFAULT_PRIORITY_LABELS[p as TaskPriority],
+            color: saved[p]?.color ?? DEFAULT_PRIORITY_COLORS[p as TaskPriority],
+          },
+        ])
+      );
+    }
+  );
+
+  function updateStatus(key: string, field: "label" | "color", value: string) {
+    setStatusConfigs((prev) => ({ ...prev, [key]: { ...prev[key]!, [field]: value } }));
+  }
+
+  function updatePriority(key: string, field: "label" | "color", value: string) {
+    setPriorityConfigs((prev) => ({ ...prev, [key]: { ...prev[key]!, [field]: value } }));
+  }
+
+  function handleSave() {
+    startTransition(async () => {
+      try {
+        const result = await savePlanningSettingsAction({
+          status_configs: statusConfigs,
+          priority_configs: priorityConfigs,
+        });
+        if (!result.success) {
+          toast.error((result as { success: false; error: string }).error);
+        } else {
+          toast.success("Settings saved");
+        }
+      } catch {
+        toast.error("Failed to save settings");
+      }
+    });
+  }
+
+  return (
+    <div className="flex max-w-2xl flex-col gap-8 p-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Planning Settings</h1>
+          <p className="text-muted-foreground mt-1 text-sm">
+            Customize status and priority labels and colors for your tasks.
+          </p>
+        </div>
+        <Button onClick={handleSave} disabled={isPending}>
+          <Save className="mr-2 h-4 w-4" />
+          {isPending ? "Saving…" : "Save settings"}
+        </Button>
+      </div>
+
+      <Separator />
+
+      {/* Statuses */}
+      <div className="flex flex-col gap-4">
+        <h2 className="text-sm font-semibold uppercase tracking-wide">Statuses</h2>
+        {TASK_STATUSES.map((status) => {
+          const cfg = statusConfigs[status]!;
+          return (
+            <div key={status} className="flex items-center gap-4">
+              <div className="w-36">
+                <PlanningTaskStatusBadge
+                  status={status}
+                  // @ts-expect-error custom color preview
+                  style={{ backgroundColor: `${cfg.color}1a`, color: cfg.color, border: 0 }}
+                  className="text-xs font-medium"
+                />
+              </div>
+              <div className="flex flex-1 items-center gap-2">
+                <Input
+                  value={cfg.label}
+                  onChange={(e) => updateStatus(status, "label", e.target.value)}
+                  className="h-8 text-sm"
+                  placeholder="Label"
+                />
+                <div className="flex items-center gap-1.5">
+                  <Label className="text-xs">Color</Label>
+                  <input
+                    type="color"
+                    value={cfg.color}
+                    onChange={(e) => updateStatus(status, "color", e.target.value)}
+                    className="h-8 w-10 cursor-pointer rounded border"
+                    title="Pick color"
+                  />
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <Separator />
+
+      {/* Priorities */}
+      <div className="flex flex-col gap-4">
+        <h2 className="text-sm font-semibold uppercase tracking-wide">Priorities</h2>
+        {TASK_PRIORITIES.map((priority) => {
+          const cfg = priorityConfigs[priority]!;
+          return (
+            <div key={priority} className="flex items-center gap-4">
+              <div className="w-36">
+                <PlanningTaskPriorityBadge
+                  priority={priority}
+                  // @ts-expect-error custom color preview
+                  style={{ backgroundColor: `${cfg.color}1a`, color: cfg.color, border: 0 }}
+                  className="text-xs font-medium"
+                />
+              </div>
+              <div className="flex flex-1 items-center gap-2">
+                <Input
+                  value={cfg.label}
+                  onChange={(e) => updatePriority(priority, "label", e.target.value)}
+                  className="h-8 text-sm"
+                  placeholder="Label"
+                />
+                <div className="flex items-center gap-1.5">
+                  <Label className="text-xs">Color</Label>
+                  <input
+                    type="color"
+                    value={cfg.color}
+                    onChange={(e) => updatePriority(priority, "color", e.target.value)}
+                    className="h-8 w-10 cursor-pointer rounded border"
+                    title="Pick color"
+                  />
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/dashboard/planning/settings/page.tsx
+++ b/apps/web/src/app/[locale]/dashboard/planning/settings/page.tsx
@@ -1,0 +1,34 @@
+import { redirect } from "@/i18n/navigation";
+import { getLocale } from "next-intl/server";
+import { loadDashboardContextV2 } from "@/server/loaders/v2/load-dashboard-context.v2";
+import { checkPermission } from "@/lib/utils/permissions";
+import { PLANNING_SETTINGS_MANAGE } from "@/lib/constants/permissions";
+import { createClient } from "@/utils/supabase/server";
+import { PlanningSettingsService } from "@/server/services/planning-settings.service";
+import { PlanningSettingsClient } from "./_components/planning-settings-client";
+
+export default async function PlanningSettingsPage() {
+  const locale = await getLocale();
+  const context = await loadDashboardContextV2();
+
+  if (!context?.app.activeOrgId) return redirect({ href: "/sign-in", locale });
+
+  if (!checkPermission(context.user.permissionSnapshot, PLANNING_SETTINGS_MANAGE)) {
+    return redirect({
+      href: {
+        pathname: "/dashboard/access-denied",
+        query: { reason: "planning_settings_manage_required" },
+      },
+      locale,
+    });
+  }
+
+  const supabase = await createClient();
+  const settingsResult = await PlanningSettingsService.getSettings(
+    supabase,
+    context.app.activeOrgId
+  );
+  const settings = settingsResult.success ? settingsResult.data : null;
+
+  return <PlanningSettingsClient settings={settings} />;
+}

--- a/apps/web/src/app/[locale]/dashboard/planning/tasks/_components/planning-task-create-dialog.tsx
+++ b/apps/web/src/app/[locale]/dashboard/planning/tasks/_components/planning-task-create-dialog.tsx
@@ -61,7 +61,7 @@ export function PlanningTaskCreateDialog({
   const [title, setTitle] = useState("");
   const [descriptionRich, setDescriptionRich] = useState<RichTextValue>(createEmptyRichText);
   const [priority, setPriority] = useState<TaskPriority>("normal");
-  const [assignedTo, setAssignedTo] = useState<string>("");
+  const [assignedTo, setAssignedTo] = useState<string>("__unassigned__");
   const [dueAt, setDueAt] = useState<string>("");
   const [titleError, setTitleError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
@@ -70,7 +70,7 @@ export function PlanningTaskCreateDialog({
     setTitle("");
     setDescriptionRich(createEmptyRichText);
     setPriority("normal");
-    setAssignedTo("");
+    setAssignedTo("__unassigned__");
     setDueAt("");
     setTitleError(null);
   }
@@ -99,7 +99,11 @@ export function PlanningTaskCreateDialog({
         description_plain: hasDescription ? descriptionPlain : undefined,
         description_rich: hasDescription ? descriptionRich : undefined,
         priority,
-        assigned_to: assignToMe ? currentUserId : assignedTo || null,
+        assigned_to: assignToMe
+          ? currentUserId
+          : assignedTo === "__unassigned__"
+            ? null
+            : assignedTo || null,
         due_at: dueAt ? new Date(dueAt).toISOString() : null,
       });
 
@@ -112,6 +116,8 @@ export function PlanningTaskCreateDialog({
       reset();
       onOpenChange(false);
       onCreated(result.data);
+    } catch {
+      toast.error("Failed to create task. Please try again.");
     } finally {
       setSubmitting(false);
     }
@@ -186,7 +192,7 @@ export function PlanningTaskCreateDialog({
                   <SelectValue placeholder="Unassigned" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="">Unassigned</SelectItem>
+                  <SelectItem value="__unassigned__">Unassigned</SelectItem>
                   {members.map((m) => (
                     <SelectItem key={m.user_id} value={m.user_id}>
                       {m.name ?? m.email ?? m.user_id}
@@ -200,13 +206,15 @@ export function PlanningTaskCreateDialog({
           {/* Due date */}
           <div className="flex flex-col gap-1.5">
             <Label htmlFor="task-due">Due date</Label>
-            <Input
-              id="task-due"
-              type="date"
-              value={dueAt}
-              onChange={(e) => setDueAt(e.target.value)}
-              disabled={submitting}
-            />
+            <div className="w-48">
+              <Input
+                id="task-due"
+                type="date"
+                value={dueAt}
+                onChange={(e) => setDueAt(e.target.value)}
+                disabled={submitting}
+              />
+            </div>
           </div>
         </div>
 

--- a/apps/web/src/app/[locale]/dashboard/planning/tasks/_components/planning-task-detail-panel.tsx
+++ b/apps/web/src/app/[locale]/dashboard/planning/tasks/_components/planning-task-detail-panel.tsx
@@ -11,6 +11,9 @@ import {
   XCircle,
   Play,
   Trash2,
+  QrCode,
+  Link2Off,
+  Plus,
 } from "lucide-react";
 import { toast } from "react-toastify";
 import { Button } from "@/components/ui/button";
@@ -34,7 +37,11 @@ import {
   cancelTaskAction,
   assignTaskAction,
   deleteTaskAction,
+  assignQrToPlanningTaskAction,
+  getQrAssignmentForTaskAction,
 } from "@/app/actions/planning";
+import { revokeQrAction } from "@/app/actions/qr/revoke";
+import { listQrCodesAction } from "@/app/actions/qr/list";
 import type { PlanningTaskDetail } from "@/server/services/planning-tasks.service";
 import type { TaskStatus } from "@/lib/validations/planning";
 
@@ -44,6 +51,14 @@ interface Member {
   email: string | null;
 }
 
+type QrInfo = {
+  assignmentId: string;
+  qrCodeId: string;
+  token: string;
+  label: string | null;
+  status: string;
+} | null;
+
 interface PlanningTaskDetailPanelProps {
   detail: PlanningTaskDetail;
   canUpdate: boolean;
@@ -52,6 +67,7 @@ interface PlanningTaskDetailPanelProps {
   currentUserId: string;
   members: Member[];
   onRefresh?: () => void;
+  initialQrAssignment?: QrInfo;
 }
 
 function formatDate(iso: string | null): string {
@@ -82,9 +98,21 @@ export function PlanningTaskDetailPanel({
   currentUserId,
   members,
   onRefresh,
+  initialQrAssignment = null,
 }: PlanningTaskDetailPanelProps) {
   const [detail, setDetail] = useState<PlanningTaskDetail>(initialDetail);
   const [saving, setSaving] = useState(false);
+  const [qrAssignment, setQrAssignment] = useState<QrInfo>(initialQrAssignment);
+  const [showAssignQr, setShowAssignQr] = useState(false);
+  const [isRevokingQr, setIsRevokingQr] = useState(false);
+  const [qrCodes, setQrCodes] = useState<
+    Array<{
+      id: string;
+      label: string | null;
+      status: string;
+      assignment: { target_type: string; target_id: string } | null;
+    }>
+  >([]);
 
   // Sync when parent provides a new detail (DataView refetch)
   const latestDetail = initialDetail.updated_at !== detail.updated_at ? initialDetail : detail;
@@ -132,6 +160,52 @@ export function PlanningTaskDetailPanel({
         return r as any;
       }),
     [currentDetail.id, saving]
+  );
+
+  const handleRevokeQr = useCallback(async () => {
+    if (!qrAssignment) return;
+    setIsRevokingQr(true);
+    try {
+      const result = await revokeQrAction({ qrCodeId: qrAssignment.qrCodeId });
+      if (result.success) {
+        setQrAssignment(null);
+        toast.success("QR code unlinked from task.");
+      } else {
+        toast.error("Failed to unlink QR code.");
+      }
+    } finally {
+      setIsRevokingQr(false);
+    }
+  }, [qrAssignment]);
+
+  const handleOpenAssignQr = useCallback(async () => {
+    const result = await listQrCodesAction();
+    if (result.success) {
+      setQrCodes(
+        (result.data as any[]).map((c: any) => ({
+          id: c.id,
+          label: c.label ?? null,
+          status: c.status,
+          assignment: c.assignment ?? null,
+        }))
+      );
+    }
+    setShowAssignQr(true);
+  }, []);
+
+  const handleQrAssigned = useCallback(
+    async (qrCodeId: string) => {
+      const result = await assignQrToPlanningTaskAction({ qrCodeId, taskId: currentDetail.id });
+      if (result.success) {
+        const freshResult = await getQrAssignmentForTaskAction(currentDetail.id);
+        if (freshResult.success && freshResult.data) setQrAssignment(freshResult.data);
+        setShowAssignQr(false);
+        toast.success("QR code assigned to task.");
+      } else {
+        toast.error("Failed to assign QR code.");
+      }
+    },
+    [currentDetail.id]
   );
 
   const handleAssignChange = useCallback(
@@ -316,6 +390,78 @@ export function PlanningTaskDetailPanel({
             </div>
           )}
         </div>
+
+        <Separator />
+
+        {/* QR Code */}
+        <div className="space-y-3 rounded-lg border p-4">
+          <h3 className="flex items-center gap-2 text-sm font-semibold">
+            <QrCode className="text-muted-foreground h-4 w-4" />
+            QR Code
+          </h3>
+          {qrAssignment ? (
+            <div className="space-y-2">
+              <div className="bg-muted/50 rounded-md px-3 py-2 text-sm">
+                <p className="truncate font-medium">{qrAssignment.label ?? "Unlabelled"}</p>
+                <p className="text-muted-foreground truncate font-mono text-xs">
+                  {qrAssignment.token}
+                </p>
+              </div>
+              {canUpdate && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="text-destructive hover:text-destructive w-full"
+                  onClick={handleRevokeQr}
+                  disabled={isRevokingQr}
+                >
+                  {isRevokingQr ? (
+                    <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+                  ) : (
+                    <Link2Off className="mr-2 h-3.5 w-3.5" />
+                  )}
+                  Unlink QR Code
+                </Button>
+              )}
+            </div>
+          ) : canUpdate ? (
+            <Button variant="outline" size="sm" className="w-full" onClick={handleOpenAssignQr}>
+              <Plus className="mr-2 h-3.5 w-3.5" />
+              Assign QR Code
+            </Button>
+          ) : (
+            <p className="text-muted-foreground text-xs">No QR code assigned.</p>
+          )}
+        </div>
+
+        {/* Assign QR inline picker */}
+        {showAssignQr && (
+          <div className="rounded-lg border p-3">
+            <div className="mb-2 flex items-center justify-between">
+              <p className="text-sm font-medium">Select a QR code</p>
+              <Button variant="ghost" size="sm" onClick={() => setShowAssignQr(false)}>
+                Cancel
+              </Button>
+            </div>
+            <div className="flex max-h-48 flex-col gap-1 overflow-y-auto">
+              {qrCodes
+                .filter((c) => c.status === "active" && !c.assignment)
+                .map((c) => (
+                  <button
+                    key={c.id}
+                    className="hover:bg-muted flex items-center gap-2 rounded px-2 py-1.5 text-left text-sm"
+                    onClick={() => handleQrAssigned(c.id)}
+                  >
+                    <QrCode className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
+                    <span className="truncate">{c.label ?? c.id.slice(0, 8)}</span>
+                  </button>
+                ))}
+              {qrCodes.filter((c) => c.status === "active" && !c.assignment).length === 0 && (
+                <p className="text-muted-foreground px-2 py-1 text-xs">No available QR codes.</p>
+              )}
+            </div>
+          </div>
+        )}
 
         <Separator />
 

--- a/apps/web/src/app/actions/planning/index.ts
+++ b/apps/web/src/app/actions/planning/index.ts
@@ -10,6 +10,7 @@ import {
   PLANNING_TASKS_UPDATE,
   PLANNING_TASKS_DELETE,
   PLANNING_TASKS_ASSIGN,
+  PLANNING_SETTINGS_MANAGE,
 } from "@/lib/constants/permissions";
 import {
   PlanningTasksService,
@@ -259,6 +260,102 @@ export async function deleteTaskAction(taskId: string): Promise<ActionResult<voi
   }
 }
 
+// ---------------------------------------------------------------------------
+// Settings
+// ---------------------------------------------------------------------------
+
+export async function savePlanningSettingsAction(input: {
+  status_configs?: Record<string, { label: string; color: string }>;
+  priority_configs?: Record<string, { label: string; color: string }>;
+}): Promise<ActionResult<void>> {
+  try {
+    const ctx = await getAuthedContext();
+    if (!ctx) return { success: false, error: "Unauthorized" };
+    if (!checkPermission(ctx.context.user.permissionSnapshot, PLANNING_SETTINGS_MANAGE))
+      return { success: false, error: "Insufficient permissions" };
+
+    const { PlanningSettingsService } = await import("@/server/services/planning-settings.service");
+    const result = await PlanningSettingsService.saveSettings(ctx.supabase, ctx.orgId, input);
+    if (!result.success)
+      return { success: false, error: (result as { success: false; error: string }).error };
+    return { success: true, data: undefined };
+  } catch {
+    return { success: false, error: "Unexpected error" };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// QR assignment for planning tasks
+// ---------------------------------------------------------------------------
+
+export async function assignQrToPlanningTaskAction(input: {
+  qrCodeId: string;
+  taskId: string;
+}): Promise<ActionResult<{ id: string; target_type: string; target_id: string }>> {
+  try {
+    const ctx = await getAuthedContext();
+    if (!ctx) return { success: false, error: "Unauthorized" };
+    if (!checkPermission(ctx.context.user.permissionSnapshot, PLANNING_TASKS_UPDATE))
+      return { success: false, error: "Insufficient permissions" };
+
+    const { QrAssignmentsService } = await import("@/server/services/qr.service");
+    return QrAssignmentsService.assignToTarget(ctx.supabase, {
+      qrCodeId: input.qrCodeId,
+      targetType: "planning.task",
+      targetId: input.taskId,
+      assignedBy: ctx.userId,
+      permissionSnapshot: ctx.context.user.permissionSnapshot,
+    });
+  } catch {
+    return { success: false, error: "Unexpected error" };
+  }
+}
+
+export async function getQrAssignmentForTaskAction(taskId: string): Promise<
+  ActionResult<{
+    assignmentId: string;
+    qrCodeId: string;
+    token: string;
+    label: string | null;
+    status: string;
+  } | null>
+> {
+  try {
+    const ctx = await getAuthedContext();
+    if (!ctx) return { success: false, error: "Unauthorized" };
+    if (!checkPermission(ctx.context.user.permissionSnapshot, PLANNING_TASKS_READ))
+      return { success: false, error: "Insufficient permissions" };
+
+    const { data, error } = await ctx.supabase
+      .from("qr_assignments")
+      .select(
+        "id, qr_code_id, revoked_at, qr_codes!qr_assignments_qr_code_id_fkey(token, label, status)"
+      )
+      .eq("target_type", "planning.task")
+      .eq("target_id", taskId)
+      .is("revoked_at", null)
+      .maybeSingle();
+
+    if (error) return { success: false, error: error.message };
+    if (!data) return { success: true, data: null };
+
+    const row = data as any;
+    const code = Array.isArray(row.qr_codes) ? row.qr_codes[0] : row.qr_codes;
+    return {
+      success: true,
+      data: {
+        assignmentId: row.id,
+        qrCodeId: row.qr_code_id,
+        token: code?.token ?? "",
+        label: code?.label ?? null,
+        status: code?.status ?? "active",
+      },
+    };
+  } catch {
+    return { success: false, error: "Unexpected error" };
+  }
+}
+
 // Re-export for pages
 export {
   PLANNING_READ,
@@ -267,4 +364,5 @@ export {
   PLANNING_TASKS_UPDATE,
   PLANNING_TASKS_DELETE,
   PLANNING_TASKS_ASSIGN,
+  PLANNING_SETTINGS_MANAGE,
 };

--- a/apps/web/src/i18n/routing.ts
+++ b/apps/web/src/i18n/routing.ts
@@ -313,6 +313,10 @@ export const routing = defineRouting({
       en: "/dashboard/planning/boards",
       pl: "/dashboard/planowanie/tablice",
     },
+    "/dashboard/planning/settings": {
+      en: "/dashboard/planning/settings",
+      pl: "/dashboard/planowanie/ustawienia",
+    },
 
     // === Analytics & Reports module ===
     "/dashboard/analytics": {

--- a/apps/web/src/lib/sidebar/v2/registry.ts
+++ b/apps/web/src/lib/sidebar/v2/registry.ts
@@ -24,6 +24,7 @@ import {
   MODULE_PLANNING_ACCESS,
   PLANNING_READ,
   PLANNING_TASKS_READ,
+  PLANNING_SETTINGS_MANAGE,
 } from "@/lib/constants/permissions";
 import {
   MODULE_ORGANIZATION_MANAGEMENT,
@@ -358,6 +359,17 @@ export const MAIN_NAV_ITEMS: SidebarItem[] = [
         match: { exact: "/dashboard/planning/boards" },
         visibility: {
           requiresPermissions: [PLANNING_TASKS_READ],
+        },
+      },
+      {
+        id: "planning.settings",
+        title: "Settings",
+        titleKey: "modules.planning.items.settings",
+        iconKey: "settings",
+        href: "/dashboard/planning/settings",
+        match: { startsWith: "/dashboard/planning/settings" },
+        visibility: {
+          requiresPermissions: [PLANNING_SETTINGS_MANAGE],
         },
       },
     ],

--- a/apps/web/src/server/qr/target-registry.ts
+++ b/apps/web/src/server/qr/target-registry.ts
@@ -3,6 +3,7 @@ import "server-only";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { WAREHOUSE_LOCATIONS_MANAGE, WAREHOUSE_LOCATIONS_READ } from "@/lib/constants/permissions";
 import { HELPDESK_TICKETS_MANAGE, HELPDESK_TICKETS_READ } from "@/lib/constants/permissions";
+import { PLANNING_TASKS_UPDATE, PLANNING_TASKS_READ } from "@/lib/constants/permissions";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -190,6 +191,64 @@ export const QR_TARGET_REGISTRY: Readonly<Record<string, QrTargetDescriptor>> = 
         primaryText: ticket?.ticket_number ?? targetId,
         secondaryText: ticket?.title ?? undefined,
         tertiaryText: ticket ? `Status: ${ticket.status}` : "Help Desk Ticket",
+      };
+    },
+  },
+
+  "planning.task": {
+    type: "planning.task",
+
+    async validate({ supabase, targetId, orgId }) {
+      const { data, error } = await supabase
+        .from("planning_tasks")
+        .select("id, organization_id, branch_id, deleted_at")
+        .eq("id", targetId)
+        .maybeSingle();
+
+      if (error || !data) {
+        return { valid: false, organizationId: null, branchId: null, error: "NOT_FOUND" };
+      }
+      if (data.deleted_at !== null) {
+        return { valid: false, organizationId: null, branchId: null, error: "SOFT_DELETED" };
+      }
+      if ((data as any).organization_id !== orgId) {
+        return { valid: false, organizationId: null, branchId: null, error: "WRONG_ORG" };
+      }
+      return {
+        valid: true,
+        organizationId: (data as any).organization_id as string,
+        branchId: ((data as any).branch_id as string | null) ?? null,
+      };
+    },
+
+    requiredAssignPermission: PLANNING_TASKS_UPDATE,
+    requiredReadPermission: PLANNING_TASKS_READ,
+
+    resolverPath({ targetId }) {
+      return `/dashboard/planning/tasks?highlight=${targetId}`;
+    },
+
+    async resolvePathAsync({ supabase, targetId }) {
+      const { data } = await supabase
+        .from("planning_tasks")
+        .select("task_number")
+        .eq("id", targetId)
+        .maybeSingle();
+      const number = (data as { task_number: string } | null)?.task_number ?? targetId;
+      return `/dashboard/planning/tasks?highlight=${number}`;
+    },
+
+    async getLabelContext({ supabase, targetId }) {
+      const { data } = await supabase
+        .from("planning_tasks")
+        .select("task_number, title, status")
+        .eq("id", targetId)
+        .maybeSingle();
+      const task = data as { task_number: string; title: string; status: string } | null;
+      return {
+        primaryText: task?.task_number ?? targetId,
+        secondaryText: task?.title ?? undefined,
+        tertiaryText: task ? `Status: ${task.status}` : "Planning Task",
       };
     },
   },

--- a/apps/web/src/server/services/planning-settings.service.ts
+++ b/apps/web/src/server/services/planning-settings.service.ts
@@ -1,0 +1,104 @@
+import "server-only";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export interface PlanningBadgeConfig {
+  label: string;
+  color: string;
+}
+
+export interface PlanningSettingsRow {
+  id: string;
+  organization_id: string;
+  status_configs: Record<string, PlanningBadgeConfig>;
+  priority_configs: Record<string, PlanningBadgeConfig>;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface SavePlanningSettingsInput {
+  status_configs?: Record<string, PlanningBadgeConfig>;
+  priority_configs?: Record<string, PlanningBadgeConfig>;
+}
+
+type ServiceResult<T> = { success: true; data: T } | { success: false; error: string };
+
+export const PlanningSettingsService = {
+  async getSettings(
+    supabase: SupabaseClient,
+    orgId: string
+  ): Promise<ServiceResult<PlanningSettingsRow | null>> {
+    try {
+      const { data, error } = await supabase
+        .from("planning_settings")
+        .select("id, organization_id, status_configs, priority_configs, created_at, updated_at")
+        .eq("organization_id", orgId)
+        .maybeSingle();
+
+      if (error) return { success: false, error: error.message };
+      if (!data) return { success: true, data: null };
+
+      return {
+        success: true,
+        data: {
+          id: (data as any).id,
+          organization_id: (data as any).organization_id,
+          status_configs: ((data as any).status_configs ?? {}) as Record<
+            string,
+            PlanningBadgeConfig
+          >,
+          priority_configs: ((data as any).priority_configs ?? {}) as Record<
+            string,
+            PlanningBadgeConfig
+          >,
+          created_at: (data as any).created_at,
+          updated_at: (data as any).updated_at,
+        },
+      };
+    } catch (e) {
+      return { success: false, error: e instanceof Error ? e.message : "Unexpected error" };
+    }
+  },
+
+  async saveSettings(
+    supabase: SupabaseClient,
+    orgId: string,
+    input: SavePlanningSettingsInput
+  ): Promise<ServiceResult<PlanningSettingsRow>> {
+    try {
+      const { data, error } = await supabase
+        .from("planning_settings")
+        .upsert(
+          {
+            organization_id: orgId,
+            status_configs: input.status_configs ?? {},
+            priority_configs: input.priority_configs ?? {},
+          },
+          { onConflict: "organization_id" }
+        )
+        .select("id, organization_id, status_configs, priority_configs, created_at, updated_at")
+        .single();
+
+      if (error) return { success: false, error: error.message };
+
+      return {
+        success: true,
+        data: {
+          id: (data as any).id,
+          organization_id: (data as any).organization_id,
+          status_configs: ((data as any).status_configs ?? {}) as Record<
+            string,
+            PlanningBadgeConfig
+          >,
+          priority_configs: ((data as any).priority_configs ?? {}) as Record<
+            string,
+            PlanningBadgeConfig
+          >,
+          created_at: (data as any).created_at,
+          updated_at: (data as any).updated_at,
+        },
+      };
+    } catch (e) {
+      return { success: false, error: e instanceof Error ? e.message : "Unexpected error" };
+    }
+  },
+};

--- a/apps/web/src/server/services/planning-tasks.service.ts
+++ b/apps/web/src/server/services/planning-tasks.service.ts
@@ -116,8 +116,8 @@ export const PlanningTasksService = {
           `id, organization_id, task_number, title, status, priority,
            branch_id, assigned_to, due_at, started_at, completed_at, cancelled_at,
            created_by, created_at, updated_at,
-           assignee:users!planning_tasks_assigned_to_fkey(first_name, last_name, email),
-           creator:users!planning_tasks_created_by_fkey(first_name, last_name, email)`,
+           assignee:users!assigned_to(first_name, last_name, email),
+           creator:users!created_by(first_name, last_name, email)`,
           { count: "exact" }
         )
         .eq("organization_id", orgId)
@@ -197,8 +197,8 @@ export const PlanningTasksService = {
           `id, organization_id, task_number, title, description_plain, description_rich,
            status, priority, branch_id, assigned_to, due_at, started_at, completed_at,
            cancelled_at, created_by, updated_by, created_at, updated_at, deleted_at,
-           assignee:users!planning_tasks_assigned_to_fkey(first_name, last_name, email),
-           creator:users!planning_tasks_created_by_fkey(first_name, last_name, email)`
+           assignee:users!assigned_to(first_name, last_name, email),
+           creator:users!created_by(first_name, last_name, email)`
         )
         .eq("organization_id", orgId)
         .eq("id", taskId)
@@ -217,7 +217,7 @@ export const PlanningTasksService = {
         .from("planning_task_activity")
         .select(
           `id, organization_id, task_id, activity_type, actor_id, message, metadata, created_at,
-           actor:users!planning_task_activity_actor_id_fkey(first_name, last_name, email)`
+           actor:users!actor_id(first_name, last_name, email)`
         )
         .eq("task_id", taskId)
         .order("created_at", { ascending: true });

--- a/apps/web/supabase/migrations/20260603140000_planning_settings_and_qr.sql
+++ b/apps/web/supabase/migrations/20260603140000_planning_settings_and_qr.sql
@@ -1,0 +1,37 @@
+-- ===========================================================================
+-- Planning: settings table + planning.settings.manage permission
+-- ===========================================================================
+
+-- 1. New permission row only (org_owner gets it via planning.* wildcard — no explicit grant needed)
+INSERT INTO public.permissions (slug, name, category, action)
+VALUES ('planning.settings.manage', 'Planning Settings Manage', 'planning', 'manage')
+ON CONFLICT (slug) DO NOTHING;
+
+-- 2. planning_settings table
+CREATE TABLE IF NOT EXISTS public.planning_settings (
+  id               UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id  UUID        NOT NULL UNIQUE REFERENCES public.organizations(id) ON DELETE CASCADE,
+  status_configs   JSONB       NOT NULL DEFAULT '{}',
+  priority_configs JSONB       NOT NULL DEFAULT '{}',
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE OR REPLACE TRIGGER planning_settings_updated_at
+  BEFORE UPDATE ON public.planning_settings
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();
+
+ALTER TABLE public.planning_settings ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "planning_settings_select" ON public.planning_settings
+  FOR SELECT TO authenticated
+  USING (is_org_member(organization_id) AND has_permission(organization_id, 'planning.tasks.read'));
+
+CREATE POLICY "planning_settings_insert" ON public.planning_settings
+  FOR INSERT TO authenticated
+  WITH CHECK (is_org_member(organization_id) AND has_permission(organization_id, 'planning.settings.manage'));
+
+CREATE POLICY "planning_settings_update" ON public.planning_settings
+  FOR UPDATE TO authenticated
+  USING (is_org_member(organization_id) AND has_permission(organization_id, 'planning.settings.manage'))
+  WITH CHECK (is_org_member(organization_id) AND has_permission(organization_id, 'planning.settings.manage'));

--- a/packages/contracts/src/permissions.ts
+++ b/packages/contracts/src/permissions.ts
@@ -205,6 +205,7 @@ export const PLANNING_TASKS_CREATE = "planning.tasks.create" as const;
 export const PLANNING_TASKS_UPDATE = "planning.tasks.update" as const;
 export const PLANNING_TASKS_DELETE = "planning.tasks.delete" as const;
 export const PLANNING_TASKS_ASSIGN = "planning.tasks.assign" as const;
+export const PLANNING_SETTINGS_MANAGE = "planning.settings.manage" as const;
 
 // Tools Permissions (user-scoped — always available, no plan gating)
 // tools.read  — view the tools catalog, tool detail pages, and personal enabled-tools list
@@ -327,6 +328,7 @@ export type PermissionSlug =
   | typeof PLANNING_TASKS_UPDATE
   | typeof PLANNING_TASKS_DELETE
   | typeof PLANNING_TASKS_ASSIGN
+  | typeof PLANNING_SETTINGS_MANAGE
   | typeof PERMISSION_TOOLS_READ
   | typeof PERMISSION_TOOLS_MANAGE
   | typeof PERMISSION_WDD_MATCHER_READ
@@ -428,6 +430,7 @@ export const ALL_PERMISSION_SLUGS: PermissionSlug[] = [
   PLANNING_TASKS_UPDATE,
   PLANNING_TASKS_DELETE,
   PLANNING_TASKS_ASSIGN,
+  PLANNING_SETTINGS_MANAGE,
   PERMISSION_TOOLS_READ,
   PERMISSION_TOOLS_MANAGE,
   PERMISSION_WDD_MATCHER_READ,


### PR DESCRIPTION
Fixes:
- Fix all FK join hints: planning_tasks_assigned_to_fkey → assigned_to, planning_tasks_created_by_fkey → created_by, planning_task_activity_actor_id_fkey → actor_id (all caused 500s)
- Add catch block to create dialog handleSubmit so failures show toast
- Fix SelectItem empty string value → __unassigned__
- Narrow due date input to w-48 (no longer full-width)

Settings page:
- planning_settings table with JSONB status_configs/priority_configs (RLS)
- PLANNING_SETTINGS_MANAGE = "planning.settings.manage" permission constant (org_owner gets via planning.* wildcard — no explicit grant needed)
- PlanningSettingsService.getSettings/saveSettings
- savePlanningSettingsAction gated by PLANNING_SETTINGS_MANAGE
- /dashboard/planning/settings page + PlanningSettingsClient (editable label+color picker for each status and priority)
- Sidebar entry + routing (pl: /planowanie/ustawienia)

QR code assignment:
- planning.task added to QR_TARGET_REGISTRY with validate/resolvePathAsync/getLabelContext
- assignQrToPlanningTaskAction + getQrAssignmentForTaskAction in planning actions
- QR card added to PlanningTaskDetailPanel: assign from list, unlink, token display