### PR TITLE
feat(kanban): add shared inbox and quick add

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -3337,6 +3337,9 @@
         "myBoards": "Boards",
         "empty": "No boards yet.",
         "selectBoard": "Select a board or create a new one.",
+        "switchBoards": "Switch board",
+        "boardSearch": "Search your boards",
+        "recentBoards": "Recent",
         "loading": "Loading...",
         "limit": "{count}/{max} boards used.",
         "limitReached": "Board limit reached. You can create up to {max} boards.",
@@ -3379,6 +3382,11 @@
         "dragColumn": "Drag column",
         "collapseColumn": "Collapse column",
         "expandColumn": "Expand column",
+        "inbox": {
+          "title": "Inbox",
+          "description": "Shared holding column across boards",
+          "toggle": "Show or hide inbox"
+        },
         "comments": {
           "title": "Comments",
           "empty": "No comments yet.",
@@ -3389,6 +3397,8 @@
           "cardCreated": "Card created",
           "cardUpdated": "Card updated",
           "cardMoved": "Card moved",
+          "cardMovedToInbox": "Card moved to inbox",
+          "cardMovedFromInbox": "Card moved from inbox",
           "cardArchived": "Card archived",
           "commentAdded": "Comment added"
         },
@@ -3830,25 +3840,68 @@
       "quickAdd": {
         "title": "Quick Add",
         "tooltip": "Quick Add",
-        "inventory": {
-          "title": "INVENTORY",
-          "product": "Product",
-          "location": "Location",
-          "order": "Order"
+        "subtitle": "Create common records without leaving your flow.",
+        "empty": "No quick actions available.",
+        "warehouse": {
+          "title": "WAREHOUSE",
+          "item": "Item",
+          "itemDescription": "Open the item creation form."
         },
-        "sales": {
-          "title": "SALES",
-          "customer": "Customer",
-          "invoice": "Invoice"
+        "helpdesk": {
+          "title": "HELP DESK",
+          "ticket": "Ticket",
+          "ticketDescription": "Open a new ticket form."
         },
-        "purchases": {
-          "title": "PURCHASES",
-          "supplier": "Supplier",
-          "bill": "Bill"
+        "planning": {
+          "title": "PLANNING",
+          "task": "Task",
+          "taskDescription": "Create a lightweight planning task.",
+          "kanbanCard": "Kanban card",
+          "kanbanCardDescription": "Add a card to a selected board."
         },
-        "other": {
-          "title": "OTHER",
-          "document": "Document"
+        "taskDialog": {
+          "title": "Create task",
+          "created": "Task created.",
+          "cancel": "Cancel",
+          "submit": "Create task",
+          "fields": {
+            "title": "Title",
+            "description": "Description",
+            "priority": "Priority",
+            "due": "Due date"
+          },
+          "placeholders": {
+            "title": "Short task summary",
+            "description": "Optional context..."
+          },
+          "priorities": {
+            "low": "Low",
+            "normal": "Normal",
+            "high": "High",
+            "urgent": "Urgent"
+          }
+        },
+        "kanbanDialog": {
+          "title": "Create Kanban card",
+          "created": "Kanban card created.",
+          "cancel": "Cancel",
+          "submit": "Create card",
+          "loadingBoards": "Loading boards...",
+          "loadingColumns": "Loading columns...",
+          "emptyBoards": "Create a Kanban board first before adding cards.",
+          "fields": {
+            "board": "Board",
+            "column": "Column",
+            "title": "Title",
+            "description": "Description",
+            "due": "Due date"
+          },
+          "placeholders": {
+            "board": "Select board",
+            "column": "Select column",
+            "title": "Card title",
+            "description": "Optional card context..."
+          }
         }
       },
       "userMenu": {

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -3308,6 +3308,9 @@
         "myBoards": "Tablice",
         "empty": "Brak tablic.",
         "selectBoard": "Wybierz tablicę albo utwórz nową.",
+        "switchBoards": "Przełącz tablicę",
+        "boardSearch": "Wyszukaj swoje tablice",
+        "recentBoards": "Ostatnie",
         "loading": "Ładowanie...",
         "limit": "Wykorzystano {count}/{max} tablic.",
         "limitReached": "Osiągnięto limit tablic. Możesz utworzyć maksymalnie {max} tablic.",
@@ -3350,6 +3353,11 @@
         "dragColumn": "Przeciągnij kolumnę",
         "collapseColumn": "Zwiń kolumnę",
         "expandColumn": "Rozwiń kolumnę",
+        "inbox": {
+          "title": "Skrzynka",
+          "description": "Wspólna skrzynka kart pomiędzy tablicami",
+          "toggle": "Pokaż lub ukryj skrzynkę"
+        },
         "comments": {
           "title": "Komentarze",
           "empty": "Brak komentarzy.",
@@ -3360,6 +3368,8 @@
           "cardCreated": "Karta utworzona",
           "cardUpdated": "Karta zaktualizowana",
           "cardMoved": "Karta przeniesiona",
+          "cardMovedToInbox": "Karta przeniesiona do skrzynki",
+          "cardMovedFromInbox": "Karta przeniesiona ze skrzynki",
           "cardArchived": "Karta zarchiwizowana",
           "commentAdded": "Komentarz dodany"
         },
@@ -3801,25 +3811,68 @@
       "quickAdd": {
         "title": "Szybkie dodawanie",
         "tooltip": "Szybkie dodawanie",
-        "inventory": {
+        "subtitle": "Twórz najczęstsze rekordy bez wychodzenia z pracy.",
+        "empty": "Brak dostępnych szybkich akcji.",
+        "warehouse": {
           "title": "MAGAZYN",
-          "product": "Produkt",
-          "location": "Lokalizacja",
-          "order": "Zamówienie"
+          "item": "Towar",
+          "itemDescription": "Otwórz formularz tworzenia towaru."
         },
-        "sales": {
-          "title": "SPRZEDAŻ",
-          "customer": "Klient",
-          "invoice": "Faktura"
+        "helpdesk": {
+          "title": "HELP DESK",
+          "ticket": "Zgłoszenie",
+          "ticketDescription": "Otwórz formularz nowego zgłoszenia."
         },
-        "purchases": {
-          "title": "ZAKUPY",
-          "supplier": "Dostawca",
-          "bill": "Rachunek"
+        "planning": {
+          "title": "PLANOWANIE",
+          "task": "Zadanie",
+          "taskDescription": "Utwórz szybkie zadanie planowania.",
+          "kanbanCard": "Karta Kanban",
+          "kanbanCardDescription": "Dodaj kartę do wybranej tablicy."
         },
-        "other": {
-          "title": "INNE",
-          "document": "Dokument"
+        "taskDialog": {
+          "title": "Utwórz zadanie",
+          "created": "Zadanie utworzone.",
+          "cancel": "Anuluj",
+          "submit": "Utwórz zadanie",
+          "fields": {
+            "title": "Tytuł",
+            "description": "Opis",
+            "priority": "Priorytet",
+            "due": "Termin"
+          },
+          "placeholders": {
+            "title": "Krótkie podsumowanie zadania",
+            "description": "Opcjonalny kontekst..."
+          },
+          "priorities": {
+            "low": "Niski",
+            "normal": "Normalny",
+            "high": "Wysoki",
+            "urgent": "Pilny"
+          }
+        },
+        "kanbanDialog": {
+          "title": "Utwórz kartę Kanban",
+          "created": "Karta Kanban utworzona.",
+          "cancel": "Anuluj",
+          "submit": "Utwórz kartę",
+          "loadingBoards": "Ładowanie tablic...",
+          "loadingColumns": "Ładowanie kolumn...",
+          "emptyBoards": "Najpierw utwórz tablicę Kanban, aby dodawać karty.",
+          "fields": {
+            "board": "Tablica",
+            "column": "Kolumna",
+            "title": "Tytuł",
+            "description": "Opis",
+            "due": "Termin"
+          },
+          "placeholders": {
+            "board": "Wybierz tablicę",
+            "column": "Wybierz kolumnę",
+            "title": "Tytuł karty",
+            "description": "Opcjonalny kontekst karty..."
+          }
         }
       },
       "userMenu": {

--- a/apps/web/src/app/[locale]/dashboard/planning/boards/_components/planning-boards-client.tsx
+++ b/apps/web/src/app/[locale]/dashboard/planning/boards/_components/planning-boards-client.tsx
@@ -8,11 +8,14 @@ import {
   Calendar,
   Edit3,
   Globe2,
+  Inbox,
+  KanbanSquare,
   Loader2,
   Lock,
   MoreHorizontal,
   Plus,
   Save,
+  Search,
   SendHorizontal,
   Trash2,
   User,
@@ -37,6 +40,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
   Select,
   SelectContent,
@@ -45,6 +49,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { KanbanBoard, KanbanCard, type KanbanCardMoveParams } from "@/components/primitives/kanban";
 import { PageLoader } from "@/components/page-loader";
 import { CommentsThread } from "@/components/features/comments";
@@ -64,9 +69,12 @@ import {
   deleteKanbanCardAction,
   deleteKanbanColumnAction,
   getKanbanBoardAction,
+  listKanbanInboxCardsAction,
   listKanbanBoardsAction,
   listKanbanCardActivityAction,
+  moveKanbanCardToInboxAction,
   moveKanbanCardAction,
+  moveKanbanInboxCardToBoardAction,
   reorderKanbanColumnsAction,
   updateKanbanBoardAction,
   updateKanbanCardAction,
@@ -94,6 +102,7 @@ interface PlanningBoardsClientProps {
 
 const COLUMN_COLORS = ["#64748b", "#0d9488", "#f59e0b", "#6366f1", "#22c55e", "#ef4444"];
 const LABEL_COLORS = ["#0d9488", "#2563eb", "#7c3aed", "#e11d48", "#ea580c", "#16a34a"];
+const INBOX_COLUMN_ID = "__kanban_inbox__";
 
 function actionError(result: unknown) {
   return "error" in (result as Record<string, unknown>)
@@ -136,6 +145,8 @@ function activityLabel(
     card_created: "activityMessages.cardCreated",
     card_updated: "activityMessages.cardUpdated",
     card_moved: "activityMessages.cardMoved",
+    card_moved_to_inbox: "activityMessages.cardMovedToInbox",
+    card_moved_from_inbox: "activityMessages.cardMovedFromInbox",
     card_archived: "activityMessages.cardArchived",
     comment_added: "activityMessages.commentAdded",
   };
@@ -181,6 +192,51 @@ function applyCardMoveToBoard(
   return { ...board, cards };
 }
 
+function removeCardFromBoard(board: KanbanBoardDetail, cardId: string): KanbanBoardDetail {
+  const cards = board.cards.filter((card) => card.id !== cardId);
+  return { ...board, cards };
+}
+
+function addInboxCardToBoard(
+  board: KanbanBoardDetail,
+  card: KanbanBoardCard,
+  toColumnId: string,
+  toIndex: number
+): KanbanBoardDetail {
+  const nextBoard: KanbanBoardDetail = {
+    ...board,
+    cards: [
+      ...board.cards.filter((candidate) => candidate.id !== card.id),
+      {
+        ...card,
+        board_id: board.id,
+        column_id: toColumnId,
+        is_inbox: false,
+      },
+    ],
+  };
+  return applyCardMoveToBoard(nextBoard, card.id, toColumnId, toIndex);
+}
+
+function moveBoardCardToInbox(cards: KanbanBoardCard[], card: KanbanBoardCard): KanbanBoardCard[] {
+  return [
+    { ...card, is_inbox: true, updated_at: new Date().toISOString() },
+    ...cards.filter((candidate) => candidate.id !== card.id),
+  ].map((candidate, position) => ({ ...candidate, position }));
+}
+
+function moveInboxCardWithinInbox(
+  cards: KanbanBoardCard[],
+  cardId: string,
+  toIndex: number
+): KanbanBoardCard[] {
+  const moving = cards.find((card) => card.id === cardId);
+  if (!moving) return cards;
+  const next = cards.filter((card) => card.id !== cardId);
+  next.splice(Math.max(0, Math.min(toIndex, next.length)), 0, moving);
+  return next.map((card, position) => ({ ...card, position }));
+}
+
 export function PlanningBoardsClient({
   initialBoards,
   initialBoard,
@@ -195,6 +251,10 @@ export function PlanningBoardsClient({
   const [activeBoardId, setActiveBoardId] = useState<string | null>(initialBoard?.id ?? null);
   const [loadingBoardId, setLoadingBoardId] = useState<string | null>(null);
   const [createOpen, setCreateOpen] = useState(false);
+  const [switcherOpen, setSwitcherOpen] = useState(false);
+  const [inboxOpen, setInboxOpen] = useState(true);
+  const [inboxCards, setInboxCards] = useState<KanbanBoardCard[]>([]);
+  const [loadingInbox, setLoadingInbox] = useState(true);
   const boardLoadRequestIdRef = useRef(0);
 
   const canCreateMore = canCreate && boards.length < MAX_KANBAN_BOARDS_PER_USER;
@@ -226,12 +286,27 @@ export function PlanningBoardsClient({
     return null;
   }, []);
 
+  const refreshInbox = useCallback(async () => {
+    setLoadingInbox(true);
+    const result = await listKanbanInboxCardsAction();
+    setLoadingInbox(false);
+    if (result.success) {
+      setInboxCards(result.data);
+      return result.data;
+    }
+    toast.error(actionError(result));
+    return null;
+  }, []);
+
+  useEffect(() => {
+    void refreshInbox();
+  }, [refreshInbox]);
+
   const loadBoard = useCallback(async (boardId: string) => {
     const requestId = boardLoadRequestIdRef.current + 1;
     boardLoadRequestIdRef.current = requestId;
     setActiveBoardId(boardId);
     setLoadingBoardId(boardId);
-    setSelectedBoard(null);
 
     const result = await getKanbanBoardAction(boardId);
     if (requestId !== boardLoadRequestIdRef.current) return;
@@ -299,6 +374,7 @@ export function PlanningBoardsClient({
       setSelectedBoard(board);
       setBoardParam(board.id);
       setCreateOpen(false);
+      setSwitcherOpen(false);
       void refreshBoards();
       toast.success(t("boards.boardCreated"));
     },
@@ -330,46 +406,204 @@ export function PlanningBoardsClient({
   );
 
   return (
-    <div className="grid h-full min-h-0 grid-cols-[18rem_minmax(0,1fr)] overflow-hidden">
-      <aside className="flex min-h-0 flex-col border-r bg-muted/10">
-        <div className="border-b p-3">
-          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-            {t("boards.myBoards")}
-          </p>
-        </div>
-        <div className="flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto p-2">
-          {boards.length ? (
-            boards.map((board) => (
-              <button
-                key={board.id}
-                type="button"
-                onClick={() => selectBoard(board.id)}
-                className={cn(
-                  "flex min-w-0 flex-col gap-1 rounded-md px-3 py-2 text-left transition hover:bg-muted",
-                  activeBoardId === board.id && "bg-muted"
-                )}
-              >
-                <span className="truncate text-sm font-medium">{board.title}</span>
-                <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                  {board.visibility === "public" ? (
-                    <Globe2 className="h-3.5 w-3.5" />
-                  ) : (
-                    <Lock className="h-3.5 w-3.5" />
-                  )}
-                  <span>{t(`boards.visibility.${board.visibility}`)}</span>
-                </div>
-              </button>
-            ))
+    <TooltipProvider delayDuration={250}>
+      <div className="grid h-full min-h-0 grid-cols-[minmax(0,1fr)_3rem] overflow-hidden">
+        <main className="min-h-0 overflow-hidden">
+          {selectedBoard || loadingBoardId ? (
+            <BoardWorkspace
+              board={selectedBoard}
+              boardLoading={Boolean(loadingBoardId)}
+              inboxOpen={inboxOpen}
+              inboxCards={inboxCards}
+              loadingInbox={loadingInbox}
+              canUpdate={canUpdate}
+              canDelete={canDelete}
+              onBoardChange={handleBoardChange}
+              onInboxChange={setInboxCards}
+              onRefreshInbox={refreshInbox}
+              onBoardDeleted={() => selectedBoard && handleBoardDeleted(selectedBoard.id)}
+            />
           ) : (
-            <div className="px-3 py-8 text-sm text-muted-foreground">{t("boards.empty")}</div>
+            <div className="flex h-full items-center justify-center p-8 text-center text-sm text-muted-foreground">
+              {t("boards.selectBoard")}
+            </div>
           )}
-        </div>
-        {canCreate ? (
-          <div className="border-t p-2">
+        </main>
+        <KanbanRightToolbar
+          inboxOpen={inboxOpen}
+          onInboxToggle={() => setInboxOpen((value) => !value)}
+          onSwitchBoards={() => setSwitcherOpen(true)}
+        />
+        <BoardSwitcherDialog
+          open={switcherOpen}
+          onOpenChange={setSwitcherOpen}
+          boards={boards}
+          activeBoardId={activeBoardId}
+          canCreate={canCreate}
+          canCreateMore={canCreateMore}
+          createOpen={createOpen}
+          onCreateOpenChange={setCreateOpen}
+          onBoardCreated={handleBoardCreated}
+          onSelectBoard={(boardId) => {
+            selectBoard(boardId);
+            setSwitcherOpen(false);
+          }}
+        />
+      </div>
+    </TooltipProvider>
+  );
+}
+
+function KanbanRightToolbar({
+  inboxOpen,
+  onInboxToggle,
+  onSwitchBoards,
+}: {
+  inboxOpen: boolean;
+  onInboxToggle: () => void;
+  onSwitchBoards: () => void;
+}) {
+  const t = useTranslations("modules.planning");
+
+  return (
+    <aside className="flex min-h-0 flex-col items-center border-l bg-muted/10 px-1.5 py-3">
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            type="button"
+            size="icon"
+            variant={inboxOpen ? "default" : "ghost"}
+            className="h-8 w-8"
+            onClick={onInboxToggle}
+            aria-pressed={inboxOpen}
+            aria-label={t("boards.inbox.toggle")}
+          >
+            <Inbox className="h-4 w-4" />
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="left">{t("boards.inbox.toggle")}</TooltipContent>
+      </Tooltip>
+
+      <div className="mt-auto">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              size="icon"
+              className="h-8 w-8"
+              onClick={onSwitchBoards}
+              aria-label={t("boards.switchBoards")}
+            >
+              <KanbanSquare className="h-4 w-4" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="left">{t("boards.switchBoards")}</TooltipContent>
+        </Tooltip>
+      </div>
+    </aside>
+  );
+}
+
+function BoardSwitcherDialog({
+  open,
+  onOpenChange,
+  boards,
+  activeBoardId,
+  canCreate,
+  canCreateMore,
+  createOpen,
+  onCreateOpenChange,
+  onBoardCreated,
+  onSelectBoard,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  boards: KanbanBoardSummary[];
+  activeBoardId: string | null;
+  canCreate: boolean;
+  canCreateMore: boolean;
+  createOpen: boolean;
+  onCreateOpenChange: (open: boolean) => void;
+  onBoardCreated: (board: KanbanBoardDetail) => void;
+  onSelectBoard: (boardId: string) => void;
+}) {
+  const t = useTranslations("modules.planning");
+  const [query, setQuery] = useState("");
+
+  const filteredBoards = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) return boards;
+    return boards.filter(
+      (board) =>
+        board.title.toLowerCase().includes(normalized) ||
+        (board.description ?? "").toLowerCase().includes(normalized)
+    );
+  }, [boards, query]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-3xl p-0">
+        <DialogHeader className="border-b px-5 py-4">
+          <DialogTitle>{t("boards.switchBoards")}</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-5 p-5">
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder={t("boards.boardSearch")}
+              className="pl-9"
+              autoFocus
+            />
+          </div>
+
+          <section className="space-y-3">
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {t("boards.recentBoards")}
+            </p>
+            {filteredBoards.length ? (
+              <div className="grid max-h-[46vh] gap-2 overflow-y-auto pr-1 sm:grid-cols-2">
+                {filteredBoards.map((board) => (
+                  <button
+                    key={board.id}
+                    type="button"
+                    onClick={() => onSelectBoard(board.id)}
+                    className={cn(
+                      "flex min-w-0 flex-col gap-2 rounded-md border bg-card p-3 text-left transition hover:border-muted-foreground/50 hover:bg-muted/40",
+                      activeBoardId === board.id && "border-primary ring-1 ring-primary/40"
+                    )}
+                  >
+                    <span className="truncate text-sm font-semibold">{board.title}</span>
+                    {board.description ? (
+                      <span className="line-clamp-2 text-xs text-muted-foreground">
+                        {board.description}
+                      </span>
+                    ) : null}
+                    <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                      {board.visibility === "public" ? (
+                        <Globe2 className="h-3.5 w-3.5" />
+                      ) : (
+                        <Lock className="h-3.5 w-3.5" />
+                      )}
+                      {t(`boards.visibility.${board.visibility}`)}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            ) : (
+              <div className="rounded-md border border-dashed py-10 text-center text-sm text-muted-foreground">
+                {t("boards.empty")}
+              </div>
+            )}
+          </section>
+
+          {canCreate ? (
             <CreateBoardDialog
               open={createOpen}
-              onOpenChange={setCreateOpen}
-              onCreated={handleBoardCreated}
+              onOpenChange={onCreateOpenChange}
+              onCreated={onBoardCreated}
               disabled={!canCreateMore}
               helperText={
                 canCreateMore
@@ -377,29 +611,10 @@ export function PlanningBoardsClient({
                   : t("boards.limitReached", { max: MAX_KANBAN_BOARDS_PER_USER })
               }
             />
-          </div>
-        ) : null}
-      </aside>
-
-      <main className="min-h-0 overflow-hidden">
-        {loadingBoardId ? (
-          <PageLoader className="h-full" />
-        ) : selectedBoard ? (
-          <BoardWorkspace
-            key={selectedBoard.id}
-            board={selectedBoard}
-            canUpdate={canUpdate}
-            canDelete={canDelete}
-            onBoardChange={handleBoardChange}
-            onBoardDeleted={() => handleBoardDeleted(selectedBoard.id)}
-          />
-        ) : (
-          <div className="flex h-full items-center justify-center p-8 text-center text-sm text-muted-foreground">
-            {t("boards.selectBoard")}
-          </div>
-        )}
-      </main>
-    </div>
+          ) : null}
+        </div>
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -496,15 +711,27 @@ function CreateBoardDialog({
 
 function BoardWorkspace({
   board,
+  boardLoading,
+  inboxOpen,
+  inboxCards,
+  loadingInbox,
   canUpdate,
   canDelete,
   onBoardChange,
+  onInboxChange,
+  onRefreshInbox,
   onBoardDeleted,
 }: {
-  board: KanbanBoardDetail;
+  board: KanbanBoardDetail | null;
+  boardLoading: boolean;
+  inboxOpen: boolean;
+  inboxCards: KanbanBoardCard[];
+  loadingInbox: boolean;
   canUpdate: boolean;
   canDelete: boolean;
   onBoardChange: (board: KanbanBoardDetail) => void;
+  onInboxChange: (cards: KanbanBoardCard[]) => void;
+  onRefreshInbox: () => Promise<KanbanBoardCard[] | null>;
   onBoardDeleted: () => void | Promise<void>;
 }) {
   const t = useTranslations("modules.planning");
@@ -514,48 +741,113 @@ function BoardWorkspace({
   const cardMovePersistenceQueueRef = useRef<Promise<void>>(Promise.resolve());
 
   const selectedCard = useMemo(
-    () => board.cards.find((card) => card.id === selectedCardId) ?? null,
-    [board.cards, selectedCardId]
+    () =>
+      board?.cards.find((card) => card.id === selectedCardId) ??
+      inboxCards.find((card) => card.id === selectedCardId) ??
+      null,
+    [board?.cards, inboxCards, selectedCardId]
   );
 
-  const columns = useMemo(
-    () =>
-      board.columns.map((column) => ({
-        id: column.id,
-        title: column.title,
-        description: column.description,
-        color: column.color,
-      })),
-    [board.columns]
+  const columns = useMemo(() => {
+    const boardColumns =
+      board && !boardLoading
+        ? board.columns.map((column) => ({
+            id: column.id,
+            title: column.title,
+            description: column.description,
+            color: column.color,
+          }))
+        : [];
+
+    if (!inboxOpen) return boardColumns;
+
+    return [
+      {
+        id: INBOX_COLUMN_ID,
+        title: t("boards.inbox.title"),
+        description: t("boards.inbox.description"),
+        color: null,
+      },
+      ...boardColumns,
+    ];
+  }, [board, boardLoading, inboxOpen, t]);
+
+  const kanbanItems = useMemo(
+    () => [
+      ...(inboxOpen && !loadingInbox ? inboxCards : []),
+      ...(board && !boardLoading ? board.cards : []),
+    ],
+    [board, boardLoading, inboxCards, inboxOpen, loadingInbox]
   );
 
   const moveCard = useCallback(
-    ({ itemId, toColumnId, newIndex }: KanbanCardMoveParams) => {
+    ({ itemId, fromColumnId, toColumnId, newIndex }: KanbanCardMoveParams) => {
+      if (!board || boardLoading) {
+        if (fromColumnId === INBOX_COLUMN_ID && toColumnId === INBOX_COLUMN_ID) {
+          onInboxChange(moveInboxCardWithinInbox(inboxCards, itemId, newIndex));
+        }
+        return;
+      }
+
       const requestId = cardMoveRequestIdRef.current + 1;
       cardMoveRequestIdRef.current = requestId;
       const previous = board;
-      const optimisticBoard = applyCardMoveToBoard(board, itemId, toColumnId, newIndex);
+      const previousInbox = inboxCards;
+      const boardCard = board.cards.find((card) => card.id === itemId);
+      const inboxCard = inboxCards.find((card) => card.id === itemId);
 
-      onBoardChange(optimisticBoard);
+      if (fromColumnId === INBOX_COLUMN_ID && toColumnId === INBOX_COLUMN_ID) {
+        onInboxChange(moveInboxCardWithinInbox(inboxCards, itemId, newIndex));
+      } else if (toColumnId === INBOX_COLUMN_ID && boardCard) {
+        onBoardChange(removeCardFromBoard(board, itemId));
+        onInboxChange(moveBoardCardToInbox(inboxCards, boardCard));
+      } else if (fromColumnId === INBOX_COLUMN_ID && inboxCard) {
+        onInboxChange(inboxCards.filter((card) => card.id !== itemId));
+        onBoardChange(addInboxCardToBoard(board, inboxCard, toColumnId, newIndex));
+      } else {
+        onBoardChange(applyCardMoveToBoard(board, itemId, toColumnId, newIndex));
+      }
 
       const persistMove = async () => {
         try {
-          const result = await moveKanbanCardAction({
-            board_id: board.id,
-            card_id: itemId,
-            to_column_id: toColumnId,
-            to_position: newIndex,
-          });
+          if (fromColumnId === INBOX_COLUMN_ID && toColumnId === INBOX_COLUMN_ID) {
+            return;
+          }
 
-          if (result.success) return;
+          const result =
+            toColumnId === INBOX_COLUMN_ID
+              ? await moveKanbanCardToInboxAction({ board_id: board.id, card_id: itemId })
+              : fromColumnId === INBOX_COLUMN_ID
+                ? await moveKanbanInboxCardToBoardAction({
+                    board_id: board.id,
+                    card_id: itemId,
+                    column_id: toColumnId,
+                    position: newIndex,
+                  })
+                : await moveKanbanCardAction({
+                    board_id: board.id,
+                    card_id: itemId,
+                    to_column_id: toColumnId,
+                    to_position: newIndex,
+                  });
+
+          if (result.success) {
+            if ("board" in result.data) {
+              onBoardChange(result.data.board);
+              onInboxChange(result.data.inbox);
+            }
+            return;
+          }
 
           if (requestId === cardMoveRequestIdRef.current) {
-            onBoardChange(previous);
+            if (previous) onBoardChange(previous);
+            onInboxChange(previousInbox);
           }
           toast.error(actionError(result));
         } catch (error) {
           if (requestId === cardMoveRequestIdRef.current) {
-            onBoardChange(previous);
+            if (previous) onBoardChange(previous);
+            onInboxChange(previousInbox);
           }
 
           toast.error(error instanceof Error ? error.message : "Operation failed");
@@ -567,12 +859,14 @@ function BoardWorkspace({
         persistMove
       );
     },
-    [board, onBoardChange]
+    [board, boardLoading, inboxCards, onBoardChange, onInboxChange]
   );
 
   const reorderColumns = useCallback(
     async (nextColumns: Array<{ id: string }>) => {
-      const optimisticColumns = nextColumns
+      if (!board || boardLoading) return;
+      const boardOnlyColumns = nextColumns.filter((column) => column.id !== INBOX_COLUMN_ID);
+      const optimisticColumns = boardOnlyColumns
         .map((column, index) => {
           const fullColumn = board.columns.find((candidate) => candidate.id === column.id);
           return fullColumn ? { ...fullColumn, position: index } : null;
@@ -582,7 +876,7 @@ function BoardWorkspace({
 
       const result = await reorderKanbanColumnsAction({
         board_id: board.id,
-        column_ids: nextColumns.map((column) => column.id),
+        column_ids: boardOnlyColumns.map((column) => column.id),
       });
       if (!result.success) {
         toast.error(actionError(result));
@@ -591,108 +885,147 @@ function BoardWorkspace({
       }
       onBoardChange(result.data);
     },
-    [board, onBoardChange]
+    [board, boardLoading, onBoardChange]
   );
 
   return (
-    <div className="flex h-full min-h-0 flex-col">
-      <div className="flex items-start justify-between gap-3 border-b px-6 py-4">
-        <div className="min-w-0">
-          <div className="flex min-w-0 items-center gap-2">
-            <h2 className="truncate text-xl font-semibold">{board.title}</h2>
-            <Badge variant="outline" className="shrink-0 gap-1.5">
-              {board.visibility === "public" ? (
-                <Globe2 className="h-3.5 w-3.5" />
-              ) : (
-                <Lock className="h-3.5 w-3.5" />
-              )}
-              {t(`boards.visibility.${board.visibility}`)}
-            </Badge>
-          </div>
-          {board.description ? (
-            <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">{board.description}</p>
-          ) : null}
-        </div>
-        <div className="flex shrink-0 items-center gap-2">
-          <BoardSettingsDialog
-            board={board}
-            canUpdate={canUpdate}
-            canDelete={canDelete}
-            onChanged={onBoardChange}
-            onDeleted={onBoardDeleted}
-          />
-        </div>
-      </div>
-
-      <div className="min-h-0 flex-1 overflow-hidden">
-        <KanbanBoard
-          columns={columns}
-          items={board.cards}
-          getItemId={(card) => card.id}
-          getItemColumnId={(card) => card.column_id}
-          disabled={!canUpdate}
-          labels={{
-            emptyColumn: t("boards.emptyColumn"),
-            dragColumn: t("boards.dragColumn"),
-            collapseColumn: t("boards.collapseColumn"),
-            expandColumn: t("boards.expandColumn"),
-          }}
-          className="gap-3 p-0 pb-0"
-          columnClassName="min-h-0 rounded-none border-y-0"
-          collapsedColumnIds={collapsedColumnIds}
-          onColumnCollapsedChange={(columnId, collapsed) => {
-            setCollapsedColumnIds((current) =>
-              collapsed
-                ? Array.from(new Set([...current, columnId]))
-                : current.filter((id) => id !== columnId)
-            );
-          }}
-          onCardMove={moveCard}
-          onColumnsChange={reorderColumns}
-          renderColumnActions={(column) =>
-            canUpdate || canDelete ? (
-              <ColumnMenu
-                boardId={board.id}
-                column={board.columns.find((candidate) => candidate.id === column.id)!}
-                canUpdate={canUpdate}
-                canDelete={canDelete}
-                onChanged={onBoardChange}
-              />
-            ) : null
-          }
-          renderColumnFooter={(column) =>
-            canUpdate ? (
-              <AddCardForm boardId={board.id} columnId={column.id} onCreated={onBoardChange} />
-            ) : null
-          }
-          renderAddColumn={
-            canUpdate
-              ? () => <AddColumnPanel boardId={board.id} onCreated={onBoardChange} />
-              : undefined
-          }
-          renderCard={(card) => (
-            <BoardCard
-              card={card}
-              column={board.columns.find((candidate) => candidate.id === card.column_id)}
-              onOpen={() => setSelectedCardId(card.id)}
-            />
-          )}
-        />
-      </div>
-
-      <CardDetailDialog
-        board={board}
-        card={selectedCard}
-        columns={board.columns}
-        canUpdate={canUpdate}
-        canDelete={canDelete}
-        onOpenChange={(open) => !open && setSelectedCardId(null)}
-        onChanged={onBoardChange}
-        onDeleted={(nextBoard) => {
-          onBoardChange(nextBoard);
-          setSelectedCardId(null);
+    <div className="h-full min-h-0 overflow-hidden">
+      <KanbanBoard
+        columns={columns}
+        items={kanbanItems}
+        getItemId={(card) => card.id}
+        getItemColumnId={(card) => (card.is_inbox ? INBOX_COLUMN_ID : card.column_id)}
+        disabled={!canUpdate || boardLoading || !board}
+        labels={{
+          emptyColumn: t("boards.emptyColumn"),
+          dragColumn: t("boards.dragColumn"),
+          collapseColumn: t("boards.collapseColumn"),
+          expandColumn: t("boards.expandColumn"),
         }}
+        scrollAreaClassName="m-3 ml-3 overflow-hidden rounded-lg border bg-muted/10"
+        className="flex-1 gap-3 p-3 pb-3"
+        columnClassName="min-h-0 rounded-md"
+        fixedStartColumnIds={inboxOpen ? [INBOX_COLUMN_ID] : []}
+        fixedStartClassName="m-3 mr-0 w-[18rem] overflow-hidden rounded-lg border bg-muted/10 shadow-sm"
+        fixedColumnClassName="w-full rounded-none border-0 bg-transparent"
+        nonDraggableColumnIds={[INBOX_COLUMN_ID]}
+        renderScrollableHeader={
+          board && !boardLoading
+            ? () => (
+                <div className="flex items-start justify-between gap-3 border-b bg-background/40 px-5 py-4">
+                  <div className="min-w-0">
+                    <div className="flex min-w-0 items-center gap-2">
+                      <h2 className="truncate text-xl font-semibold">{board.title}</h2>
+                      <Badge variant="outline" className="shrink-0 gap-1.5 bg-background/60">
+                        {board.visibility === "public" ? (
+                          <Globe2 className="h-3.5 w-3.5" />
+                        ) : (
+                          <Lock className="h-3.5 w-3.5" />
+                        )}
+                        {t(`boards.visibility.${board.visibility}`)}
+                      </Badge>
+                    </div>
+                    {board.description ? (
+                      <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">
+                        {board.description}
+                      </p>
+                    ) : null}
+                  </div>
+                  <BoardSettingsDialog
+                    board={board}
+                    canUpdate={canUpdate}
+                    canDelete={canDelete}
+                    onChanged={onBoardChange}
+                    onDeleted={onBoardDeleted}
+                  />
+                </div>
+              )
+            : undefined
+        }
+        renderScrollableEmpty={
+          boardLoading || !board
+            ? () => <PageLoader className="h-full min-h-0 flex-1" />
+            : undefined
+        }
+        collapsedColumnIds={collapsedColumnIds}
+        onColumnCollapsedChange={(columnId, collapsed) => {
+          if (columnId === INBOX_COLUMN_ID) return;
+          setCollapsedColumnIds((current) =>
+            collapsed
+              ? Array.from(new Set([...current, columnId]))
+              : current.filter((id) => id !== columnId)
+          );
+        }}
+        onCardMove={moveCard}
+        onColumnsChange={reorderColumns}
+        renderColumnActions={(column) =>
+          column.id === INBOX_COLUMN_ID || !board || boardLoading ? null : canUpdate ||
+            canDelete ? (
+            <ColumnMenu
+              boardId={board.id}
+              column={board.columns.find((candidate) => candidate.id === column.id)!}
+              canUpdate={canUpdate}
+              canDelete={canDelete}
+              onChanged={onBoardChange}
+            />
+          ) : null
+        }
+        renderColumnFooter={(column) =>
+          column.id === INBOX_COLUMN_ID || !board || boardLoading ? null : canUpdate ? (
+            <AddCardForm boardId={board.id} columnId={column.id} onCreated={onBoardChange} />
+          ) : null
+        }
+        renderColumnEmpty={(column) =>
+          column.id === INBOX_COLUMN_ID && loadingInbox ? <InboxLoadingSkeleton /> : null
+        }
+        renderAddColumn={
+          canUpdate && board && !boardLoading
+            ? () => <AddColumnPanel boardId={board.id} onCreated={onBoardChange} />
+            : undefined
+        }
+        renderCard={(card) => (
+          <BoardCard
+            card={card}
+            column={board?.columns.find((candidate) => candidate.id === card.column_id)}
+            onOpen={() => !boardLoading && setSelectedCardId(card.id)}
+          />
+        )}
       />
+
+      {board ? (
+        <CardDetailDialog
+          board={board}
+          card={selectedCard}
+          columns={board.columns}
+          canUpdate={canUpdate && !selectedCard?.is_inbox}
+          canDelete={canDelete && !selectedCard?.is_inbox}
+          onOpenChange={(open) => !open && setSelectedCardId(null)}
+          onChanged={onBoardChange}
+          onDeleted={(nextBoard) => {
+            onBoardChange(nextBoard);
+            void onRefreshInbox();
+            setSelectedCardId(null);
+          }}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function InboxLoadingSkeleton() {
+  return (
+    <div className="flex flex-col gap-2">
+      {Array.from({ length: 3 }).map((_, index) => (
+        <div key={index} className="rounded-md border border-border bg-card p-3 shadow-xs">
+          <div className="flex items-start justify-between gap-3">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-2 w-2 rounded-full" />
+          </div>
+          <Skeleton className="mt-3 h-3 w-24" />
+          <Skeleton className="mt-4 h-3 w-full" />
+          <Skeleton className="mt-2 h-3 w-2/3" />
+        </div>
+      ))}
     </div>
   );
 }
@@ -998,7 +1331,7 @@ function CardDetailDialog({
   useEffect(() => {
     setTitle(card?.title ?? "");
     setDescriptionRich(normalizeRichText(card?.description_rich) ?? createEmptyRichText());
-    setColumnId(card?.column_id ?? "");
+    setColumnId(card?.is_inbox ? "" : (card?.column_id ?? ""));
     setDueAt(toDateInput(card?.due_at ?? null));
     setLabel(card?.label ?? "");
     setLabelColor(card?.label_color ?? LABEL_COLORS[0]);
@@ -1077,7 +1410,11 @@ function CardDetailDialog({
             <div className="mb-1 flex items-center gap-2 text-xs text-muted-foreground">
               <span>{t("boards.cardDetails")}</span>
               <span>•</span>
-              <span>{columns.find((column) => column.id === card?.column_id)?.title}</span>
+              <span>
+                {card?.is_inbox
+                  ? t("boards.inbox.title")
+                  : columns.find((column) => column.id === card?.column_id)?.title}
+              </span>
             </div>
             <DialogTitle asChild>
               <Input

--- a/apps/web/src/app/actions/kanban/index.ts
+++ b/apps/web/src/app/actions/kanban/index.ts
@@ -16,7 +16,9 @@ import {
   createKanbanColumnSchema,
   deleteKanbanBoardSchema,
   deleteKanbanColumnSchema,
+  moveKanbanCardToInboxSchema,
   moveKanbanCardSchema,
+  moveKanbanInboxCardToBoardSchema,
   reorderKanbanColumnsSchema,
   updateKanbanBoardSchema,
   updateKanbanCardSchema,
@@ -26,7 +28,9 @@ import {
   type CreateKanbanColumnInput,
   type DeleteKanbanBoardInput,
   type DeleteKanbanColumnInput,
+  type MoveKanbanCardToInboxInput,
   type MoveKanbanCardInput,
+  type MoveKanbanInboxCardToBoardInput,
   type ReorderKanbanColumnsInput,
   type UpdateKanbanBoardInput,
   type UpdateKanbanCardInput,
@@ -35,6 +39,7 @@ import {
 import {
   type KanbanBoardDetail,
   type KanbanBoardSummary,
+  type KanbanBoardCard,
   type KanbanCardActivity,
 } from "@/lib/types/kanban";
 import { KanbanBoardsService } from "@/server/services/kanban-boards.service";
@@ -100,6 +105,19 @@ export async function listKanbanCardActivityAction(
       return { success: false, error: "Insufficient permissions" };
     }
     return KanbanBoardsService.listCardActivity(ctx.supabase, ctx.orgId, cardId);
+  } catch {
+    return { success: false, error: "Unexpected error" };
+  }
+}
+
+export async function listKanbanInboxCardsAction(): Promise<ActionResult<KanbanBoardCard[]>> {
+  try {
+    const ctx = await getAuthedContext();
+    if (!ctx) return { success: false, error: "Unauthorized" };
+    if (!checkPermission(ctx.context.user.permissionSnapshot, PLANNING_BOARDS_READ)) {
+      return { success: false, error: "Insufficient permissions" };
+    }
+    return KanbanBoardsService.listInboxCards(ctx.supabase, ctx.orgId);
   } catch {
     return { success: false, error: "Unexpected error" };
   }
@@ -299,6 +317,54 @@ export async function moveKanbanCardAction(
     const parsed = moveKanbanCardSchema.safeParse(input);
     if (!parsed.success) return { success: false, error: firstZodError(parsed.error) };
     const result = await KanbanBoardsService.moveCard(
+      ctx.supabase,
+      ctx.orgId,
+      ctx.userId,
+      parsed.data
+    );
+    if (result.success) revalidateBoards();
+    return result;
+  } catch {
+    return { success: false, error: "Unexpected error" };
+  }
+}
+
+export async function moveKanbanCardToInboxAction(
+  input: MoveKanbanCardToInboxInput
+): Promise<ActionResult<{ board: KanbanBoardDetail; inbox: KanbanBoardCard[] }>> {
+  try {
+    const ctx = await getAuthedContext();
+    if (!ctx) return { success: false, error: "Unauthorized" };
+    if (!checkPermission(ctx.context.user.permissionSnapshot, PLANNING_BOARDS_UPDATE)) {
+      return { success: false, error: "Insufficient permissions" };
+    }
+    const parsed = moveKanbanCardToInboxSchema.safeParse(input);
+    if (!parsed.success) return { success: false, error: firstZodError(parsed.error) };
+    const result = await KanbanBoardsService.moveCardToInbox(
+      ctx.supabase,
+      ctx.orgId,
+      ctx.userId,
+      parsed.data
+    );
+    if (result.success) revalidateBoards();
+    return result;
+  } catch {
+    return { success: false, error: "Unexpected error" };
+  }
+}
+
+export async function moveKanbanInboxCardToBoardAction(
+  input: MoveKanbanInboxCardToBoardInput
+): Promise<ActionResult<{ board: KanbanBoardDetail; inbox: KanbanBoardCard[] }>> {
+  try {
+    const ctx = await getAuthedContext();
+    if (!ctx) return { success: false, error: "Unauthorized" };
+    if (!checkPermission(ctx.context.user.permissionSnapshot, PLANNING_BOARDS_UPDATE)) {
+      return { success: false, error: "Insufficient permissions" };
+    }
+    const parsed = moveKanbanInboxCardToBoardSchema.safeParse(input);
+    if (!parsed.success) return { success: false, error: firstZodError(parsed.error) };
+    const result = await KanbanBoardsService.moveInboxCardToBoard(
       ctx.supabase,
       ctx.orgId,
       ctx.userId,

--- a/apps/web/src/components/primitives/kanban/kanban-board.tsx
+++ b/apps/web/src/components/primitives/kanban/kanban-board.tsx
@@ -36,12 +36,20 @@ export function KanbanBoard<TItem>({
   onColumnsChange,
   renderColumnActions,
   renderColumnFooter,
+  renderColumnEmpty,
   renderAddColumn,
+  renderScrollableHeader,
+  renderScrollableEmpty,
   labels,
   className,
   columnClassName,
+  scrollAreaClassName,
+  fixedStartColumnIds = [],
+  fixedStartClassName,
+  fixedColumnClassName,
   disabled = false,
   columnsDraggable = true,
+  nonDraggableColumnIds = [],
   collapsedColumnIds = [],
   onColumnCollapsedChange,
 }: KanbanBoardProps<TItem>) {
@@ -79,8 +87,25 @@ export function KanbanBoard<TItem>({
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
   );
 
-  const columnIds = useMemo(() => orderedColumns.map((column) => column.id), [orderedColumns]);
+  const fixedStartColumnSet = useMemo(() => new Set(fixedStartColumnIds), [fixedStartColumnIds]);
+  const fixedStartColumns = useMemo(
+    () => orderedColumns.filter((column) => fixedStartColumnSet.has(column.id)),
+    [fixedStartColumnSet, orderedColumns]
+  );
+  const scrollColumns = useMemo(
+    () => orderedColumns.filter((column) => !fixedStartColumnSet.has(column.id)),
+    [fixedStartColumnSet, orderedColumns]
+  );
+  const scrollColumnIds = useMemo(() => scrollColumns.map((column) => column.id), [scrollColumns]);
+  const fixedStartColumnIdsInOrder = useMemo(
+    () => fixedStartColumns.map((column) => column.id),
+    [fixedStartColumns]
+  );
   const collapsedColumnSet = useMemo(() => new Set(collapsedColumnIds), [collapsedColumnIds]);
+  const nonDraggableColumnSet = useMemo(
+    () => new Set(nonDraggableColumnIds),
+    [nonDraggableColumnIds]
+  );
 
   const resetToProps = useCallback(() => {
     setOrderedColumns(columns);
@@ -100,7 +125,7 @@ export function KanbanBoard<TItem>({
     const column = orderedColumns.find((candidate) => candidate.id === activeId);
 
     if (column) {
-      if (!columnsDraggable) return;
+      if (!columnsDraggable || nonDraggableColumnSet.has(column.id)) return;
       setActiveColumn(column);
       return;
     }
@@ -126,7 +151,9 @@ export function KanbanBoard<TItem>({
     if (activeId === overId) return;
 
     const draggingColumn =
-      columnsDraggable && orderedColumns.some((column) => column.id === activeId);
+      columnsDraggable &&
+      !nonDraggableColumnSet.has(activeId) &&
+      orderedColumns.some((column) => column.id === activeId);
     if (draggingColumn) {
       const activeIndex = orderedColumns.findIndex((column) => column.id === activeId);
       const overIndex = orderedColumns.findIndex((column) => column.id === overId);
@@ -192,6 +219,10 @@ export function KanbanBoard<TItem>({
         resetToProps();
         return;
       }
+      if (nonDraggableColumnSet.has(activeId) || nonDraggableColumnSet.has(overId)) {
+        resetToProps();
+        return;
+      }
 
       const activeIndex = columns.findIndex((column) => column.id === activeId);
       const overIndex = columns.findIndex((column) => column.id === overId);
@@ -238,31 +269,72 @@ export function KanbanBoard<TItem>({
       onDragOver={disabled ? undefined : handleDragOver}
       onDragEnd={disabled ? undefined : handleDragEnd}
     >
-      <div className={cn("flex h-full min-h-0 gap-4 overflow-x-auto p-1 pb-4", className)}>
-        <SortableContext items={columnIds} strategy={horizontalListSortingStrategy}>
-          {orderedColumns.map((column) => (
-            <KanbanColumn
-              key={column.id}
-              column={column}
-              items={groupedItems[column.id] ?? []}
-              getItemId={getItemId}
-              renderCard={(item) => renderCard(item, false)}
-              actions={renderColumnActions?.(column)}
-              footer={renderColumnFooter?.(column)}
-              labels={labels}
-              className={columnClassName}
-              disabled={disabled}
-              columnDraggable={columnsDraggable}
-              collapsed={collapsedColumnSet.has(column.id)}
-              onCollapsedChange={
-                onColumnCollapsedChange
-                  ? (collapsed) => onColumnCollapsedChange(column.id, collapsed)
-                  : undefined
-              }
-            />
-          ))}
-        </SortableContext>
-        {renderAddColumn ? <div className="shrink-0">{renderAddColumn()}</div> : null}
+      <div className="flex h-full min-h-0 overflow-hidden">
+        {fixedStartColumns.length ? (
+          <div className={cn("flex h-full min-h-0 shrink-0", fixedStartClassName)}>
+            <SortableContext
+              items={fixedStartColumnIdsInOrder}
+              strategy={horizontalListSortingStrategy}
+            >
+              {fixedStartColumns.map((column) => (
+                <KanbanColumn
+                  key={column.id}
+                  column={column}
+                  items={groupedItems[column.id] ?? []}
+                  getItemId={getItemId}
+                  renderCard={(item) => renderCard(item, false)}
+                  actions={renderColumnActions?.(column)}
+                  footer={renderColumnFooter?.(column)}
+                  emptyContent={renderColumnEmpty?.(column)}
+                  labels={labels}
+                  className={cn(columnClassName, fixedColumnClassName)}
+                  disabled={disabled}
+                  columnDraggable={columnsDraggable && !nonDraggableColumnSet.has(column.id)}
+                  collapsed={collapsedColumnSet.has(column.id)}
+                  onCollapsedChange={
+                    onColumnCollapsedChange && !nonDraggableColumnSet.has(column.id)
+                      ? (collapsed) => onColumnCollapsedChange(column.id, collapsed)
+                      : undefined
+                  }
+                />
+              ))}
+            </SortableContext>
+          </div>
+        ) : null}
+        <div className={cn("flex min-w-0 flex-1 flex-col overflow-hidden", scrollAreaClassName)}>
+          {renderScrollableHeader ? renderScrollableHeader() : null}
+          {scrollColumns.length || renderAddColumn ? (
+            <div className={cn("flex h-full min-h-0 gap-4 overflow-x-auto p-1 pb-4", className)}>
+              <SortableContext items={scrollColumnIds} strategy={horizontalListSortingStrategy}>
+                {scrollColumns.map((column) => (
+                  <KanbanColumn
+                    key={column.id}
+                    column={column}
+                    items={groupedItems[column.id] ?? []}
+                    getItemId={getItemId}
+                    renderCard={(item) => renderCard(item, false)}
+                    actions={renderColumnActions?.(column)}
+                    footer={renderColumnFooter?.(column)}
+                    emptyContent={renderColumnEmpty?.(column)}
+                    labels={labels}
+                    className={columnClassName}
+                    disabled={disabled}
+                    columnDraggable={columnsDraggable && !nonDraggableColumnSet.has(column.id)}
+                    collapsed={collapsedColumnSet.has(column.id)}
+                    onCollapsedChange={
+                      onColumnCollapsedChange
+                        ? (collapsed) => onColumnCollapsedChange(column.id, collapsed)
+                        : undefined
+                    }
+                  />
+                ))}
+              </SortableContext>
+              {renderAddColumn ? <div className="shrink-0">{renderAddColumn()}</div> : null}
+            </div>
+          ) : (
+            <div className="flex min-h-0 flex-1">{renderScrollableEmpty?.()}</div>
+          )}
+        </div>
       </div>
 
       <DragOverlay

--- a/apps/web/src/components/primitives/kanban/kanban-column.tsx
+++ b/apps/web/src/components/primitives/kanban/kanban-column.tsx
@@ -14,6 +14,7 @@ interface KanbanColumnProps<TItem> {
   renderCard: (item: TItem) => ReactNode;
   actions?: ReactNode;
   footer?: ReactNode;
+  emptyContent?: ReactNode;
   labels?: KanbanBoardLabels;
   className?: string;
   disabled?: boolean;
@@ -30,6 +31,7 @@ export function KanbanColumn<TItem>({
   renderCard,
   actions,
   footer,
+  emptyContent,
   labels,
   className,
   disabled = false,
@@ -166,6 +168,8 @@ export function KanbanColumn<TItem>({
           <div className="flex min-h-full flex-col gap-2">
             {items.length ? (
               items.map((item) => <div key={getItemId(item)}>{renderCard(item)}</div>)
+            ) : emptyContent ? (
+              emptyContent
             ) : (
               <div className="flex min-h-24 items-center justify-center rounded-md border border-dashed border-border bg-background/40 px-3 text-center text-xs text-muted-foreground">
                 {labels?.emptyColumn}

--- a/apps/web/src/components/primitives/kanban/kanban-types.ts
+++ b/apps/web/src/components/primitives/kanban/kanban-types.ts
@@ -32,12 +32,20 @@ export interface KanbanBoardProps<TItem> {
   onColumnsChange?: (columns: KanbanColumnDefinition[]) => void | Promise<void>;
   renderColumnActions?: (column: KanbanColumnDefinition) => ReactNode;
   renderColumnFooter?: (column: KanbanColumnDefinition) => ReactNode;
+  renderColumnEmpty?: (column: KanbanColumnDefinition) => ReactNode;
   renderAddColumn?: () => ReactNode;
+  renderScrollableHeader?: () => ReactNode;
+  renderScrollableEmpty?: () => ReactNode;
   labels?: KanbanBoardLabels;
   className?: string;
   columnClassName?: string;
+  scrollAreaClassName?: string;
+  fixedStartColumnIds?: string[];
+  fixedStartClassName?: string;
+  fixedColumnClassName?: string;
   disabled?: boolean;
   columnsDraggable?: boolean;
+  nonDraggableColumnIds?: string[];
   collapsedColumnIds?: string[];
   onColumnCollapsedChange?: (columnId: string, collapsed: boolean) => void;
 }

--- a/apps/web/src/components/v2/layout/__tests__/dashboard-header.test.tsx
+++ b/apps/web/src/components/v2/layout/__tests__/dashboard-header.test.tsx
@@ -13,6 +13,10 @@ vi.mock("../header-notifications", () => ({
   HeaderNotifications: () => <div data-testid="header-notifications">Notifications</div>,
 }));
 
+vi.mock("../header-quick-add", () => ({
+  HeaderQuickAdd: () => <div data-testid="header-quick-add">Quick Add</div>,
+}));
+
 // Mock shadcn/ui sidebar components
 vi.mock("@/components/ui/sidebar", () => ({
   SidebarTrigger: ({ className }: { className?: string }) => (

--- a/apps/web/src/components/v2/layout/dashboard-header.tsx
+++ b/apps/web/src/components/v2/layout/dashboard-header.tsx
@@ -6,6 +6,7 @@ import { HeaderSearch } from "./header-search";
 import { HeaderNotifications } from "./header-notifications";
 import { HeaderMessages } from "./header-messages";
 import { HeaderContacts } from "./header-contacts";
+import { HeaderQuickAdd } from "./header-quick-add";
 
 /**
  * Dashboard Header V2
@@ -41,13 +42,14 @@ export function DashboardHeaderV2() {
         <HeaderSearch />
       </div>
 
-      {/* Right: Contacts + Messages + Notifications */}
+      {/* Right: Quick Add + Contacts + Messages + Notifications */}
       <div className="flex items-center gap-2 ml-auto px-6">
         {/* Mobile: Search icon */}
         <div className="md:hidden">
           <HeaderSearch />
         </div>
 
+        <HeaderQuickAdd />
         <HeaderContacts />
         <HeaderMessages />
         <HeaderNotifications />

--- a/apps/web/src/components/v2/layout/header-quick-add.tsx
+++ b/apps/web/src/components/v2/layout/header-quick-add.tsx
@@ -1,0 +1,560 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { CheckSquare, KanbanSquare, Loader2, PackagePlus, Plus, Ticket } from "lucide-react";
+import { toast } from "react-toastify";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  createKanbanCardAction,
+  getKanbanBoardAction,
+  listKanbanBoardsAction,
+} from "@/app/actions/kanban";
+import { createTaskAction } from "@/app/actions/planning";
+import { TASK_PRIORITIES, type TaskPriority } from "@/lib/validations/planning";
+import type { KanbanBoardDetail, KanbanBoardSummary } from "@/lib/types/kanban";
+
+type QuickAddDialog = "task" | "kanban-card" | null;
+
+interface QuickAddAction {
+  id: string;
+  label: string;
+  description: string;
+  icon: typeof Plus;
+  onSelect: () => void;
+}
+
+function actionError(result: unknown) {
+  return "error" in (result as Record<string, unknown>)
+    ? String((result as { error: string }).error)
+    : "Operation failed";
+}
+
+function toDateTime(value: string): string | null {
+  if (!value) return null;
+  return new Date(`${value}T12:00:00.000Z`).toISOString();
+}
+
+export function HeaderQuickAdd() {
+  const t = useTranslations("dashboard.header.quickAdd");
+  const router = useRouter();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [dialog, setDialog] = useState<QuickAddDialog>(null);
+
+  const openDialog = useCallback((nextDialog: QuickAddDialog) => {
+    setMenuOpen(false);
+    setDialog(nextDialog);
+  }, []);
+
+  const navigate = useCallback(
+    (href: string) => {
+      setMenuOpen(false);
+      router.push(href);
+    },
+    [router]
+  );
+
+  const groups = useMemo(
+    () => [
+      {
+        id: "warehouse",
+        title: t("warehouse.title"),
+        actions: [
+          {
+            id: "item",
+            label: t("warehouse.item"),
+            description: t("warehouse.itemDescription"),
+            icon: PackagePlus,
+            onSelect: () => navigate("/dashboard/warehouse/items/new"),
+          },
+        ],
+      },
+      {
+        id: "helpdesk",
+        title: t("helpdesk.title"),
+        actions: [
+          {
+            id: "ticket",
+            label: t("helpdesk.ticket"),
+            description: t("helpdesk.ticketDescription"),
+            icon: Ticket,
+            onSelect: () => navigate("/dashboard/help-desk/tickets/new"),
+          },
+        ],
+      },
+      {
+        id: "planning",
+        title: t("planning.title"),
+        actions: [
+          {
+            id: "task",
+            label: t("planning.task"),
+            description: t("planning.taskDescription"),
+            icon: CheckSquare,
+            onSelect: () => openDialog("task"),
+          },
+          {
+            id: "kanbanCard",
+            label: t("planning.kanbanCard"),
+            description: t("planning.kanbanCardDescription"),
+            icon: KanbanSquare,
+            onSelect: () => openDialog("kanban-card"),
+          },
+        ],
+      },
+    ],
+    [navigate, openDialog, t]
+  );
+
+  return (
+    <>
+      <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+        <DropdownMenuTrigger asChild>
+          <Button size="sm" className="h-8 w-8 p-0" aria-label={t("tooltip")} title={t("tooltip")}>
+            <Plus className="h-5 w-5" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="end"
+          sideOffset={8}
+          className="w-[min(calc(100vw-2rem),42rem)] rounded-lg border bg-popover p-0 shadow-xl"
+        >
+          <div className="grid gap-5 p-5 md:grid-cols-3">
+            {groups.map((group) => (
+              <section key={group.id} className="space-y-3">
+                <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  {group.title}
+                </p>
+                <div className="space-y-1">
+                  {group.actions.map((action) => (
+                    <QuickAddActionButton key={action.id} action={action} />
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <QuickTaskDialog
+        open={dialog === "task"}
+        onOpenChange={(open) => setDialog(open ? "task" : null)}
+      />
+      <QuickKanbanCardDialog
+        open={dialog === "kanban-card"}
+        onOpenChange={(open) => setDialog(open ? "kanban-card" : null)}
+      />
+    </>
+  );
+}
+
+function QuickAddActionButton({ action }: { action: QuickAddAction }) {
+  const Icon = action.icon;
+
+  return (
+    <button
+      type="button"
+      onClick={action.onSelect}
+      className="group flex w-full items-start gap-3 rounded-md border border-transparent px-2 py-2 text-left transition hover:border-primary/30 hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground transition group-hover:bg-primary group-hover:text-primary-foreground">
+        <Icon className="h-3.5 w-3.5" />
+      </span>
+      <span className="min-w-0">
+        <span className="block text-sm font-medium leading-none">{action.label}</span>
+        <span className="mt-1 block text-xs leading-snug text-muted-foreground">
+          {action.description}
+        </span>
+      </span>
+    </button>
+  );
+}
+
+function QuickTaskDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const t = useTranslations("dashboard.header.quickAdd.taskDialog");
+  const router = useRouter();
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [priority, setPriority] = useState<TaskPriority>("normal");
+  const [dueAt, setDueAt] = useState("");
+  const [isPending, startTransition] = useTransition();
+
+  const reset = useCallback(() => {
+    setTitle("");
+    setDescription("");
+    setPriority("normal");
+    setDueAt("");
+  }, []);
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (isPending) return;
+      if (!nextOpen) reset();
+      onOpenChange(nextOpen);
+    },
+    [isPending, onOpenChange, reset]
+  );
+
+  const submit = useCallback(() => {
+    const trimmedTitle = title.trim();
+    if (!trimmedTitle) return;
+
+    startTransition(async () => {
+      const result = await createTaskAction({
+        title: trimmedTitle,
+        description_plain: description.trim() || undefined,
+        priority,
+        due_at: toDateTime(dueAt),
+      });
+
+      if (!result.success) {
+        toast.error(actionError(result));
+        return;
+      }
+
+      toast.success(t("created"));
+      reset();
+      onOpenChange(false);
+      router.push(`/dashboard/planning/tasks?selected=${result.data.task_number}`);
+    });
+  }, [description, dueAt, onOpenChange, priority, reset, router, t, title]);
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-[480px]">
+        <DialogHeader>
+          <DialogTitle>{t("title")}</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="quick-task-title">{t("fields.title")}</Label>
+            <Input
+              id="quick-task-title"
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              placeholder={t("placeholders.title")}
+              disabled={isPending}
+              autoFocus
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="quick-task-description">{t("fields.description")}</Label>
+            <Textarea
+              id="quick-task-description"
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              placeholder={t("placeholders.description")}
+              disabled={isPending}
+              rows={3}
+            />
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label>{t("fields.priority")}</Label>
+              <Select
+                value={priority}
+                onValueChange={(value) => setPriority(value as TaskPriority)}
+                disabled={isPending}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {TASK_PRIORITIES.map((candidate) => (
+                    <SelectItem key={candidate} value={candidate}>
+                      {t(`priorities.${candidate}`)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="quick-task-due">{t("fields.due")}</Label>
+              <Input
+                id="quick-task-due"
+                type="date"
+                value={dueAt}
+                onChange={(event) => setDueAt(event.target.value)}
+                disabled={isPending}
+              />
+            </div>
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => handleOpenChange(false)} disabled={isPending}>
+            {t("cancel")}
+          </Button>
+          <Button onClick={submit} disabled={!title.trim() || isPending}>
+            {isPending ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : null}
+            {t("submit")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function QuickKanbanCardDialog({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const t = useTranslations("dashboard.header.quickAdd.kanbanDialog");
+  const router = useRouter();
+  const [boards, setBoards] = useState<KanbanBoardSummary[]>([]);
+  const [selectedBoardId, setSelectedBoardId] = useState("");
+  const [selectedBoard, setSelectedBoard] = useState<KanbanBoardDetail | null>(null);
+  const [selectedColumnId, setSelectedColumnId] = useState("");
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [dueAt, setDueAt] = useState("");
+  const [loadingBoards, setLoadingBoards] = useState(false);
+  const [loadingBoardDetail, setLoadingBoardDetail] = useState(false);
+  const [isPending, startTransition] = useTransition();
+
+  const columns = selectedBoard?.columns ?? [];
+
+  const reset = useCallback(() => {
+    setTitle("");
+    setDescription("");
+    setDueAt("");
+  }, []);
+
+  const loadBoardDetail = useCallback(async (boardId: string) => {
+    setLoadingBoardDetail(true);
+    const result = await getKanbanBoardAction(boardId);
+    setLoadingBoardDetail(false);
+
+    if (!result.success) {
+      toast.error(actionError(result));
+      setSelectedBoard(null);
+      setSelectedColumnId("");
+      return;
+    }
+
+    setSelectedBoard(result.data);
+    setSelectedColumnId(result.data.columns[0]?.id ?? "");
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+
+    let cancelled = false;
+    setLoadingBoards(true);
+    listKanbanBoardsAction().then(async (result) => {
+      if (cancelled) return;
+      setLoadingBoards(false);
+
+      if (!result.success) {
+        toast.error(actionError(result));
+        return;
+      }
+
+      setBoards(result.data);
+      const firstBoardId = result.data[0]?.id ?? "";
+      setSelectedBoardId(firstBoardId);
+      if (firstBoardId) await loadBoardDetail(firstBoardId);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [loadBoardDetail, open]);
+
+  const handleBoardChange = useCallback(
+    (boardId: string) => {
+      setSelectedBoardId(boardId);
+      void loadBoardDetail(boardId);
+    },
+    [loadBoardDetail]
+  );
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (isPending) return;
+      if (!nextOpen) reset();
+      onOpenChange(nextOpen);
+    },
+    [isPending, onOpenChange, reset]
+  );
+
+  const submit = useCallback(() => {
+    const trimmedTitle = title.trim();
+    if (!trimmedTitle || !selectedBoardId || !selectedColumnId) return;
+
+    startTransition(async () => {
+      const result = await createKanbanCardAction({
+        board_id: selectedBoardId,
+        column_id: selectedColumnId,
+        title: trimmedTitle,
+        description: description.trim() || null,
+        due_at: toDateTime(dueAt),
+      });
+
+      if (!result.success) {
+        toast.error(actionError(result));
+        return;
+      }
+
+      toast.success(t("created"));
+      reset();
+      onOpenChange(false);
+      router.push(`/dashboard/planning/boards?board=${selectedBoardId}`);
+    });
+  }, [
+    description,
+    dueAt,
+    onOpenChange,
+    reset,
+    router,
+    selectedBoardId,
+    selectedColumnId,
+    t,
+    title,
+  ]);
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-[520px]">
+        <DialogHeader>
+          <DialogTitle>{t("title")}</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label>{t("fields.board")}</Label>
+              <Select
+                value={selectedBoardId}
+                onValueChange={handleBoardChange}
+                disabled={loadingBoards || isPending}
+              >
+                <SelectTrigger>
+                  <SelectValue
+                    placeholder={loadingBoards ? t("loadingBoards") : t("placeholders.board")}
+                  />
+                </SelectTrigger>
+                <SelectContent>
+                  {boards.map((board) => (
+                    <SelectItem key={board.id} value={board.id}>
+                      {board.title}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label>{t("fields.column")}</Label>
+              <Select
+                value={selectedColumnId}
+                onValueChange={setSelectedColumnId}
+                disabled={loadingBoardDetail || isPending || columns.length === 0}
+              >
+                <SelectTrigger>
+                  <SelectValue
+                    placeholder={
+                      loadingBoardDetail ? t("loadingColumns") : t("placeholders.column")
+                    }
+                  />
+                </SelectTrigger>
+                <SelectContent>
+                  {columns.map((column) => (
+                    <SelectItem key={column.id} value={column.id}>
+                      {column.title}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          {boards.length === 0 && !loadingBoards ? (
+            <div className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+              {t("emptyBoards")}
+            </div>
+          ) : null}
+
+          <Separator />
+
+          <div className="space-y-2">
+            <Label htmlFor="quick-kanban-title">{t("fields.title")}</Label>
+            <Input
+              id="quick-kanban-title"
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              placeholder={t("placeholders.title")}
+              disabled={isPending}
+              autoFocus
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="quick-kanban-description">{t("fields.description")}</Label>
+            <Textarea
+              id="quick-kanban-description"
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              placeholder={t("placeholders.description")}
+              disabled={isPending}
+              rows={3}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="quick-kanban-due">{t("fields.due")}</Label>
+            <Input
+              id="quick-kanban-due"
+              type="date"
+              value={dueAt}
+              onChange={(event) => setDueAt(event.target.value)}
+              disabled={isPending}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => handleOpenChange(false)} disabled={isPending}>
+            {t("cancel")}
+          </Button>
+          <Button
+            onClick={submit}
+            disabled={!title.trim() || !selectedBoardId || !selectedColumnId || isPending}
+          >
+            {isPending ? <Loader2 className="mr-1.5 h-4 w-4 animate-spin" /> : null}
+            {t("submit")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/lib/types/kanban.ts
+++ b/apps/web/src/lib/types/kanban.ts
@@ -38,6 +38,7 @@ export interface KanbanBoardCard {
   due_at: string | null;
   label: string | null;
   label_color: string | null;
+  is_inbox: boolean;
   position: number;
   created_by: string;
   creator_name: string | null;

--- a/apps/web/src/lib/validations/kanban.ts
+++ b/apps/web/src/lib/validations/kanban.ts
@@ -63,6 +63,18 @@ export const moveKanbanCardSchema = z.object({
   to_position: z.number().int().min(0),
 });
 
+export const moveKanbanCardToInboxSchema = z.object({
+  card_id: z.string().uuid(),
+  board_id: z.string().uuid(),
+});
+
+export const moveKanbanInboxCardToBoardSchema = z.object({
+  card_id: z.string().uuid(),
+  board_id: z.string().uuid(),
+  column_id: z.string().uuid(),
+  position: z.number().int().min(0),
+});
+
 export const reorderKanbanColumnsSchema = z.object({
   board_id: z.string().uuid(),
   column_ids: z.array(z.string().uuid()).min(1),
@@ -77,4 +89,6 @@ export type DeleteKanbanColumnInput = z.infer<typeof deleteKanbanColumnSchema>;
 export type CreateKanbanCardInput = z.infer<typeof createKanbanCardSchema>;
 export type UpdateKanbanCardInput = z.infer<typeof updateKanbanCardSchema>;
 export type MoveKanbanCardInput = z.infer<typeof moveKanbanCardSchema>;
+export type MoveKanbanCardToInboxInput = z.infer<typeof moveKanbanCardToInboxSchema>;
+export type MoveKanbanInboxCardToBoardInput = z.infer<typeof moveKanbanInboxCardToBoardSchema>;
 export type ReorderKanbanColumnsInput = z.infer<typeof reorderKanbanColumnsSchema>;

--- a/apps/web/src/server/services/kanban-boards.service.ts
+++ b/apps/web/src/server/services/kanban-boards.service.ts
@@ -7,7 +7,9 @@ import type {
   DeleteKanbanBoardInput,
   DeleteKanbanColumnInput,
   KanbanVisibility,
+  MoveKanbanCardToInboxInput,
   MoveKanbanCardInput,
+  MoveKanbanInboxCardToBoardInput,
   ReorderKanbanColumnsInput,
   UpdateKanbanBoardInput,
   UpdateKanbanCardInput,
@@ -79,6 +81,7 @@ function mapCard(row: any): KanbanBoardCard {
     due_at: row.due_at ?? null,
     label: row.label ?? null,
     label_color: row.label_color ?? null,
+    is_inbox: row.is_inbox ?? false,
     position: row.position ?? 0,
     created_by: row.created_by,
     creator_name: creator
@@ -117,6 +120,19 @@ async function nextPosition(
     .from(table)
     .select("position")
     .eq(filterColumn, filterValue)
+    .is("deleted_at", null)
+    .order("position", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  return ((data as any)?.position ?? -1) + 1;
+}
+
+async function nextInboxPosition(supabase: SupabaseClient, orgId: string): Promise<number> {
+  const { data } = await supabase
+    .from("planning_kanban_cards")
+    .select("position")
+    .eq("organization_id", orgId)
+    .eq("is_inbox", true)
     .is("deleted_at", null)
     .order("position", { ascending: false })
     .limit(1)
@@ -224,12 +240,13 @@ export const KanbanBoardsService = {
         supabase
           .from("planning_kanban_cards")
           .select(
-            `id, board_id, column_id, organization_id, title, description, due_at, label, label_color, position, created_by, created_at, updated_at,
+            `id, board_id, column_id, organization_id, title, description, due_at, label, label_color, is_inbox, position, created_by, created_at, updated_at,
              description_rich,
              creator:users!created_by(first_name, last_name, email)`
           )
           .eq("organization_id", orgId)
           .eq("board_id", boardId)
+          .eq("is_inbox", false)
           .is("deleted_at", null)
           .order("position", { ascending: true }),
       ]);
@@ -466,6 +483,7 @@ export const KanbanBoardsService = {
           due_at: input.due_at || null,
           label: input.label || null,
           label_color: input.label_color || null,
+          is_inbox: false,
           position,
           created_by: userId,
           updated_by: userId,
@@ -537,6 +555,7 @@ export const KanbanBoardsService = {
         .select("id, column_id, position")
         .eq("organization_id", orgId)
         .eq("board_id", input.board_id)
+        .eq("is_inbox", false)
         .is("deleted_at", null)
         .order("position", { ascending: true });
 
@@ -565,6 +584,7 @@ export const KanbanBoardsService = {
               .from("planning_kanban_cards")
               .update({
                 column_id: columnId,
+                is_inbox: false,
                 position: index,
                 updated_by: userId,
               })
@@ -595,6 +615,180 @@ export const KanbanBoardsService = {
       );
 
       return KanbanBoardsService.getBoard(supabase, orgId, input.board_id);
+    } catch (e) {
+      return { success: false, error: e instanceof Error ? e.message : "Unexpected error" };
+    }
+  },
+
+  async listInboxCards(
+    supabase: SupabaseClient,
+    orgId: string
+  ): Promise<ServiceResult<KanbanBoardCard[]>> {
+    try {
+      const { data, error } = await supabase
+        .from("planning_kanban_cards")
+        .select(
+          `id, board_id, column_id, organization_id, title, description, due_at, label, label_color, is_inbox, position, created_by, created_at, updated_at,
+           description_rich,
+           creator:users!created_by(first_name, last_name, email)`
+        )
+        .eq("organization_id", orgId)
+        .eq("is_inbox", true)
+        .is("deleted_at", null)
+        .order("position", { ascending: true })
+        .order("updated_at", { ascending: false });
+
+      if (error) return { success: false, error: error.message };
+      return { success: true, data: (data ?? []).map(mapCard) };
+    } catch (e) {
+      return { success: false, error: e instanceof Error ? e.message : "Unexpected error" };
+    }
+  },
+
+  async moveCardToInbox(
+    supabase: SupabaseClient,
+    orgId: string,
+    userId: string,
+    input: MoveKanbanCardToInboxInput
+  ): Promise<ServiceResult<{ board: KanbanBoardDetail; inbox: KanbanBoardCard[] }>> {
+    try {
+      const position = await nextInboxPosition(supabase, orgId);
+      const { data: cardRaw, error } = await supabase
+        .from("planning_kanban_cards")
+        .update({ is_inbox: true, position, updated_by: userId })
+        .eq("organization_id", orgId)
+        .eq("board_id", input.board_id)
+        .eq("id", input.card_id)
+        .eq("is_inbox", false)
+        .is("deleted_at", null)
+        .select("column_id")
+        .single();
+
+      if (error) return { success: false, error: error.message };
+
+      await KanbanBoardsService.recordCardActivity(
+        supabase,
+        orgId,
+        input.board_id,
+        input.card_id,
+        userId,
+        "card_moved_to_inbox",
+        { from_column_id: (cardRaw as any)?.column_id ?? null }
+      );
+
+      const [boardResult, inboxResult] = await Promise.all([
+        KanbanBoardsService.getBoard(supabase, orgId, input.board_id),
+        KanbanBoardsService.listInboxCards(supabase, orgId),
+      ]);
+      if (!boardResult.success) {
+        return {
+          success: false,
+          error: "error" in boardResult ? boardResult.error : "Failed to load board",
+        };
+      }
+      if (!inboxResult.success) {
+        return {
+          success: false,
+          error: "error" in inboxResult ? inboxResult.error : "Failed to load inbox",
+        };
+      }
+      return { success: true, data: { board: boardResult.data, inbox: inboxResult.data } };
+    } catch (e) {
+      return { success: false, error: e instanceof Error ? e.message : "Unexpected error" };
+    }
+  },
+
+  async moveInboxCardToBoard(
+    supabase: SupabaseClient,
+    orgId: string,
+    userId: string,
+    input: MoveKanbanInboxCardToBoardInput
+  ): Promise<ServiceResult<{ board: KanbanBoardDetail; inbox: KanbanBoardCard[] }>> {
+    try {
+      const { data: targetCardsRaw, error: cardsError } = await supabase
+        .from("planning_kanban_cards")
+        .select("id, column_id, position")
+        .eq("organization_id", orgId)
+        .eq("board_id", input.board_id)
+        .eq("is_inbox", false)
+        .is("deleted_at", null)
+        .order("position", { ascending: true });
+
+      if (cardsError) return { success: false, error: cardsError.message };
+
+      const destinationCards = ((targetCardsRaw ?? []) as any[])
+        .filter((card) => card.column_id === input.column_id)
+        .sort((a, b) => a.position - b.position);
+      const boundedPosition = Math.max(0, Math.min(input.position, destinationCards.length));
+
+      destinationCards.splice(boundedPosition, 0, {
+        id: input.card_id,
+        column_id: input.column_id,
+        position: boundedPosition,
+      });
+
+      const movedUpdate = supabase
+        .from("planning_kanban_cards")
+        .update({
+          board_id: input.board_id,
+          column_id: input.column_id,
+          is_inbox: false,
+          position: boundedPosition,
+          updated_by: userId,
+        })
+        .eq("organization_id", orgId)
+        .eq("id", input.card_id)
+        .eq("is_inbox", true)
+        .is("deleted_at", null);
+
+      const positionUpdates = destinationCards
+        .filter((card) => card.id !== input.card_id)
+        .map((card, index) =>
+          supabase
+            .from("planning_kanban_cards")
+            .update({ position: index >= boundedPosition ? index + 1 : index, updated_by: userId })
+            .eq("organization_id", orgId)
+            .eq("board_id", input.board_id)
+            .eq("id", card.id)
+            .is("deleted_at", null)
+        );
+
+      const results = await Promise.all([movedUpdate, ...positionUpdates]);
+      const failed = results.find((result) => result.error);
+      if (failed?.error) {
+        return {
+          success: false,
+          error: failed.error instanceof Error ? failed.error.message : "Failed to move inbox card",
+        };
+      }
+
+      await KanbanBoardsService.recordCardActivity(
+        supabase,
+        orgId,
+        input.board_id,
+        input.card_id,
+        userId,
+        "card_moved_from_inbox",
+        { to_column_id: input.column_id }
+      );
+
+      const [boardResult, inboxResult] = await Promise.all([
+        KanbanBoardsService.getBoard(supabase, orgId, input.board_id),
+        KanbanBoardsService.listInboxCards(supabase, orgId),
+      ]);
+      if (!boardResult.success) {
+        return {
+          success: false,
+          error: "error" in boardResult ? boardResult.error : "Failed to load board",
+        };
+      }
+      if (!inboxResult.success) {
+        return {
+          success: false,
+          error: "error" in inboxResult ? inboxResult.error : "Failed to load inbox",
+        };
+      }
+      return { success: true, data: { board: boardResult.data, inbox: inboxResult.data } };
     } catch (e) {
       return { success: false, error: e instanceof Error ? e.message : "Unexpected error" };
     }

--- a/apps/web/supabase/migrations/20260606093000_planning_kanban_inbox.sql
+++ b/apps/web/supabase/migrations/20260606093000_planning_kanban_inbox.sql
@@ -1,0 +1,6 @@
+ALTER TABLE public.planning_kanban_cards
+  ADD COLUMN IF NOT EXISTS is_inbox BOOLEAN NOT NULL DEFAULT false;
+
+CREATE INDEX IF NOT EXISTS planning_kanban_cards_inbox_idx
+  ON public.planning_kanban_cards (organization_id, is_inbox, updated_at DESC)
+  WHERE deleted_at IS NULL;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Kanban boards now feature an "Inbox" column for organizing and managing cards outside of active board columns.
  * Introduced "Quick Add" functionality in the dashboard header to quickly create tasks, warehouse items, helpdesk tickets, and planning cards.
  * Enhanced board management with board switcher dialog and recent boards quick access.
  * Improved Kanban board layout with better column organization and scrollable regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->