### PR TITLE
feat(planning): unified planning calendar on /dashboard/planowanie

### DIFF
--- a/apps/web/src/app/[locale]/dashboard/planning/_components/planning-calendar-client.tsx
+++ b/apps/web/src/app/[locale]/dashboard/planning/_components/planning-calendar-client.tsx
@@ -1,0 +1,442 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useLocale, useTranslations } from "next-intl";
+import { toast } from "react-toastify";
+import { format, startOfDay } from "date-fns";
+import { CalendarRange, ClipboardList, ExternalLink, KanbanSquare } from "lucide-react";
+import { Link } from "@/i18n/navigation";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { PageLoader } from "@/components/page-loader";
+import {
+  CalendarScheduler,
+  type CalendarEvent,
+  type CalendarSource,
+  type SchedulerSettings,
+  type UnscheduledTask,
+} from "@/components/primitives/scheduler";
+import { LABELS_MAP, LOCALE_MAP } from "@/components/primitives/scheduler/scheduler-utils";
+import {
+  getPlanningCalendarDataAction,
+  updateCalendarItemDueDateAction,
+} from "@/app/actions/planning/calendar";
+import { updateModuleSettingsAction } from "@/app/actions/user-preferences";
+import { useDebounce } from "@/hooks/use-debounce";
+import { useUiStoreV2 } from "@/lib/stores/v2/ui-store";
+import {
+  HELPDESK_TICKETS_SOURCE_ID,
+  PLANNING_TASKS_SOURCE_ID,
+} from "@/lib/constants/planning-calendar";
+import type {
+  CalendarEventDTO,
+  CalendarItemSourceType,
+  PlanningCalendarData,
+  UnscheduledItemDTO,
+} from "@/lib/types/planning-calendar";
+import type { PlanningTaskDetail } from "@/server/services/planning-tasks.service";
+import type { PlanningPriorityBadgeConfig } from "@/components/planning/planning-task-priority-badge";
+import { PlanningTaskCreateDialog } from "../tasks/_components/planning-task-create-dialog";
+
+interface Member {
+  user_id: string;
+  name: string | null;
+  email: string | null;
+}
+
+interface PlanningCalendarClientProps {
+  members: Member[];
+  currentUserId: string;
+  canAssign: boolean;
+  canCreateTasks: boolean;
+  priorityConfigs: Record<string, PlanningPriorityBadgeConfig> | null;
+  initialVisibleSources: Record<string, boolean>;
+}
+
+const CATEGORY_DOT_MAP: Record<string, string> = {
+  meeting: "bg-indigo-500",
+  workshop: "bg-emerald-500",
+  reminder: "bg-amber-500",
+  warehouse: "bg-rose-500",
+  task: "bg-cyan-500",
+  personal: "bg-fuchsia-500",
+};
+
+function parseSourceId(id: string): { sourceType: CalendarItemSourceType; sourceId: string } {
+  const separatorIndex = id.indexOf(":");
+  return {
+    sourceType: id.slice(0, separatorIndex) as CalendarItemSourceType,
+    sourceId: id.slice(separatorIndex + 1),
+  };
+}
+
+function boardIdFromCalendarSource(calendarSourceId?: string): string | undefined {
+  return calendarSourceId?.startsWith("kanban-board:")
+    ? calendarSourceId.slice("kanban-board:".length)
+    : undefined;
+}
+
+function dtoToCalendarEvent(dto: CalendarEventDTO): CalendarEvent {
+  const date = startOfDay(new Date(dto.dueAt));
+  return {
+    id: dto.id,
+    title: dto.title,
+    start: date,
+    end: date,
+    allDay: true,
+    category: dto.category,
+    calendarSourceId: dto.calendarSourceId,
+    sourceModule: dto.sourceModule,
+    sourceType: dto.sourceType,
+    sourceId: dto.sourceId,
+    metadata: dto.metadata,
+    isDraggable: true,
+    isResizable: false,
+  };
+}
+
+function dtoToUnscheduledTask(dto: UnscheduledItemDTO): UnscheduledTask {
+  return {
+    id: dto.id,
+    title: dto.title,
+    category: dto.category,
+    calendarSourceId: dto.calendarSourceId,
+    estimatedDurationMinutes: 60,
+  };
+}
+
+function capitalize(value: string): string {
+  return value.length ? value[0].toUpperCase() + value.slice(1) : value;
+}
+
+function actionErrorMessage(
+  result: { success: false; error: string } | { success: true; data: unknown }
+): string {
+  return (result as { success: false; error: string }).error;
+}
+
+export function PlanningCalendarClient({
+  members,
+  currentUserId,
+  canAssign,
+  canCreateTasks,
+  priorityConfigs,
+  initialVisibleSources,
+}: PlanningCalendarClientProps) {
+  const locale = useLocale() as "en" | "pl";
+  const t = useTranslations("modules.planning");
+  const tTasks = useTranslations("modules.planning.tasks");
+  const labels = LABELS_MAP[locale];
+
+  const setFlushContent = useUiStoreV2((state) => state.setFlushContent);
+  useEffect(() => {
+    setFlushContent(true);
+    return () => setFlushContent(false);
+  }, [setFlushContent]);
+
+  const [calendarData, setCalendarData] = useState<PlanningCalendarData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshKey, setRefreshKey] = useState(0);
+  const [visibleSources, setVisibleSources] =
+    useState<Record<string, boolean>>(initialVisibleSources);
+  const [selectedEvent, setSelectedEvent] = useState<CalendarEvent | null>(null);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [createDueAt, setCreateDueAt] = useState<string | undefined>(undefined);
+
+  const debouncedVisibleSources = useDebounce(visibleSources, 800);
+
+  const loadCalendarData = useCallback(async () => {
+    const result = await getPlanningCalendarDataAction();
+    if (result.success) {
+      setCalendarData(result.data);
+    } else {
+      toast.error(actionErrorMessage(result));
+    }
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      setLoading(true);
+      const result = await getPlanningCalendarDataAction();
+      if (!active) return;
+      if (result.success) {
+        setCalendarData(result.data);
+      } else {
+        toast.error(actionErrorMessage(result));
+      }
+      setLoading(false);
+    })();
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (debouncedVisibleSources === initialVisibleSources) return;
+    void updateModuleSettingsAction("calendar", { visibleSources: debouncedVisibleSources });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedVisibleSources]);
+
+  const reloadCalendarData = useCallback(async () => {
+    await loadCalendarData();
+    setRefreshKey((key) => key + 1);
+  }, [loadCalendarData]);
+
+  const calendarSources = useMemo<CalendarSource[]>(() => {
+    if (!calendarData) return [];
+    return calendarData.sources.map((source) => {
+      if (source.id === PLANNING_TASKS_SOURCE_ID) return { ...source, label: labels.catTask };
+      if (source.id === HELPDESK_TICKETS_SOURCE_ID)
+        return { ...source, label: labels.ticketsSource };
+      return source;
+    });
+  }, [calendarData, labels]);
+
+  const initialEvents = useMemo<CalendarEvent[]>(
+    () => calendarData?.events.map(dtoToCalendarEvent) ?? [],
+    [calendarData]
+  );
+
+  const initialUnscheduledTasks = useMemo<UnscheduledTask[]>(
+    () => calendarData?.unscheduled.map(dtoToUnscheduledTask) ?? [],
+    [calendarData]
+  );
+
+  const initialSettings = useMemo<Partial<SchedulerSettings>>(
+    () => ({ visibleCalendarSources: visibleSources, locale }),
+    // Only used as the initializer for the (re)mounted scheduler instance.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [refreshKey, locale]
+  );
+
+  const handleSettingsChange = useCallback((settings: SchedulerSettings) => {
+    setVisibleSources(settings.visibleCalendarSources ?? {});
+  }, []);
+
+  const handleSelectRealEvent = useCallback((event: CalendarEvent) => {
+    setSelectedEvent(event);
+  }, []);
+
+  const handleCreateAt = useCallback(
+    (date: Date) => {
+      if (!canCreateTasks) return;
+      setCreateDueAt(format(date, "yyyy-MM-dd"));
+      setCreateOpen(true);
+    },
+    [canCreateTasks]
+  );
+
+  const handleMoveRealEvent = useCallback(
+    async (event: CalendarEvent, newDate: Date) => {
+      if (!event.sourceType || !event.sourceId) return;
+      const boardId =
+        event.sourceType === "kanban_card"
+          ? boardIdFromCalendarSource(event.calendarSourceId)
+          : undefined;
+
+      const result = await updateCalendarItemDueDateAction({
+        sourceType: event.sourceType as CalendarItemSourceType,
+        sourceId: event.sourceId,
+        boardId,
+        dueAt: newDate.toISOString(),
+      });
+
+      if (!result.success) {
+        toast.error(actionErrorMessage(result));
+        await reloadCalendarData();
+      }
+    },
+    [reloadCalendarData]
+  );
+
+  const handleScheduleRealTask = useCallback(
+    async (task: UnscheduledTask, date: Date) => {
+      const { sourceType, sourceId } = parseSourceId(task.id);
+      const boardId =
+        sourceType === "kanban_card" ? boardIdFromCalendarSource(task.calendarSourceId) : undefined;
+
+      const result = await updateCalendarItemDueDateAction({
+        sourceType,
+        sourceId,
+        boardId,
+        dueAt: date.toISOString(),
+      });
+
+      if (!result.success) {
+        toast.error(actionErrorMessage(result));
+      }
+      await reloadCalendarData();
+    },
+    [reloadCalendarData]
+  );
+
+  const handleTaskCreated = useCallback(
+    (_task: PlanningTaskDetail) => {
+      void reloadCalendarData();
+    },
+    [reloadCalendarData]
+  );
+
+  const openHref = useMemo(() => {
+    if (!selectedEvent) return null;
+    switch (selectedEvent.sourceType) {
+      case "planning_task":
+        return {
+          pathname: "/dashboard/planning/tasks/[taskId]" as const,
+          params: { taskId: selectedEvent.sourceId ?? "" },
+        };
+      case "helpdesk_ticket":
+        return {
+          pathname: "/dashboard/help-desk/tickets/[ticketId]" as const,
+          params: {
+            ticketId: String(selectedEvent.metadata?.ticketNumber ?? selectedEvent.sourceId ?? ""),
+          },
+        };
+      case "kanban_card": {
+        const boardId = boardIdFromCalendarSource(selectedEvent.calendarSourceId);
+        return boardId
+          ? { pathname: "/dashboard/planning/boards" as const, query: { board: boardId } }
+          : { pathname: "/dashboard/planning/boards" as const };
+      }
+      default:
+        return null;
+    }
+  }, [selectedEvent]);
+
+  const selectedSource = useMemo(
+    () => calendarSources.find((source) => source.id === selectedEvent?.calendarSourceId),
+    [calendarSources, selectedEvent]
+  );
+
+  const status = selectedEvent?.metadata?.status as string | undefined;
+  const priority = selectedEvent?.metadata?.priority as string | undefined;
+  const priorityLabel =
+    selectedEvent?.sourceType === "planning_task" && priority
+      ? (priorityConfigs?.[priority]?.label ?? capitalize(priority))
+      : priority
+        ? capitalize(priority)
+        : undefined;
+
+  if (loading) {
+    return <PageLoader />;
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex flex-none flex-wrap items-start justify-between gap-4 border-b px-6 py-4">
+        <div>
+          <div className="mb-1 flex items-center gap-2">
+            <CalendarRange className="h-5 w-5 text-primary" />
+            <h1 className="text-2xl font-semibold tracking-tight">{t("pages.overview.title")}</h1>
+          </div>
+          <p className="text-muted-foreground text-sm">{t("pages.overview.subtitle")}</p>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm" asChild>
+            <Link href="/dashboard/planning/tasks">
+              <ClipboardList className="mr-1.5 h-4 w-4" />
+              {t("features.tasks")}
+            </Link>
+          </Button>
+          <Button variant="outline" size="sm" asChild>
+            <Link href="/dashboard/planning/boards">
+              <KanbanSquare className="mr-1.5 h-4 w-4" />
+              {t("features.boards")}
+            </Link>
+          </Button>
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1">
+        <CalendarScheduler
+          key={refreshKey}
+          title={t("pages.overview.title")}
+          calendarSources={calendarSources}
+          initialEvents={initialEvents}
+          initialUnscheduledTasks={initialUnscheduledTasks}
+          initialSettings={initialSettings}
+          onSelectRealEvent={handleSelectRealEvent}
+          onCreateAt={handleCreateAt}
+          onMoveRealEvent={handleMoveRealEvent}
+          onScheduleRealTask={handleScheduleRealTask}
+          onSettingsChange={handleSettingsChange}
+        />
+      </div>
+
+      <PlanningTaskCreateDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        members={members}
+        currentUserId={currentUserId}
+        canAssign={canAssign}
+        onCreated={handleTaskCreated}
+        priorityConfigs={priorityConfigs}
+        initialDueAt={createDueAt}
+      />
+
+      <Dialog
+        open={Boolean(selectedEvent)}
+        onOpenChange={(open) => !open && setSelectedEvent(null)}
+      >
+        <DialogContent className="sm:max-w-[440px]">
+          <DialogHeader>
+            <DialogTitle>{selectedEvent?.title}</DialogTitle>
+          </DialogHeader>
+
+          <div className="flex flex-col gap-3 py-1">
+            {selectedSource && (
+              <div className="flex items-center gap-2 text-sm">
+                <span
+                  className={`h-2.5 w-2.5 rounded-full ${CATEGORY_DOT_MAP[selectedSource.category]}`}
+                />
+                <span className="text-muted-foreground">{selectedSource.label}</span>
+              </div>
+            )}
+
+            {selectedEvent && (
+              <div className="text-sm">
+                <span className="text-muted-foreground">{tTasks("dueDate")}: </span>
+                {format(selectedEvent.start, "PPP", { locale: LOCALE_MAP[locale] })}
+              </div>
+            )}
+
+            {(status || priorityLabel) && (
+              <div className="flex flex-wrap items-center gap-2">
+                {status && (
+                  <Badge variant="secondary">
+                    {tTasks("status")}: {capitalize(status)}
+                  </Badge>
+                )}
+                {priorityLabel && (
+                  <Badge variant="outline">
+                    {tTasks("priority")}: {priorityLabel}
+                  </Badge>
+                )}
+              </div>
+            )}
+          </div>
+
+          <DialogFooter>
+            {openHref && (
+              <Button asChild>
+                <Link href={openHref}>
+                  <ExternalLink className="mr-1.5 h-4 w-4" />
+                  {labels.openItem}
+                </Link>
+              </Button>
+            )}
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/dashboard/planning/page.tsx
+++ b/apps/web/src/app/[locale]/dashboard/planning/page.tsx
@@ -2,10 +2,16 @@ import { redirect } from "@/i18n/navigation";
 import { getLocale } from "next-intl/server";
 import { loadDashboardContextV2 } from "@/server/loaders/v2/load-dashboard-context.v2";
 import { checkPermission } from "@/lib/utils/permissions";
-import { PLANNING_READ } from "@/lib/constants/permissions";
-import { getTranslations } from "next-intl/server";
-
-const FEATURE_CARDS = ["tasks", "boards"] as const;
+import {
+  PLANNING_READ,
+  PLANNING_TASKS_CREATE,
+  PLANNING_TASKS_ASSIGN,
+} from "@/lib/constants/permissions";
+import { createClient } from "@/utils/supabase/server";
+import { OrgMembersService } from "@/server/services/organization.service";
+import { PlanningSettingsService } from "@/server/services/planning-settings.service";
+import { UserPreferencesService } from "@/server/services/user-preferences.service";
+import { PlanningCalendarClient } from "./_components/planning-calendar-client";
 
 export default async function PlanningOverviewPage() {
   const locale = await getLocale();
@@ -25,27 +31,37 @@ export default async function PlanningOverviewPage() {
     });
   }
 
