### PR TITLE
fix(planning): use lightweight auth for list/detail actions (match ti…

### DIFF
--- a/apps/web/src/app/[locale]/dashboard/planning/tasks/_components/tasks-client.tsx
+++ b/apps/web/src/app/[locale]/dashboard/planning/tasks/_components/tasks-client.tsx
@@ -142,18 +142,21 @@ export function TasksClient({
 
   const listFetcher = useCallback(
     async (params: DataViewListParams): Promise<PaginatedResult<PlanningTaskListRow>> => {
-      const result = await listTasksForDataViewAction(params);
+      const result = await listTasksForDataViewAction(params, orgId);
       if (result.success) return result.data;
       throw new Error((result as { success: false; error: string }).error);
     },
-    []
+    [orgId]
   );
 
-  const detailFetcher = useCallback(async (id: string): Promise<PlanningTaskDetail | null> => {
-    const result = await getTaskDetailAction(id);
-    if (!result.success) return null;
-    return result.data;
-  }, []);
+  const detailFetcher = useCallback(
+    async (id: string): Promise<PlanningTaskDetail | null> => {
+      const result = await getTaskDetailAction(id, orgId);
+      if (!result.success) return null;
+      return result.data;
+    },
+    [orgId]
+  );
 
   const handleCreated = useCallback(() => {
     queryClient.invalidateQueries({ queryKey: PLANNING_TASKS_QUERY_KEY });

--- a/apps/web/src/app/actions/planning/index.ts
+++ b/apps/web/src/app/actions/planning/index.ts
@@ -51,37 +51,41 @@ async function getAuthedContext() {
 }
 
 // ---------------------------------------------------------------------------
-// List
+// List — lightweight auth (RLS enforces org membership + read permission)
 // ---------------------------------------------------------------------------
 
 export async function listTasksForDataViewAction(
   params: DataViewListParams,
+  orgId: string,
   filters: TaskListFilters = {}
 ): Promise<ActionResult<PaginatedResult<PlanningTaskListRow>>> {
   try {
-    const ctx = await getAuthedContext();
-    if (!ctx) return { success: false, error: "Unauthorized" };
-    if (!checkPermission(ctx.context.user.permissionSnapshot, PLANNING_TASKS_READ))
-      return { success: false, error: "Insufficient permissions" };
-    return PlanningTasksService.listForDataView(ctx.supabase, ctx.orgId, params, filters);
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return { success: false, error: "Unauthorized" };
+    return PlanningTasksService.listForDataView(supabase, orgId, params, filters);
   } catch {
     return { success: false, error: "Unexpected error" };
   }
 }
 
 // ---------------------------------------------------------------------------
-// Detail
+// Detail — lightweight auth (RLS enforces org membership + read permission)
 // ---------------------------------------------------------------------------
 
 export async function getTaskDetailAction(
-  taskId: string
+  taskId: string,
+  orgId: string
 ): Promise<ActionResult<PlanningTaskDetail>> {
   try {
-    const ctx = await getAuthedContext();
-    if (!ctx) return { success: false, error: "Unauthorized" };
-    if (!checkPermission(ctx.context.user.permissionSnapshot, PLANNING_TASKS_READ))
-      return { success: false, error: "Insufficient permissions" };
-    return PlanningTasksService.getDetail(ctx.supabase, ctx.orgId, taskId);
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return { success: false, error: "Unauthorized" };
+    return PlanningTasksService.getDetail(supabase, orgId, taskId);
   } catch {
     return { success: false, error: "Unexpected error" };
   }
@@ -321,12 +325,14 @@ export async function getQrAssignmentForTaskAction(taskId: string): Promise<
   } | null>
 > {
   try {
-    const ctx = await getAuthedContext();
-    if (!ctx) return { success: false, error: "Unauthorized" };
-    if (!checkPermission(ctx.context.user.permissionSnapshot, PLANNING_TASKS_READ))
-      return { success: false, error: "Insufficient permissions" };
+    // Lightweight auth — RLS enforces org membership + read permission
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) return { success: false, error: "Unauthorized" };
 
-    const { data, error } = await ctx.supabase
+    const { data, error } = await supabase
       .from("qr_assignments")
       .select(
         "id, qr_code_id, revoked_at, qr_codes!qr_assignments_qr_code_id_fkey(token, label, status)"


### PR DESCRIPTION
…ckets pattern)

The tickets feature passes orgId from client and uses only auth.getUser() for read actions, relying on RLS for security. Tasks were calling loadDashboardContextV2() on every DataView fetch — 6+ extra DB queries per call — causing timeouts/500s.

Fix: listTasksForDataViewAction + getTaskDetailAction + getQrAssignmentForTaskAction now accept orgId from client and use auth.getUser() only. RLS enforces is_org_member + has_permission('planning.tasks.read') at the DB level.