### PR TITLE
fix(planning): bypass React server action serialization for descripti…

### DIFF
--- a/apps/web/src/app/[locale]/dashboard/planning/tasks/_components/planning-task-create-dialog.tsx
+++ b/apps/web/src/app/[locale]/dashboard/planning/tasks/_components/planning-task-create-dialog.tsx
@@ -97,7 +97,7 @@ export function PlanningTaskCreateDialog({
       const result = await createTaskAction({
         title: trimmedTitle,
         description_plain: hasDescription ? descriptionPlain : undefined,
-        description_rich: hasDescription ? descriptionRich : undefined,
+        description_rich: hasDescription ? JSON.stringify(descriptionRich) : undefined,
         priority,
         assigned_to: assignToMe
           ? currentUserId

--- a/apps/web/src/lib/validations/planning.ts
+++ b/apps/web/src/lib/validations/planning.ts
@@ -17,7 +17,7 @@ export type TaskPriority = (typeof TASK_PRIORITIES)[number];
 export const createTaskSchema = z.object({
   title: z.string().trim().min(1, "Title is required").max(500),
   description_plain: z.string().max(10000).optional(),
-  description_rich: z.unknown().optional(),
+  description_rich: z.string().optional(), // JSON-stringified on client to bypass React serialization
   priority: z.enum(TASK_PRIORITIES).default("normal"),
   branch_id: z.string().uuid().nullable().optional(),
   assigned_to: z.string().uuid().nullable().optional(),
@@ -28,7 +28,7 @@ export const updateTaskSchema = z.object({
   id: z.string().uuid(),
   title: z.string().trim().min(1, "Title is required").max(500),
   description_plain: z.string().max(10000).optional(),
-  description_rich: z.unknown().optional(),
+  description_rich: z.string().optional(), // JSON-stringified on client
   priority: z.enum(TASK_PRIORITIES),
   branch_id: z.string().uuid().nullable().optional(),
   due_at: z.string().datetime().nullable().optional(),

--- a/apps/web/src/server/services/planning-tasks.service.ts
+++ b/apps/web/src/server/services/planning-tasks.service.ts
@@ -293,7 +293,15 @@ export const PlanningTasksService = {
           updated_by: userId,
           title: input.title,
           description_plain: input.description_plain ?? null,
-          description_rich: (input.description_rich as object | null) ?? null,
+          description_rich: input.description_rich
+            ? (() => {
+                try {
+                  return JSON.parse(input.description_rich);
+                } catch {
+                  return null;
+                }
+              })()
+            : null,
           status: "open",
           priority: input.priority ?? "normal",
           branch_id: input.branch_id ?? null,
@@ -348,7 +356,15 @@ export const PlanningTasksService = {
         .update({
           title: input.title,
           description_plain: input.description_plain ?? null,
-          description_rich: (input.description_rich as object | null) ?? null,
+          description_rich: input.description_rich
+            ? (() => {
+                try {
+                  return JSON.parse(input.description_rich);
+                } catch {
+                  return null;
+                }
+              })()
+            : null,
           priority: input.priority,
           branch_id: input.branch_id ?? null,
           due_at: input.due_at ?? null,


### PR DESCRIPTION
…on_rich

Root cause: TipTap link marks have attrs where null values get serialized by React's server action format as '$T' tokens. The server fails to deserialize '$T' → 500 on createTaskAction.

Fix: JSON.stringify description_rich on the client before passing to the server action, JSON.parse it in the service. Changes z.unknown() → z.string() for the wire format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Improved handling of rich text descriptions in task creation and updates, ensuring formatted content is properly preserved and stored across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->