-  const t = await getTranslations("modules.planning");
+  const supabase = await createClient();
+  const orgId = context.app.activeOrgId;
+  const userId = context.user.user?.id ?? "";
+  const snap = context.user.permissionSnapshot;
+
+  const [membersResult, settingsResult, preferences] = await Promise.all([
+    OrgMembersService.listMembers(supabase, orgId),
+    PlanningSettingsService.getSettings(supabase, orgId),
+    UserPreferencesService.getOrCreatePreferences(supabase, userId),
+  ]);
+
+  const members = membersResult.success
+    ? membersResult.data.map((m) => ({
+        user_id: m.user_id,
+        name: [m.user_first_name, m.user_last_name].filter(Boolean).join(" ") || null,
+        email: m.user_email,
+      }))
+    : [];
+
+  const calendarSettings = preferences.moduleSettings.calendar as
+    | { visibleSources?: Record<string, boolean> }
+    | undefined;
 
   return (
-    <div className="flex flex-col gap-6 p-6">
-      <div>
-        <h1 className="text-2xl font-semibold tracking-tight">{t("pages.overview.title")}</h1>
-        <p className="text-muted-foreground mt-1 text-sm">{t("pages.overview.subtitle")}</p>
-      </div>
-
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {FEATURE_CARDS.map((key) => (
-          <div
-            key={key}
-            className="bg-card text-card-foreground border-border flex flex-col gap-2 rounded-lg border p-5"
-          >
-            <div className="flex items-center justify-between">
-              <span className="text-sm font-medium">{t(`features.${key}`)}</span>
-            </div>
-          </div>
-        ))}
-      </div>
-    </div>
+    <PlanningCalendarClient
+      members={members}
+      currentUserId={userId}
+      canAssign={checkPermission(snap, PLANNING_TASKS_ASSIGN)}
+      canCreateTasks={checkPermission(snap, PLANNING_TASKS_CREATE)}
+      priorityConfigs={settingsResult.success ? settingsResult.data.priority_configs : null}
+      initialVisibleSources={calendarSettings?.visibleSources ?? {}}
+    />
   );
 }

--- a/apps/web/src/app/[locale]/dashboard/planning/tasks/_components/planning-task-create-dialog.tsx
+++ b/apps/web/src/app/[locale]/dashboard/planning/tasks/_components/planning-task-create-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
 import { Loader2, UserCheck } from "lucide-react";
 import { toast } from "react-toastify";
@@ -46,6 +46,7 @@ interface PlanningTaskCreateDialogProps {
   canAssign: boolean;
   onCreated: (task: PlanningTaskDetail) => void;
   priorityConfigs: Record<string, PlanningPriorityBadgeConfig> | null;
+  initialDueAt?: string;
 }
 
 export function PlanningTaskCreateDialog({
@@ -56,22 +57,29 @@ export function PlanningTaskCreateDialog({
   canAssign,
   onCreated,
   priorityConfigs,
+  initialDueAt,
 }: PlanningTaskCreateDialogProps) {
   const t = useTranslations("modules.planning.tasks");
   const [title, setTitle] = useState("");
   const [descriptionRich, setDescriptionRich] = useState<RichTextValue>(createEmptyRichText);
   const [priority, setPriority] = useState<TaskPriority>("normal");
   const [assignedTo, setAssignedTo] = useState<string>("__unassigned__");
-  const [dueAt, setDueAt] = useState<string>("");
+  const [dueAt, setDueAt] = useState<string>(initialDueAt ?? "");
   const [titleError, setTitleError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setDueAt(initialDueAt ?? "");
+    }
+  }, [open, initialDueAt]);
 
   function reset() {
     setTitle("");
     setDescriptionRich(createEmptyRichText);
     setPriority("normal");
     setAssignedTo("__unassigned__");
-    setDueAt("");
+    setDueAt(initialDueAt ?? "");
     setTitleError(null);
   }
 

--- a/apps/web/src/app/actions/planning/calendar.ts
+++ b/apps/web/src/app/actions/planning/calendar.ts
@@ -1,0 +1,100 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/utils/supabase/server";
+import { loadDashboardContextV2 } from "@/server/loaders/v2/load-dashboard-context.v2";
+import { checkPermission } from "@/lib/utils/permissions";
+import { PLANNING_READ, PLANNING_TASKS_UPDATE } from "@/lib/constants/permissions";
+import { PlanningCalendarService } from "@/server/services/planning-calendar.service";
+import { PlanningTasksService } from "@/server/services/planning-tasks.service";
+import { HelpdeskTicketsService } from "@/server/services/helpdesk-tickets.service";
+import { KanbanBoardsService } from "@/server/services/kanban-boards.service";
+import {
+  updateCalendarItemDueDateSchema,
+  type UpdateCalendarItemDueDateInput,
+} from "@/lib/validations/planning-calendar";
+import type { PlanningCalendarData } from "@/lib/types/planning-calendar";
+
+type ActionResult<T> = { success: true; data: T } | { success: false; error: string };
+
+async function getAuthedContext() {
+  const supabase = await createClient();
+  const context = await loadDashboardContextV2();
+  if (!context?.app.activeOrgId) return null;
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return null;
+  return { supabase, context, userId: user.id, orgId: context.app.activeOrgId };
+}
+
+function firstZodError(error: unknown) {
+  const issues = (error as { issues?: Array<{ message?: string }> })?.issues;
+  return issues?.[0]?.message ?? "Invalid input";
+}
+
+export async function getPlanningCalendarDataAction(): Promise<ActionResult<PlanningCalendarData>> {
+  try {
+    const ctx = await getAuthedContext();
+    if (!ctx) return { success: false, error: "Unauthorized" };
+    if (!checkPermission(ctx.context.user.permissionSnapshot, PLANNING_READ))
+      return { success: false, error: "Insufficient permissions" };
+
+    return PlanningCalendarService.getCalendarData(
+      ctx.supabase,
+      ctx.orgId,
+      ctx.context.user.permissionSnapshot
+    );
+  } catch {
+    return { success: false, error: "Unexpected error" };
+  }
+}
+
+export async function updateCalendarItemDueDateAction(
+  input: UpdateCalendarItemDueDateInput
+): Promise<ActionResult<void>> {
+  try {
+    const ctx = await getAuthedContext();
+    if (!ctx) return { success: false, error: "Unauthorized" };
+
+    const parsed = updateCalendarItemDueDateSchema.safeParse(input);
+    if (!parsed.success) return { success: false, error: firstZodError(parsed.error) };
+
+    const { sourceType, sourceId, boardId, dueAt } = parsed.data;
+
+    switch (sourceType) {
+      case "planning_task": {
+        if (!checkPermission(ctx.context.user.permissionSnapshot, PLANNING_TASKS_UPDATE))
+          return { success: false, error: "Insufficient permissions" };
+        return PlanningTasksService.updateDueAt(
+          ctx.supabase,
+          ctx.orgId,
+          ctx.userId,
+          sourceId,
+          dueAt
+        );
+      }
+      case "helpdesk_ticket": {
+        return HelpdeskTicketsService.updateDueAt(ctx.supabase, ctx.orgId, sourceId, dueAt);
+      }
+      case "kanban_card": {
+        if (!boardId) return { success: false, error: "boardId is required for kanban cards" };
+        const result = await KanbanBoardsService.updateCardDueAt(
+          ctx.supabase,
+          ctx.orgId,
+          ctx.userId,
+          sourceId,
+          boardId,
+          dueAt
+        );
+        if (result.success) {
+          revalidatePath("/dashboard/planning/boards");
+          revalidatePath("/dashboard/planowanie/tablice");
+        }
+        return result;
+      }
+    }
+  } catch {
+    return { success: false, error: "Unexpected error" };
+  }
+}

--- a/apps/web/src/components/primitives/scheduler/index.ts
+++ b/apps/web/src/components/primitives/scheduler/index.ts
@@ -5,7 +5,9 @@ export type { ResourcePlannerProps } from "./resource-planner";
 export type {
   BackgroundEvent,
   CalendarEvent,
+  CalendarSource,
   CalendarView,
+  EventCategory,
   SchedulerSettings,
   UnscheduledTask,
 } from "./scheduler-types";

--- a/apps/web/src/components/primitives/scheduler/scheduler-shell.tsx
+++ b/apps/web/src/components/primitives/scheduler/scheduler-shell.tsx
@@ -19,6 +19,7 @@ import {
   UnscheduledTask,
   CalendarView,
   SchedulerSettings,
+  CalendarSource,
 } from "./scheduler-types";
 import {
   INITIAL_SETTINGS,
@@ -55,6 +56,12 @@ export interface SchedulerWorkspaceProps {
   initialBackgroundEvents?: BackgroundEvent[];
   initialUnscheduledTasks?: UnscheduledTask[];
   title?: string;
+  calendarSources?: CalendarSource[];
+  onSelectRealEvent?: (event: CalendarEvent) => void;
+  onCreateAt?: (date: Date) => void;
+  onMoveRealEvent?: (event: CalendarEvent, newDate: Date) => void;
+  onScheduleRealTask?: (task: UnscheduledTask, date: Date) => void;
+  onSettingsChange?: (settings: SchedulerSettings) => void;
 }
 
 export const SchedulerWorkspace: React.FC<SchedulerWorkspaceProps> = ({
@@ -66,6 +73,12 @@ export const SchedulerWorkspace: React.FC<SchedulerWorkspaceProps> = ({
   initialBackgroundEvents = INITIAL_BACKGROUND_EVENTS,
   initialUnscheduledTasks = INITIAL_UNSCHEDULED_TASKS,
   title = "Scheduler",
+  calendarSources,
+  onSelectRealEvent,
+  onCreateAt,
+  onMoveRealEvent,
+  onScheduleRealTask,
+  onSettingsChange,
 }) => {
   const today = useMemo(() => startOfDay(new Date()), []);
   const mergedInitialSettings = useMemo<SchedulerSettings>(
@@ -133,9 +146,13 @@ export const SchedulerWorkspace: React.FC<SchedulerWorkspaceProps> = ({
     }
   };
 
-  // Safe category filtering for showing calendar items and translating on-the-fly
+  // Safe category/source filtering for showing calendar items and translating on-the-fly
   const activeEvents = events
-    .filter((ev) => settings.visibleCategories[ev.category])
+    .filter((ev) =>
+      calendarSources
+        ? settings.visibleCalendarSources?.[ev.calendarSourceId ?? ""] !== false
+        : settings.visibleCategories[ev.category]
+    )
     .map((ev) => getLocalizedEvent(ev, settings.locale));
 
   const localizedBackgroundEvents = backgroundEvents.map((bg) =>
@@ -152,6 +169,7 @@ export const SchedulerWorkspace: React.FC<SchedulerWorkspaceProps> = ({
       if (newSettings.locale && newSettings.locale !== prev.locale) {
         updated.timeFormat = newSettings.locale === "en" ? "12h" : "24h";
       }
+      onSettingsChange?.(updated);
       return updated;
     });
   };
@@ -163,6 +181,11 @@ export const SchedulerWorkspace: React.FC<SchedulerWorkspaceProps> = ({
     resourceId?: string,
     endDate?: Date
   ) => {
+    if (onCreateAt) {
+      onCreateAt(date);
+      return;
+    }
+
     const now = new Date();
     // Maintain clicked day but prefill hours nicely
     const startObj = new Date(date);
@@ -182,11 +205,20 @@ export const SchedulerWorkspace: React.FC<SchedulerWorkspaceProps> = ({
   };
 
   const handleCreateNewClick = () => {
+    if (onCreateAt) {
+      onCreateAt(currentDate);
+      return;
+    }
+
     setDialogPrefillEvent(null);
     setIsDialogModelOpen(true);
   };
 
   const handleSelectEvent = (event: CalendarEvent) => {
+    if (event.sourceModule && onSelectRealEvent) {
+      onSelectRealEvent(event);
+      return;
+    }
     setSelectedEvent(event);
   };
 
@@ -266,6 +298,8 @@ export const SchedulerWorkspace: React.FC<SchedulerWorkspaceProps> = ({
 
   // Drag event handler for moving items on grid columns
   const handleMoveEvent = (eventId: string, newStartDate: Date, newResourceId?: string) => {
+    const sourceEvent = events.find((ev) => ev.id === eventId);
+
     setEvents((prev) =>
       prev.map((ev) => {
         if (ev.id === eventId) {
@@ -278,6 +312,10 @@ export const SchedulerWorkspace: React.FC<SchedulerWorkspaceProps> = ({
         return ev;
       })
     );
+
+    if (sourceEvent?.sourceModule && onMoveRealEvent) {
+      onMoveRealEvent(sourceEvent, newStartDate);
+    }
   };
 
   // Resizing event card boundaries handler
@@ -307,6 +345,10 @@ export const SchedulerWorkspace: React.FC<SchedulerWorkspaceProps> = ({
     }
     setEvents((prev) => [...prev, newEvent]);
     setUnscheduledTasks((prev) => prev.filter((t) => t.id !== taskId));
+
+    if (task.calendarSourceId && onScheduleRealTask) {
+      onScheduleRealTask(task, targetDate);
+    }
   };
 
   let computedStartHour = settings.dayStartHour;
@@ -388,6 +430,8 @@ export const SchedulerWorkspace: React.FC<SchedulerWorkspaceProps> = ({
             onDragTaskEnd={() => setDraggedTaskId(null)}
             currentDate={currentDate}
             onNavigateDate={setCurrentDate}
+            calendarSources={calendarSources}
+            events={activeEvents}
           />
         </div>
       </div>

--- a/apps/web/src/components/primitives/scheduler/scheduler-sidebar.tsx
+++ b/apps/web/src/components/primitives/scheduler/scheduler-sidebar.tsx
@@ -17,6 +17,8 @@ import {
   SchedulerSettings,
   EventCategory,
   UnscheduledTask,
+  CalendarEvent,
+  CalendarSource,
   SchedulerTheme,
   SchedulerLocale,
   SchedulerTimezone,
@@ -40,6 +42,8 @@ interface SchedulerSidebarProps {
   onDragTaskEnd?: () => void;
   currentDate?: Date;
   onNavigateDate?: (date: Date) => void;
+  calendarSources?: CalendarSource[];
+  events?: CalendarEvent[];
 }
 
 export const SchedulerSidebar: React.FC<SchedulerSidebarProps> = ({
@@ -50,6 +54,8 @@ export const SchedulerSidebar: React.FC<SchedulerSidebarProps> = ({
   onDragTaskEnd,
   currentDate = startOfDay(new Date()),
   onNavigateDate,
+  calendarSources,
+  events = [],
 }) => {
   const label = LABELS_MAP[settings.locale];
 
@@ -173,6 +179,30 @@ export const SchedulerSidebar: React.FC<SchedulerSidebarProps> = ({
     onUpdateSettings({ visibleCategories: updated });
   };
 
+  // Color swatches reused for dynamic calendar sources (keyed by their cycled category)
+  const CATEGORY_COLOR_MAP: Record<EventCategory, { bg: string; border: string }> = {
+    meeting: { bg: "bg-indigo-500", border: "border-indigo-200" },
+    workshop: { bg: "bg-emerald-500", border: "border-emerald-200" },
+    reminder: { bg: "bg-amber-500", border: "border-amber-200" },
+    warehouse: { bg: "bg-rose-500", border: "border-rose-200" },
+    task: { bg: "bg-cyan-500", border: "border-cyan-200" },
+    personal: { bg: "bg-fuchsia-500", border: "border-fuchsia-200" },
+  };
+
+  const isSourceVisible = (sourceId: string) =>
+    settings.visibleCalendarSources?.[sourceId] !== false;
+
+  const handleCalendarSourceToggle = (sourceId: string) => {
+    const updated = {
+      ...(settings.visibleCalendarSources ?? {}),
+      [sourceId]: !isSourceVisible(sourceId),
+    };
+    onUpdateSettings({ visibleCalendarSources: updated });
+  };
+
+  const getSourceForTask = (task: UnscheduledTask) =>
+    calendarSources?.find((source) => source.id === task.calendarSourceId);
+
   const handleThemeChange = (theme: SchedulerTheme) => {
     onUpdateSettings({ theme });
   };
@@ -283,42 +313,81 @@ export const SchedulerSidebar: React.FC<SchedulerSidebarProps> = ({
       {/* Calendars / Filters Categories */}
       <div className="space-y-4 pt-1">
         <h3 className="text-[10px] font-extrabold text-slate-400 dark:text-neutral-500 uppercase tracking-widest font-mono">
-          {label.filters}
+          {calendarSources ? label.calendarsTitle || "Calendars" : label.filters}
         </h3>
         <div className="space-y-2.5">
-          {categories.map((cat) => {
-            const isSelected = settings.visibleCategories[cat.key];
-            return (
-              <label
-                key={cat.key}
-                onClick={() => handleCategoryToggle(cat.key)}
-                className="flex items-center gap-3 text-xs text-slate-600 dark:text-neutral-300 cursor-pointer p-1.5 rounded-lg hover:bg-slate-100/50 dark:hover:bg-neutral-800/40 transition duration-150"
-              >
-                <div
-                  className={`w-4 h-4 rounded border flex items-center justify-center transition duration-150 ${
-                    isSelected
-                      ? `${cat.bg} border-transparent text-white`
-                      : "border-slate-300 dark:border-neutral-700 bg-transparent"
-                  }`}
-                >
-                  {isSelected && (
-                    <svg
-                      className="w-3 h-3 text-white"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                      strokeWidth="3"
+          {calendarSources
+            ? calendarSources.map((source) => {
+                const isSelected = isSourceVisible(source.id);
+                const colors = CATEGORY_COLOR_MAP[source.category];
+                const count = events.filter((ev) => ev.calendarSourceId === source.id).length;
+                return (
+                  <label
+                    key={source.id}
+                    onClick={() => handleCalendarSourceToggle(source.id)}
+                    className="flex items-center gap-3 text-xs text-slate-600 dark:text-neutral-300 cursor-pointer p-1.5 rounded-lg hover:bg-slate-100/50 dark:hover:bg-neutral-800/40 transition duration-150"
+                  >
+                    <div
+                      className={`w-4 h-4 rounded border flex items-center justify-center transition duration-150 shrink-0 ${
+                        isSelected
+                          ? `${colors.bg} border-transparent text-white`
+                          : "border-slate-300 dark:border-neutral-700 bg-transparent"
+                      }`}
                     >
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-                    </svg>
-                  )}
-                </div>
-                <span className="font-semibold text-slate-700 dark:text-neutral-250">
-                  {cat.labelText}
-                </span>
-              </label>
-            );
-          })}
+                      {isSelected && (
+                        <svg
+                          className="w-3 h-3 text-white"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                          strokeWidth="3"
+                        >
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                        </svg>
+                      )}
+                    </div>
+                    <span className="font-semibold text-slate-700 dark:text-neutral-250 flex-1 line-clamp-1">
+                      {source.label}
+                    </span>
+                    <span className="text-[9px] bg-slate-50 dark:bg-neutral-800 text-slate-500 dark:text-neutral-400 px-1.5 py-0.5 rounded border border-slate-100 dark:border-neutral-700/60 font-mono font-semibold shrink-0">
+                      {count}
+                    </span>
+                  </label>
+                );
+              })
+            : categories.map((cat) => {
+                const isSelected = settings.visibleCategories[cat.key];
+                return (
+                  <label
+                    key={cat.key}
+                    onClick={() => handleCategoryToggle(cat.key)}
+                    className="flex items-center gap-3 text-xs text-slate-600 dark:text-neutral-300 cursor-pointer p-1.5 rounded-lg hover:bg-slate-100/50 dark:hover:bg-neutral-800/40 transition duration-150"
+                  >
+                    <div
+                      className={`w-4 h-4 rounded border flex items-center justify-center transition duration-150 ${
+                        isSelected
+                          ? `${cat.bg} border-transparent text-white`
+                          : "border-slate-300 dark:border-neutral-700 bg-transparent"
+                      }`}
+                    >
+                      {isSelected && (
+                        <svg
+                          className="w-3 h-3 text-white"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          stroke="currentColor"
+                          strokeWidth="3"
+                        >
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                        </svg>
+                      )}
+                    </div>
+                    <span className="font-semibold text-slate-700 dark:text-neutral-250">
+                      {cat.labelText}
+                    </span>
+                  </label>
+                );
+              })}
         </div>
       </div>
 
@@ -327,7 +396,7 @@ export const SchedulerSidebar: React.FC<SchedulerSidebarProps> = ({
         <div className="flex-1 space-y-4 flex flex-col border-t border-slate-200/50 dark:border-neutral-800 pt-5 text-left">
           <div className="flex items-center justify-between shrink-0">
             <h3 className="text-[10px] font-extrabold text-slate-400 dark:text-neutral-500 uppercase tracking-widest font-mono text-left">
-              {label.taskPool}
+              {calendarSources ? label.noDueDateTitle || "No due date" : label.taskPool}
             </h3>
             <span className="bg-indigo-50 dark:bg-indigo-950/50 text-indigo-600 dark:text-indigo-400 font-extrabold px-2 py-0.5 rounded-full text-[10px]">
               {unscheduledTasks.length}
@@ -361,12 +430,29 @@ export const SchedulerSidebar: React.FC<SchedulerSidebarProps> = ({
                       {task.description}
                     </p>
                   )}
-                  <div className="flex items-center gap-1">
-                    <div className="w-1.5 h-1.5 rounded-full bg-indigo-500" />
-                    <span className="text-[8.5px] text-slate-400 uppercase tracking-tighter font-extrabold font-mono dark:text-neutral-500">
-                      {getCategoryLabel(task.category)}
-                    </span>
-                  </div>
+                  {calendarSources ? (
+                    (() => {
+                      const source = getSourceForTask(task);
+                      const colors = source
+                        ? CATEGORY_COLOR_MAP[source.category]
+                        : CATEGORY_COLOR_MAP.task;
+                      return (
+                        <div className="flex items-center gap-1">
+                          <div className={`w-1.5 h-1.5 rounded-full ${colors.bg}`} />
+                          <span className="text-[8.5px] text-slate-400 uppercase tracking-tighter font-extrabold font-mono dark:text-neutral-500">
+                            {source?.label ?? getCategoryLabel(task.category)}
+                          </span>
+                        </div>
+                      );
+                    })()
+                  ) : (
+                    <div className="flex items-center gap-1">
+                      <div className="w-1.5 h-1.5 rounded-full bg-indigo-500" />
+                      <span className="text-[8.5px] text-slate-400 uppercase tracking-tighter font-extrabold font-mono dark:text-neutral-500">
+                        {getCategoryLabel(task.category)}
+                      </span>
+                    </div>
+                  )}
                 </div>
               ))
             )}

--- a/apps/web/src/components/primitives/scheduler/scheduler-types.ts
+++ b/apps/web/src/components/primitives/scheduler/scheduler-types.ts
@@ -23,6 +23,7 @@ export interface CalendarEvent {
   isProvisional?: boolean;
   resourceId?: string;
   metadata?: Record<string, unknown>;
+  calendarSourceId?: string;
 }
 
 export interface BackgroundEvent {
@@ -44,6 +45,7 @@ export interface UnscheduledTask {
   priority?: "low" | "medium" | "high";
   category: EventCategory;
   color?: string;
+  calendarSourceId?: string;
 }
 
 export type SchedulerTheme = "light" | "dark" | "system";
@@ -71,4 +73,13 @@ export interface SchedulerSettings {
   dayEndHour: number;
   autoTimeScale?: boolean;
   visibleCategories: Record<EventCategory, boolean>;
+  visibleCalendarSources?: Record<string, boolean>;
+}
+
+export interface CalendarSource {
+  id: string;
+  label: string;
+  category: EventCategory;
+  module: "planning" | "helpdesk" | "kanban";
+  boardId?: string;
 }

--- a/apps/web/src/components/primitives/scheduler/scheduler-utils.ts
+++ b/apps/web/src/components/primitives/scheduler/scheduler-utils.ts
@@ -23,6 +23,16 @@ export const LOCALE_MAP = {
   de: de,
 };
 
+// Cycle of existing event categories used to assign colors to dynamic calendar sources
+export const CALENDAR_SOURCE_CATEGORY_CYCLE: EventCategory[] = [
+  "task",
+  "warehouse",
+  "meeting",
+  "reminder",
+  "personal",
+  "workshop",
+];
+
 // Map locale to common labels
 export const LABELS_MAP = {
   en: {
@@ -108,6 +118,10 @@ export const LABELS_MAP = {
     timelineView: "Timeline View",
     gridView: "Grid View",
     searchResources: "Search resources...",
+    calendarsTitle: "Calendars",
+    noDueDateTitle: "No due date",
+    ticketsSource: "Tickets",
+    openItem: "Open",
   },
   pl: {
     today: "Dzisiaj",
@@ -192,6 +206,10 @@ export const LABELS_MAP = {
     timelineView: "Widok osi czasu",
     gridView: "Widok siatki",
     searchResources: "Szukaj zasobów...",
+    calendarsTitle: "Kalendarze",
+    noDueDateTitle: "Bez terminu",
+    ticketsSource: "Zgłoszenia",
+    openItem: "Otwórz",
   },
   de: {
     today: "Heute",
@@ -277,6 +295,10 @@ export const LABELS_MAP = {
     timelineView: "Zeitachse",
     gridView: "Spaltenansicht",
     searchResources: "Ressourcen suchen...",
+    calendarsTitle: "Kalender",
+    noDueDateTitle: "Ohne Termin",
+    ticketsSource: "Tickets",
+    openItem: "Öffnen",
   },
 };
 

--- a/apps/web/src/lib/constants/planning-calendar.ts
+++ b/apps/web/src/lib/constants/planning-calendar.ts
@@ -1,0 +1,2 @@
+export const PLANNING_TASKS_SOURCE_ID = "planning-tasks";
+export const HELPDESK_TICKETS_SOURCE_ID = "helpdesk-tickets";

--- a/apps/web/src/lib/types/planning-calendar.ts
+++ b/apps/web/src/lib/types/planning-calendar.ts
@@ -1,0 +1,33 @@
+import type { CalendarSource, EventCategory } from "@/components/primitives/scheduler";
+
+export type CalendarItemSourceModule = "planning" | "helpdesk" | "kanban";
+export type CalendarItemSourceType = "planning_task" | "helpdesk_ticket" | "kanban_card";
+
+export interface CalendarEventDTO {
+  id: string;
+  title: string;
+  dueAt: string;
+  category: EventCategory;
+  calendarSourceId: string;
+  sourceModule: CalendarItemSourceModule;
+  sourceType: CalendarItemSourceType;
+  sourceId: string;
+  metadata: Record<string, unknown>;
+}
+
+export interface UnscheduledItemDTO {
+  id: string;
+  title: string;
+  category: EventCategory;
+  calendarSourceId: string;
+  sourceModule: CalendarItemSourceModule;
+  sourceType: CalendarItemSourceType;
+  sourceId: string;
+  metadata: Record<string, unknown>;
+}
+
+export interface PlanningCalendarData {
+  sources: CalendarSource[];
+  events: CalendarEventDTO[];
+  unscheduled: UnscheduledItemDTO[];
+}

--- a/apps/web/src/lib/validations/planning-calendar.ts
+++ b/apps/web/src/lib/validations/planning-calendar.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+export const updateCalendarItemDueDateSchema = z.object({
+  sourceType: z.enum(["planning_task", "helpdesk_ticket", "kanban_card"]),
+  sourceId: z.string().uuid(),
+  boardId: z.string().uuid().optional(),
+  dueAt: z.string().datetime().nullable(),
+});
+
+export type UpdateCalendarItemDueDateInput = z.infer<typeof updateCalendarItemDueDateSchema>;

--- a/apps/web/src/server/services/helpdesk-tickets.service.ts
+++ b/apps/web/src/server/services/helpdesk-tickets.service.ts
@@ -106,6 +106,15 @@ export interface HelpdeskTicketActivity {
   created_at: string;
 }
 
+export interface TicketCalendarRow {
+  id: string;
+  ticket_number: string;
+  title: string;
+  due_at: string | null;
+  status: TicketStatus;
+  priority: TicketPriority;
+}
+
 // Legacy type kept for backward compat with existing action imports
 export interface HelpdeskTicket {
   id: string;
@@ -939,5 +948,46 @@ export class HelpdeskTicketsService {
       success: true,
       data: result.data.rows.map(mapAppCommentToHelpdeskComment),
     };
+  }
+
+  // ── Calendar ────────────────────────────────────────────────────────────
+
+  static async listForCalendar(
+    supabase: SupabaseClient,
+    orgId: string
+  ): Promise<ServiceResult<{ scheduled: TicketCalendarRow[]; unscheduled: TicketCalendarRow[] }>> {
+    const { data, error } = await supabase
+      .from("helpdesk_tickets")
+      .select("id, ticket_number, title, due_at, status, priority")
+      .eq("org_id", orgId)
+      .is("deleted_at", null)
+      .neq("status", "cancelled");
+
+    if (error) return { success: false, error: error.message };
+
+    const rows = (data ?? []) as TicketCalendarRow[];
+    const scheduled = rows.filter((row) => row.due_at !== null);
+    const unscheduled = rows.filter(
+      (row) => row.due_at === null && row.status !== "closed" && row.status !== "resolved"
+    );
+
+    return { success: true, data: { scheduled, unscheduled } };
+  }
+
+  static async updateDueAt(
+    supabase: SupabaseClient,
+    orgId: string,
+    ticketId: string,
+    dueAt: string | null
+  ): Promise<ServiceResult<void>> {
+    const { error } = await supabase
+      .from("helpdesk_tickets")
+      .update({ due_at: dueAt, updated_at: new Date().toISOString() })
+      .eq("id", ticketId)
+      .eq("org_id", orgId)
+      .is("deleted_at", null);
+
+    if (error) return { success: false, error: error.message };
+    return { success: true, data: undefined };
   }
 }

--- a/apps/web/src/server/services/kanban-boards.service.ts
+++ b/apps/web/src/server/services/kanban-boards.service.ts
@@ -27,6 +27,16 @@ import {
 
 export type ServiceResult<T> = { success: true; data: T } | { success: false; error: string };
 
+export interface CardCalendarRow {
+  id: string;
+  board_id: string;
+  title: string;
+  due_at: string | null;
+  label: string | null;
+  label_color: string | null;
+  is_inbox: boolean;
+}
+
 function displayName(
   firstName: string | null,
   lastName: string | null,
@@ -844,6 +854,61 @@ export const KanbanBoardsService = {
         "card_archived"
       );
       return KanbanBoardsService.getBoard(supabase, orgId, boardId);
+    } catch (e) {
+      return { success: false, error: e instanceof Error ? e.message : "Unexpected error" };
+    }
+  },
+
+  // ── Calendar ─────────────────────────────────────────────────────────────
+
+  async listCardsForCalendar(
+    supabase: SupabaseClient,
+    orgId: string
+  ): Promise<ServiceResult<CardCalendarRow[]>> {
+    try {
+      const { data, error } = await supabase
+        .from("planning_kanban_cards")
+        .select("id, board_id, title, due_at, label, label_color, is_inbox")
+        .eq("organization_id", orgId)
+        .is("deleted_at", null);
+
+      if (error) return { success: false, error: error.message };
+      return { success: true, data: (data ?? []) as CardCalendarRow[] };
+    } catch (e) {
+      return { success: false, error: e instanceof Error ? e.message : "Unexpected error" };
+    }
+  },
+
+  async updateCardDueAt(
+    supabase: SupabaseClient,
+    orgId: string,
+    userId: string,
+    cardId: string,
+    boardId: string,
+    dueAt: string | null
+  ): Promise<ServiceResult<void>> {
+    try {
+      const { error } = await supabase
+        .from("planning_kanban_cards")
+        .update({ due_at: dueAt, updated_by: userId })
+        .eq("organization_id", orgId)
+        .eq("board_id", boardId)
+        .eq("id", cardId)
+        .is("deleted_at", null);
+
+      if (error) return { success: false, error: error.message };
+
+      await KanbanBoardsService.recordCardActivity(
+        supabase,
+        orgId,
+        boardId,
+        cardId,
+        userId,
+        "card_updated",
+        { due_at: dueAt }
+      );
+
+      return { success: true, data: undefined };
     } catch (e) {
       return { success: false, error: e instanceof Error ? e.message : "Unexpected error" };
     }

--- a/apps/web/src/server/services/planning-calendar.service.ts
+++ b/apps/web/src/server/services/planning-calendar.service.ts
@@ -1,0 +1,181 @@
+import "server-only";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { checkPermission, type PermissionSnapshot } from "@/lib/utils/permissions";
+import { HELPDESK_TICKETS_READ } from "@/lib/constants/permissions";
+import { MODULE_HELPDESK } from "@/lib/constants/modules";
+import { EntitlementsService } from "./entitlements-service";
+import { PlanningTasksService } from "./planning-tasks.service";
+import { HelpdeskTicketsService } from "./helpdesk-tickets.service";
+import { KanbanBoardsService } from "./kanban-boards.service";
+import { CALENDAR_SOURCE_CATEGORY_CYCLE } from "@/components/primitives/scheduler/scheduler-utils";
+import type { CalendarSource } from "@/components/primitives/scheduler";
+import type {
+  CalendarEventDTO,
+  PlanningCalendarData,
+  UnscheduledItemDTO,
+} from "@/lib/types/planning-calendar";
+import {
+  PLANNING_TASKS_SOURCE_ID,
+  HELPDESK_TICKETS_SOURCE_ID,
+} from "@/lib/constants/planning-calendar";
+
+export type ServiceResult<T> = { success: true; data: T } | { success: false; error: string };
+
+function failureOf(result: { success: false; error: string } | { success: true; data: unknown }) {
+  return { success: false as const, error: (result as { success: false; error: string }).error };
+}
+
+export const PlanningCalendarService = {
+  async getCalendarData(
+    supabase: SupabaseClient,
+    orgId: string,
+    permissionSnapshot: PermissionSnapshot
+  ): Promise<ServiceResult<PlanningCalendarData>> {
+    const sources: CalendarSource[] = [];
+    const events: CalendarEventDTO[] = [];
+    const unscheduled: UnscheduledItemDTO[] = [];
+
+    // ── Planning tasks ──────────────────────────────────────────────────────
+    const tasksCategory = CALENDAR_SOURCE_CATEGORY_CYCLE[0];
+    sources.push({
+      id: PLANNING_TASKS_SOURCE_ID,
+      label: "Tasks",
+      category: tasksCategory,
+      module: "planning",
+    });
+
+    const tasksResult = await PlanningTasksService.listForCalendar(supabase, orgId);
+    if (!tasksResult.success) return failureOf(tasksResult);
+
+    for (const row of tasksResult.data.scheduled) {
+      events.push({
+        id: `planning_task:${row.id}`,
+        title: row.title,
+        dueAt: row.due_at as string,
+        category: tasksCategory,
+        calendarSourceId: PLANNING_TASKS_SOURCE_ID,
+        sourceModule: "planning",
+        sourceType: "planning_task",
+        sourceId: row.id,
+        metadata: { status: row.status, priority: row.priority },
+      });
+    }
+    for (const row of tasksResult.data.unscheduled) {
+      unscheduled.push({
+        id: `planning_task:${row.id}`,
+        title: row.title,
+        category: tasksCategory,
+        calendarSourceId: PLANNING_TASKS_SOURCE_ID,
+        sourceModule: "planning",
+        sourceType: "planning_task",
+        sourceId: row.id,
+        metadata: { status: row.status, priority: row.priority },
+      });
+    }
+
+    // ── Helpdesk tickets (gated by permission + module entitlement) ─────────
+    const canReadTickets = checkPermission(permissionSnapshot, HELPDESK_TICKETS_READ);
+    const hasHelpdeskModule = canReadTickets
+      ? await EntitlementsService.hasModuleAccess(orgId, MODULE_HELPDESK)
+      : false;
+
+    if (canReadTickets && hasHelpdeskModule) {
+      const ticketsCategory = CALENDAR_SOURCE_CATEGORY_CYCLE[1];
+      sources.push({
+        id: HELPDESK_TICKETS_SOURCE_ID,
+        label: "Tickets",
+        category: ticketsCategory,
+        module: "helpdesk",
+      });
+
+      const ticketsResult = await HelpdeskTicketsService.listForCalendar(supabase, orgId);
+      if (!ticketsResult.success) return failureOf(ticketsResult);
+
+      for (const row of ticketsResult.data.scheduled) {
+        events.push({
+          id: `helpdesk_ticket:${row.id}`,
+          title: `#${row.ticket_number} ${row.title}`,
+          dueAt: row.due_at as string,
+          category: ticketsCategory,
+          calendarSourceId: HELPDESK_TICKETS_SOURCE_ID,
+          sourceModule: "helpdesk",
+          sourceType: "helpdesk_ticket",
+          sourceId: row.id,
+          metadata: { status: row.status, priority: row.priority, ticketNumber: row.ticket_number },
+        });
+      }
+      for (const row of ticketsResult.data.unscheduled) {
+        unscheduled.push({
+          id: `helpdesk_ticket:${row.id}`,
+          title: `#${row.ticket_number} ${row.title}`,
+          category: ticketsCategory,
+          calendarSourceId: HELPDESK_TICKETS_SOURCE_ID,
+          sourceModule: "helpdesk",
+          sourceType: "helpdesk_ticket",
+          sourceId: row.id,
+          metadata: { status: row.status, priority: row.priority, ticketNumber: row.ticket_number },
+        });
+      }
+    }
+
+    // ── Kanban boards (one calendar source per visible board) ───────────────
+    const boardsResult = await KanbanBoardsService.listBoards(supabase, orgId);
+    if (!boardsResult.success) return failureOf(boardsResult);
+
+    const cardsResult = await KanbanBoardsService.listCardsForCalendar(supabase, orgId);
+    if (!cardsResult.success) return failureOf(cardsResult);
+
+    const cardsByBoard = new Map<string, typeof cardsResult.data>();
+    for (const card of cardsResult.data) {
+      const list = cardsByBoard.get(card.board_id);
+      if (list) {
+        list.push(card);
+      } else {
+        cardsByBoard.set(card.board_id, [card]);
+      }
+    }
+
+    boardsResult.data.forEach((board, index) => {
+      const category =
+        CALENDAR_SOURCE_CATEGORY_CYCLE[(index + 2) % CALENDAR_SOURCE_CATEGORY_CYCLE.length];
+      const sourceId = `kanban-board:${board.id}`;
+
+      sources.push({
+        id: sourceId,
+        label: board.title,
+        category,
+        module: "kanban",
+        boardId: board.id,
+      });
+
+      for (const card of cardsByBoard.get(board.id) ?? []) {
+        if (card.due_at) {
+          events.push({
+            id: `kanban_card:${card.id}`,
+            title: card.title,
+            dueAt: card.due_at,
+            category,
+            calendarSourceId: sourceId,
+            sourceModule: "kanban",
+            sourceType: "kanban_card",
+            sourceId: card.id,
+            metadata: { boardId: board.id, label: card.label, labelColor: card.label_color },
+          });
+        } else {
+          unscheduled.push({
+            id: `kanban_card:${card.id}`,
+            title: card.title,
+            category,
+            calendarSourceId: sourceId,
+            sourceModule: "kanban",
+            sourceType: "kanban_card",
+            sourceId: card.id,
+            metadata: { boardId: board.id, label: card.label, labelColor: card.label_color },
+          });
+        }
+      }
+    });
+
+    return { success: true, data: { sources, events, unscheduled } };
+  },
+};

--- a/apps/web/src/server/services/planning-tasks.service.ts
+++ b/apps/web/src/server/services/planning-tasks.service.ts
@@ -59,6 +59,15 @@ export interface PlanningTaskDetail extends PlanningTaskListRow {
   activity: PlanningTaskActivity[];
 }
 
+export interface TaskCalendarRow {
+  id: string;
+  title: string;
+  due_at: string | null;
+  status: TaskStatus;
+  priority: TaskPriority;
+  assigned_to: string | null;
+}
+
 export type ServiceResult<T> = { success: true; data: T } | { success: false; error: string };
 type DataViewFilterValue = string | string[] | boolean | null | undefined;
 
@@ -803,6 +812,78 @@ export const PlanningTasksService = {
       if (error) return { success: false, error: error.message };
 
       await insertActivity(supabase, orgId, taskId, userId, "archived", "Task archived");
+      return { success: true, data: undefined };
+    } catch (e) {
+      return { success: false, error: e instanceof Error ? e.message : "Unexpected error" };
+    }
+  },
+
+  // ── Calendar ─────────────────────────────────────────────────────────────
+
+  async listForCalendar(
+    supabase: SupabaseClient,
+    orgId: string
+  ): Promise<ServiceResult<{ scheduled: TaskCalendarRow[]; unscheduled: TaskCalendarRow[] }>> {
+    try {
+      const { data, error } = await supabase
+        .from("planning_tasks")
+        .select("id, title, due_at, status, priority, assigned_to")
+        .eq("organization_id", orgId)
+        .is("deleted_at", null)
+        .neq("status", "cancelled");
+
+      if (error) return { success: false, error: error.message };
+
+      const rows = (data ?? []) as TaskCalendarRow[];
+      const scheduled = rows.filter((row) => row.due_at !== null);
+      const unscheduled = rows.filter((row) => row.due_at === null && row.status !== "completed");
+
+      return { success: true, data: { scheduled, unscheduled } };
+    } catch (e) {
+      return { success: false, error: e instanceof Error ? e.message : "Unexpected error" };
+    }
+  },
+
+  async updateDueAt(
+    supabase: SupabaseClient,
+    orgId: string,
+    userId: string,
+    taskId: string,
+    dueAt: string | null
+  ): Promise<ServiceResult<void>> {
+    try {
+      const { data: previous, error: fetchError } = await supabase
+        .from("planning_tasks")
+        .select("due_at")
+        .eq("id", taskId)
+        .eq("organization_id", orgId)
+        .is("deleted_at", null)
+        .maybeSingle();
+
+      if (fetchError) return { success: false, error: fetchError.message };
+      if (!previous) return { success: false, error: "Task not found" };
+
+      const { error } = await supabase
+        .from("planning_tasks")
+        .update({ due_at: dueAt, updated_by: userId })
+        .eq("id", taskId)
+        .eq("organization_id", orgId)
+        .is("deleted_at", null);
+
+      if (error) return { success: false, error: error.message };
+
+      if ((previous.due_at ?? null) !== (dueAt ?? null)) {
+        await insertActivity(
+          supabase,
+          orgId,
+          taskId,
+          userId,
+          "due_date_changed",
+          "Due date updated",
+          { from: previous.due_at, to: dueAt }
+        );
+      }
+
       return { success: true, data: undefined };
     } catch (e) {
       return { success: false, error: e instanceof Error ? e.message : "Unexpected error" };


### PR DESCRIPTION
Replaces the Tasks/Boards placeholder cards with a full calendar that aggregates planning tasks, helpdesk tickets, and kanban board cards into toggleable calendar sources, with an unscheduled-items inbox and drag-to- schedule support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Unified planning calendar view integrating planning tasks, helpdesk tickets, and kanban board items
  * Drag-and-drop functionality to reschedule items directly on the calendar
  * Create new tasks quickly from calendar date selection
  * Toggle visibility of different calendar sources (tasks, tickets, boards)
  * View event details including status, priority, due dates, and direct links to items

<!-- end of auto-generated comment: release notes by coderabbit.ai -->