### PR TITLE
fix(scheduler): re-theme calendar chrome to match app's primary color

### DIFF
--- a/apps/web/src/components/primitives/scheduler/scheduler-day-view.tsx
+++ b/apps/web/src/components/primitives/scheduler/scheduler-day-view.tsx
@@ -523,7 +523,7 @@ export const SchedulerDayView: React.FC<SchedulerDayViewProps> = ({
             {/* Hover active indicator time text badge inside side ruler */}
             {hoveredMinutes !== null && selectionStartMinutes === null && (
               <div
-                className="absolute right-1.5 bg-indigo-600 text-white font-mono text-[9px] px-1 py-0.5 rounded shadow-sm z-30 pointer-events-none opacity-95 whitespace-nowrap animate-fade-in"
+                className="absolute right-1.5 bg-primary text-primary-foreground font-mono text-[9px] px-1 py-0.5 rounded shadow-sm z-30 pointer-events-none opacity-95 whitespace-nowrap animate-fade-in"
                 style={{
                   top: `${((hoveredMinutes - dayStartHour * 60) / 60) * HOUR_HEIGHT}px`,
                   transform: "translateY(-50%)",
@@ -541,7 +541,7 @@ export const SchedulerDayView: React.FC<SchedulerDayViewProps> = ({
           {/* Global hover dashed line spanning all columns */}
           {hoveredMinutes !== null && selectionStartMinutes === null && (
             <div
-              className="absolute left-14 right-0 border-t border-dashed border-indigo-500/50 pointer-events-none z-30"
+              className="absolute left-14 right-0 border-t border-dashed border-primary/50 pointer-events-none z-30"
               style={{ top: `${((hoveredMinutes - dayStartHour * 60) / 60) * HOUR_HEIGHT}px` }}
             />
           )}
@@ -596,13 +596,13 @@ export const SchedulerDayView: React.FC<SchedulerDayViewProps> = ({
 
               return (
                 <div
-                  className="absolute left-0 right-0 bg-indigo-500/20 border-y-2 border-indigo-500/50 pointer-events-none z-30 animate-pulse"
+                  className="absolute left-0 right-0 bg-primary/20 border-y-2 border-primary/50 pointer-events-none z-30 animate-pulse"
                   style={style}
                 >
-                  <span className="absolute top-0.5 left-2 bg-indigo-600 text-white font-mono text-[9px] px-1 py-0.2 rounded shadow-xs select-none opacity-95 whitespace-nowrap">
+                  <span className="absolute top-0.5 left-2 bg-primary text-primary-foreground font-mono text-[9px] px-1 py-0.2 rounded shadow-xs select-none opacity-95 whitespace-nowrap">
                     Start: {format(startD, timeFormat === "24h" ? "HH:mm" : "h:mm a")}
                   </span>
-                  <span className="absolute bottom-0.5 right-2 bg-indigo-600 text-white font-mono text-[9px] px-1 py-0.2 rounded shadow-xs select-none opacity-95 whitespace-nowrap">
+                  <span className="absolute bottom-0.5 right-2 bg-primary text-primary-foreground font-mono text-[9px] px-1 py-0.2 rounded shadow-xs select-none opacity-95 whitespace-nowrap">
                     End: {format(endD, timeFormat === "24h" ? "HH:mm" : "h:mm a")}
                   </span>
                 </div>
@@ -632,11 +632,11 @@ export const SchedulerDayView: React.FC<SchedulerDayViewProps> = ({
                 return (
                   <div
                     key={hr}
-                    className="w-full border-b border-gray-100/30 dark:border-neutral-800/5 hover:bg-indigo-500/[0.04] dark:hover:bg-indigo-400/[0.04] cursor-pointer pointer-events-auto transition duration-75 flex items-start pl-2 text-[9px] font-mono font-medium text-slate-350 dark:text-neutral-650 tracking-wider group"
+                    className="w-full border-b border-gray-100/30 dark:border-neutral-800/5 hover:bg-primary/[0.04] cursor-pointer pointer-events-auto transition duration-75 flex items-start pl-2 text-[9px] font-mono font-medium text-slate-350 dark:text-neutral-650 tracking-wider group"
                     style={{ height: `${HOUR_HEIGHT}px` }}
                     id={`day-hour-slot-${hr}`}
                   >
-                    <span className="opacity-0 group-hover:opacity-100 mt-1.5 text-indigo-600 dark:text-indigo-400 font-semibold transition-opacity duration-100 font-mono">
+                    <span className="opacity-0 group-hover:opacity-100 mt-1.5 text-primary font-semibold transition-opacity duration-100 font-mono">
                       {LABELS_MAP[locale]?.hoverScheduleAt || "+ Click to schedule at"}{" "}
                       {isThisHourHovered
                         ? formatPreciseMins(hoveredMinutes)
@@ -667,8 +667,7 @@ export const SchedulerDayView: React.FC<SchedulerDayViewProps> = ({
                     "bg-rose-500/5 hover:bg-rose-500/10 border-rose-500/15 text-rose-600 dark:text-rose-450",
                   unavailable:
                     "bg-neutral-500/5 hover:bg-neutral-500/10 border-neutral-500/15 text-neutral-400",
-                  focus:
-                    "bg-indigo-500/5 hover:bg-indigo-500/10 border-indigo-500/15 text-indigo-600 dark:text-indigo-400",
+                  focus: "bg-primary/5 hover:bg-primary/10 border-primary/15 text-primary",
                 };
 
                 const bgStartStr = formatInTimezone(
@@ -842,10 +841,10 @@ export const SchedulerDayView: React.FC<SchedulerDayViewProps> = ({
                         setIsResizeHandleActive(false);
                         handleResizePointerUp(e, event.id);
                       }}
-                      className="absolute bottom-0 left-0 right-0 h-3 bg-transparent group-hover/card:bg-indigo-500/5 active:bg-indigo-555/20 cursor-ns-resize transition duration-150 flex items-center justify-center pointer-events-auto"
+                      className="absolute bottom-0 left-0 right-0 h-3 bg-transparent group-hover/card:bg-primary/5 active:bg-primary/20 cursor-ns-resize transition duration-150 flex items-center justify-center pointer-events-auto"
                       title="Drag to resize duration"
                     >
-                      <span className="w-6 h-[3px] bg-indigo-500/40 rounded-full" />
+                      <span className="w-6 h-[3px] bg-primary/40 rounded-full" />
                     </div>
                   )}
                 </div>

--- a/apps/web/src/components/primitives/scheduler/scheduler-event-dialog.tsx
+++ b/apps/web/src/components/primitives/scheduler/scheduler-event-dialog.tsx
@@ -198,7 +198,7 @@ export const SchedulerEventDialog: React.FC<SchedulerEventDialogProps> = ({
         {/* Header toolbar */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100 dark:border-neutral-800">
           <div className="flex items-center gap-2">
-            <Calendar className="text-indigo-600 dark:text-indigo-400" size={18} />
+            <Calendar className="text-primary" size={18} />
             <span className="font-sans font-bold text-gray-900 dark:text-white">
               {event?.id ? `Edit: ${event.title}` : label.createEvent}
             </span>
@@ -233,7 +233,7 @@ export const SchedulerEventDialog: React.FC<SchedulerEventDialogProps> = ({
               value={title}
               onChange={(e) => setTitle(e.target.value)}
               placeholder={label.titlePlaceholder}
-              className="w-full text-sm bg-gray-50 dark:bg-neutral-800 text-gray-900 dark:text-white border border-gray-200 dark:border-neutral-700 rounded-xl p-3 focus:ring-1 focus:ring-indigo-500 outline-none placeholder-gray-400 dark:placeholder-neutral-500 font-semibold"
+              className="w-full text-sm bg-gray-50 dark:bg-neutral-800 text-gray-900 dark:text-white border border-gray-200 dark:border-neutral-700 rounded-xl p-3 focus:ring-1 focus:ring-primary outline-none placeholder-gray-400 dark:placeholder-neutral-500 font-semibold"
               id="input-event-title"
             />
           </div>
@@ -250,7 +250,7 @@ export const SchedulerEventDialog: React.FC<SchedulerEventDialogProps> = ({
                 required
                 value={startDateStr}
                 onChange={(e) => setStartDateStr(e.target.value)}
-                className="w-full text-xs bg-gray-50 dark:bg-neutral-800 text-gray-900 dark:text-white border border-gray-200 dark:border-neutral-700 rounded-xl p-3 focus:ring-1 focus:ring-indigo-500 outline-none font-mono"
+                className="w-full text-xs bg-gray-50 dark:bg-neutral-800 text-gray-900 dark:text-white border border-gray-200 dark:border-neutral-700 rounded-xl p-3 focus:ring-1 focus:ring-primary outline-none font-mono"
                 id="input-event-start"
               />
             </div>
@@ -267,7 +267,7 @@ export const SchedulerEventDialog: React.FC<SchedulerEventDialogProps> = ({
                 disabled={allDay}
                 value={endDateStr}
                 onChange={(e) => setEndDateStr(e.target.value)}
-                className={`w-full text-xs border rounded-xl p-3 focus:ring-1 focus:ring-indigo-500 outline-none font-mono ${
+                className={`w-full text-xs border rounded-xl p-3 focus:ring-1 focus:ring-primary outline-none font-mono ${
                   allDay
                     ? "bg-gray-100 dark:bg-neutral-850/40 text-gray-400 dark:text-neutral-600 border-gray-200 dark:border-neutral-800 cursor-not-allowed"
                     : "bg-gray-50 dark:bg-neutral-800 text-gray-900 dark:text-white border-gray-200 dark:border-neutral-700"
@@ -291,7 +291,7 @@ export const SchedulerEventDialog: React.FC<SchedulerEventDialogProps> = ({
               type="checkbox"
               checked={allDay}
               onChange={(e) => setAllDay(e.target.checked)}
-              className="accent-indigo-600 w-4 h-4 cursor-pointer"
+              className="accent-primary w-4 h-4 cursor-pointer"
               id="chk-event-allday"
             />
           </div>
@@ -311,7 +311,7 @@ export const SchedulerEventDialog: React.FC<SchedulerEventDialogProps> = ({
                 type="checkbox"
                 checked={isBackground}
                 onChange={(e) => setIsBackground(e.target.checked)}
-                className="accent-indigo-600 w-4 h-4 cursor-pointer"
+                className="accent-primary w-4 h-4 cursor-pointer"
                 id="chk-event-background"
               />
             </div>
@@ -324,7 +324,7 @@ export const SchedulerEventDialog: React.FC<SchedulerEventDialogProps> = ({
                 <select
                   value={bgType}
                   onChange={(e) => setBgType(e.target.value as any)}
-                  className="w-full text-xs bg-white dark:bg-neutral-800 text-gray-900 dark:text-white border border-gray-200 dark:border-neutral-700 rounded-lg p-2 outline-none focus:ring-1 focus:ring-indigo-500 font-semibold cursor-pointer"
+                  className="w-full text-xs bg-white dark:bg-neutral-800 text-gray-900 dark:text-white border border-gray-200 dark:border-neutral-700 rounded-lg p-2 outline-none focus:ring-1 focus:ring-primary font-semibold cursor-pointer"
                   id="select-bg-type"
                 >
                   <option value="break">🥪 Lunch Break / Rest Hour {"(break)"}</option>
@@ -354,7 +354,7 @@ export const SchedulerEventDialog: React.FC<SchedulerEventDialogProps> = ({
                     // Auto color match on category selection
                     if (!color) setColor(e.target.value);
                   }}
-                  className="w-full text-xs bg-gray-50 dark:bg-neutral-800 text-gray-900 dark:text-white border border-gray-200 dark:border-neutral-700 rounded-xl p-2.5 outline-none focus:ring-1 focus:ring-indigo-500"
+                  className="w-full text-xs bg-gray-50 dark:bg-neutral-800 text-gray-900 dark:text-white border border-gray-200 dark:border-neutral-700 rounded-xl p-2.5 outline-none focus:ring-1 focus:ring-primary"
                   id="select-event-category"
                 >
                   <option value="meeting">{label.catMeeting || "Meeting"}</option>
@@ -374,7 +374,7 @@ export const SchedulerEventDialog: React.FC<SchedulerEventDialogProps> = ({
                 <select
                   value={priority}
                   onChange={(e) => setPriority(e.target.value as "low" | "medium" | "high")}
-                  className="w-full text-xs bg-gray-50 dark:bg-neutral-800 text-gray-900 dark:text-white border border-gray-200 dark:border-neutral-700 rounded-xl p-2.5 outline-none focus:ring-1 focus:ring-indigo-500"
+                  className="w-full text-xs bg-gray-50 dark:bg-neutral-800 text-gray-900 dark:text-white border border-gray-200 dark:border-neutral-700 rounded-xl p-2.5 outline-none focus:ring-1 focus:ring-primary"
                   id="select-event-priority"
                 >
                   <option value="low">{label.priorityLow || "Low"}</option>
@@ -391,7 +391,7 @@ export const SchedulerEventDialog: React.FC<SchedulerEventDialogProps> = ({
                 <select
                   value={status}
                   onChange={(e) => setStatus(e.target.value as any)}
-                  className="w-full text-xs bg-gray-50 dark:bg-neutral-800 text-gray-900 dark:text-white border border-gray-200 dark:border-neutral-700 rounded-xl p-2.5 outline-none focus:ring-1 focus:ring-indigo-500"
+                  className="w-full text-xs bg-gray-50 dark:bg-neutral-800 text-gray-900 dark:text-white border border-gray-200 dark:border-neutral-700 rounded-xl p-2.5 outline-none focus:ring-1 focus:ring-primary"
                   id="select-event-status"
                 >
                   <option value="confirmed">{label.statusConfirmed || "Confirmed"}</option>
@@ -410,7 +410,7 @@ export const SchedulerEventDialog: React.FC<SchedulerEventDialogProps> = ({
             <select
               value={resourceId}
               onChange={(e) => setResourceId(e.target.value)}
-              className="w-full text-xs bg-gray-50 dark:bg-neutral-800 text-gray-900 dark:text-white border border-gray-200 dark:border-neutral-700 rounded-xl p-3 outline-none focus:ring-1 focus:ring-indigo-500 font-semibold"
+              className="w-full text-xs bg-gray-50 dark:bg-neutral-800 text-gray-900 dark:text-white border border-gray-200 dark:border-neutral-700 rounded-xl p-3 outline-none focus:ring-1 focus:ring-primary font-semibold"
               id="select-event-resource"
             >
               <option value="">-- No Assigned Resource (Unassigned Event) --</option>
@@ -445,7 +445,7 @@ export const SchedulerEventDialog: React.FC<SchedulerEventDialogProps> = ({
                       onClick={() => setColor(p.value)}
                       className={`w-5 h-5 rounded-full flex items-center justify-center transition border ${p.class} ${
                         color === p.value
-                          ? "ring-2 ring-indigo-500 ring-offset-2 scale-110 border-white"
+                          ? "ring-2 ring-primary ring-offset-2 scale-110 border-white"
                           : "border-transparent opacity-80 hover:opacity-100 hover:scale-105"
                       }`}
                       title={p.name}
@@ -470,7 +470,7 @@ export const SchedulerEventDialog: React.FC<SchedulerEventDialogProps> = ({
                     value={location}
                     onChange={(e) => setLocation(e.target.value)}
                     placeholder={label.locationPlaceholder || "Google Meet, Conference Room A..."}
-                    className="w-full text-xs bg-gray-50 dark:bg-neutral-800 text-gray-900 dark:text-white border border-gray-200 dark:border-neutral-700 rounded-xl p-3 pl-9 focus:ring-1 focus:ring-indigo-500 outline-none placeholder-gray-400"
+                    className="w-full text-xs bg-gray-50 dark:bg-neutral-800 text-gray-900 dark:text-white border border-gray-200 dark:border-neutral-700 rounded-xl p-3 pl-9 focus:ring-1 focus:ring-primary outline-none placeholder-gray-400"
                     id="input-event-location"
                   />
                 </div>
@@ -488,7 +488,7 @@ export const SchedulerEventDialog: React.FC<SchedulerEventDialogProps> = ({
                     label.descriptionPlaceholder || "Provide a core outline, links, checklist..."
                   }
                   rows={3}
-                  className="w-full text-xs bg-gray-50 dark:bg-neutral-800 text-gray-900 dark:text-white border border-gray-200 dark:border-neutral-700 rounded-xl p-3 focus:ring-1 focus:ring-indigo-500 outline-none placeholder-gray-400 dark:placeholder-neutral-500 text-left resize-none font-sans"
+                  className="w-full text-xs bg-gray-50 dark:bg-neutral-800 text-gray-900 dark:text-white border border-gray-200 dark:border-neutral-700 rounded-xl p-3 focus:ring-1 focus:ring-primary outline-none placeholder-gray-400 dark:placeholder-neutral-500 text-left resize-none font-sans"
                   id="input-event-description"
                 />
               </div>
@@ -504,7 +504,7 @@ export const SchedulerEventDialog: React.FC<SchedulerEventDialogProps> = ({
                   value={attendeesStr}
                   onChange={(e) => setAttendeesStr(e.target.value)}
                   placeholder={label.attendeesPlaceholder || "Ariadne V., Juliet S., Caleb P."}
-                  className="w-full text-xs bg-gray-50 dark:bg-neutral-800 text-gray-900 dark:text-white border border-gray-200 dark:border-neutral-750 rounded-xl p-3 focus:ring-1 focus:ring-indigo-500 outline-none placeholder-gray-400"
+                  className="w-full text-xs bg-gray-50 dark:bg-neutral-800 text-gray-900 dark:text-white border border-gray-200 dark:border-neutral-750 rounded-xl p-3 focus:ring-1 focus:ring-primary outline-none placeholder-gray-400"
                   id="input-event-attendees"
                 />
               </div>
@@ -516,7 +516,7 @@ export const SchedulerEventDialog: React.FC<SchedulerEventDialogProps> = ({
                     type="checkbox"
                     checked={isDraggable}
                     onChange={(e) => setIsDraggable(e.target.checked)}
-                    className="accent-indigo-600 cursor-pointer"
+                    className="accent-primary cursor-pointer"
                     id="chk-event-draggable"
                   />
                   <span className="text-gray-600 dark:text-neutral-300 font-semibold">
@@ -532,7 +532,7 @@ export const SchedulerEventDialog: React.FC<SchedulerEventDialogProps> = ({
                     disabled={allDay}
                     checked={allDay ? false : isResizable}
                     onChange={(e) => setIsResizable(e.target.checked)}
-                    className="accent-indigo-600 cursor-pointer"
+                    className="accent-primary cursor-pointer"
                     id="chk-event-resizable"
                   />
                   <span className="text-gray-600 dark:text-neutral-300 font-semibold">
@@ -554,7 +554,7 @@ export const SchedulerEventDialog: React.FC<SchedulerEventDialogProps> = ({
             </button>
             <button
               type="submit"
-              className="px-5 py-2.5 text-xs font-bold text-white bg-indigo-600 hover:bg-indigo-500 active:scale-95 rounded-xl transition cursor-pointer shadow-sm shadow-indigo-600/10"
+              className="px-5 py-2.5 text-xs font-bold text-primary-foreground bg-primary hover:bg-primary/90 active:scale-95 rounded-xl transition cursor-pointer shadow-sm shadow-primary/10"
               id="btn-event-dialog-save"
             >
               {label.save}

--- a/apps/web/src/components/primitives/scheduler/scheduler-event-popover.tsx
+++ b/apps/web/src/components/primitives/scheduler/scheduler-event-popover.tsx
@@ -135,7 +135,7 @@ export const SchedulerEventPopover: React.FC<SchedulerEventPopoverProps> = ({
             </h3>
 
             {/* Start and end time display */}
-            <div className="flex items-center gap-2 text-xs font-medium text-indigo-600 dark:text-indigo-400 font-mono mt-1.5 bg-indigo-50/50 dark:bg-indigo-950/20 py-1 px-2.5 rounded-md w-fit">
+            <div className="flex items-center gap-2 text-xs font-medium text-primary font-mono mt-1.5 bg-primary/10 py-1 px-2.5 rounded-md w-fit">
               <Calendar size={13} />
               <span>{formatInTimezone(event.start, "EEEE, d MMM yyyy", timezone, locale)}</span>
               <span className="text-gray-300 dark:text-neutral-700">|</span>
@@ -184,7 +184,7 @@ export const SchedulerEventPopover: React.FC<SchedulerEventPopoverProps> = ({
                     key={index}
                     className="inline-flex items-center gap-1 px-2.5 py-1 text-xs text-gray-600 dark:text-neutral-300 bg-gray-50 dark:bg-neutral-800 border border-gray-150 dark:border-neutral-700 rounded-lg font-medium"
                   >
-                    <span className="w-1.5 h-1.5 bg-indigo-400 rounded-full" />
+                    <span className="w-1.5 h-1.5 bg-primary rounded-full" />
                     {attendee}
                   </span>
                 ))}
@@ -221,7 +221,7 @@ export const SchedulerEventPopover: React.FC<SchedulerEventPopoverProps> = ({
             </button>
             <button
               onClick={onEdit}
-              className="flex items-center gap-1.5 px-4 py-2 text-xs font-bold text-white bg-indigo-600 hover:bg-indigo-500 active:scale-95 shadow-sm rounded-lg transition"
+              className="flex items-center gap-1.5 px-4 py-2 text-xs font-bold text-primary-foreground bg-primary hover:bg-primary/90 active:scale-95 shadow-sm rounded-lg transition"
               id={`btn-popover-edit-${event.id}`}
             >
               <Edit3 size={14} />

--- a/apps/web/src/components/primitives/scheduler/scheduler-list-view.tsx
+++ b/apps/web/src/components/primitives/scheduler/scheduler-list-view.tsx
@@ -116,8 +116,8 @@ export const SchedulerListView: React.FC<SchedulerListViewProps> = ({
             return (
               <div key={dateStr} className="space-y-3" id={`agenda-date-group-${dateStr}`}>
                 {/* Date header label bubble banner */}
-                <h4 className="font-sans font-bold text-xs text-indigo-600 dark:text-indigo-400 flex items-center gap-2 pl-1 select-none">
-                  <span className="w-1.5 h-1.5 bg-indigo-500 rounded-full" />
+                <h4 className="font-sans font-bold text-xs text-primary flex items-center gap-2 pl-1 select-none">
+                  <span className="w-1.5 h-1.5 bg-primary rounded-full" />
                   <span>{formatInTimezone(dateObj, "EEEE, MMMM d, yyyy", timezone, locale)}</span>
                 </h4>
 
@@ -131,7 +131,7 @@ export const SchedulerListView: React.FC<SchedulerListViewProps> = ({
                       <div
                         key={event.id}
                         onClick={() => onSelectEvent(event)}
-                        className="group relative p-4 border border-slate-200/60 dark:border-neutral-800 bg-white dark:bg-neutral-800/30 rounded-xl hover:border-indigo-400 dark:hover:border-neutral-700 hover:shadow-xs cursor-pointer transition flex flex-col md:flex-row md:items-center justify-between gap-4 select-none"
+                        className="group relative p-4 border border-slate-200/60 dark:border-neutral-800 bg-white dark:bg-neutral-800/30 rounded-xl hover:border-primary/40 hover:shadow-xs cursor-pointer transition flex flex-col md:flex-row md:items-center justify-between gap-4 select-none"
                         id={`agenda-event-row-${event.id}`}
                       >
                         {/* Event details summary info */}
@@ -154,7 +154,7 @@ export const SchedulerListView: React.FC<SchedulerListViewProps> = ({
                           />
 
                           <div className="space-y-1">
-                            <h5 className="font-sans font-bold text-sm text-slate-800 dark:text-white leading-tight group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors">
+                            <h5 className="font-sans font-bold text-sm text-slate-800 dark:text-white leading-tight group-hover:text-primary transition-colors">
                               {event.title}
                             </h5>
 

--- a/apps/web/src/components/primitives/scheduler/scheduler-month-view.tsx
+++ b/apps/web/src/components/primitives/scheduler/scheduler-month-view.tsx
@@ -292,8 +292,8 @@ export const SchedulerMonthView: React.FC<SchedulerMonthViewProps> = ({
               }}
               className={`relative border-r border-b border-gray-100 dark:border-neutral-800/60 p-1.5 flex flex-col min-h-16 h-full transition duration-150 group select-none cursor-pointer ${
                 isSelected
-                  ? "bg-indigo-50/70 dark:bg-indigo-950/30 shadow-[inset_0_0_0_1.5px_rgba(99,102,241,0.4)] dark:shadow-[inset_0_0_0_1.5px_rgba(129,140,248,0.4)] z-30"
-                  : "hover:bg-indigo-500/[0.04] dark:hover:bg-indigo-400/[0.04] hover:shadow-[inset_0_0_0_1px_rgba(79,70,229,0.15)] dark:hover:shadow-[inset_0_0_0_1px_rgba(129,140,248,0.15)] hover:z-40"
+                  ? "bg-primary/10 ring-2 ring-inset ring-primary/40 z-30"
+                  : "hover:bg-primary/[0.04] hover:ring-1 hover:ring-inset hover:ring-primary/15 hover:z-40"
               } ${
                 isCurrentMonth
                   ? "bg-transparent"
@@ -305,7 +305,7 @@ export const SchedulerMonthView: React.FC<SchedulerMonthViewProps> = ({
             >
               {/* Day Badge Number */}
               <div className="flex items-center justify-between mb-1">
-                <span className="opacity-0 group-hover:opacity-100 text-[10px] font-bold text-indigo-600 dark:text-indigo-400 font-semibold tracking-wider transition-opacity duration-100 pointer-events-none pl-1">
+                <span className="opacity-0 group-hover:opacity-100 text-[10px] font-bold text-primary font-semibold tracking-wider transition-opacity duration-100 pointer-events-none pl-1">
                   {LABELS_MAP[locale]?.hoverAddAt || "+ Add"}
                 </span>
                 <span
@@ -319,7 +319,7 @@ export const SchedulerMonthView: React.FC<SchedulerMonthViewProps> = ({
                   }}
                   className={`text-xs ml-auto font-bold flex items-center justify-center rounded-full w-6 h-6 transition-colors ${
                     isTodayDate
-                      ? "bg-indigo-600 text-white shadow-sm"
+                      ? "bg-primary text-primary-foreground shadow-sm"
                       : isCurrentMonth
                         ? "text-gray-800 dark:text-neutral-200 group-hover:bg-gray-100 dark:group-hover:bg-neutral-800"
                         : "text-gray-300 dark:text-neutral-700"
@@ -455,7 +455,7 @@ export const SchedulerMonthView: React.FC<SchedulerMonthViewProps> = ({
                             })}
                           </div>
                           <button
-                            className="bg-indigo-600 hover:bg-indigo-700 text-white text-[10px] py-1.5 px-3 rounded-lg font-bold w-full transition-colors cursor-pointer mt-1"
+                            className="bg-primary hover:bg-primary/90 text-primary-foreground text-[10px] py-1.5 px-3 rounded-lg font-bold w-full transition-colors cursor-pointer mt-1"
                             onClick={(e) => {
                               e.stopPropagation();
                               setOpenTooltipDay(null);

--- a/apps/web/src/components/primitives/scheduler/scheduler-sidebar.tsx
+++ b/apps/web/src/components/primitives/scheduler/scheduler-sidebar.tsx
@@ -299,7 +299,7 @@ export const SchedulerSidebar: React.FC<SchedulerSidebarProps> = ({
                 onClick={() => onNavigateDate && onNavigateDate(md.date)}
                 className={`h-6 w-6 flex items-center justify-center mx-auto rounded-full cursor-pointer transition duration-150 ${textClass} ${
                   isTodayDay
-                    ? "bg-indigo-600 text-white font-bold hover:bg-indigo-700 shadow-sm"
+                    ? "bg-primary text-primary-foreground font-bold hover:bg-primary/90 shadow-sm"
                     : ""
                 }`}
               >
@@ -398,7 +398,7 @@ export const SchedulerSidebar: React.FC<SchedulerSidebarProps> = ({
             <h3 className="text-[10px] font-extrabold text-slate-400 dark:text-neutral-500 uppercase tracking-widest font-mono text-left">
               {calendarSources ? label.noDueDateTitle || "No due date" : label.taskPool}
             </h3>
-            <span className="bg-indigo-50 dark:bg-indigo-950/50 text-indigo-600 dark:text-indigo-400 font-extrabold px-2 py-0.5 rounded-full text-[10px]">
+            <span className="bg-primary/10 text-primary font-extrabold px-2 py-0.5 rounded-full text-[10px]">
               {unscheduledTasks.length}
             </span>
           </div>
@@ -415,10 +415,10 @@ export const SchedulerSidebar: React.FC<SchedulerSidebarProps> = ({
                   draggable
                   onDragStart={(e) => handleDragStart(e, task.id)}
                   onDragEnd={() => onDragTaskEnd?.()}
-                  className="p-3 bg-white dark:bg-neutral-800 border border-slate-200 dark:border-neutral-800 rounded-lg shadow-xs hover:border-indigo-300 dark:hover:border-neutral-700 hover:shadow-xs transition duration-200 cursor-pointer active:cursor-grabbing group"
+                  className="p-3 bg-white dark:bg-neutral-800 border border-slate-200 dark:border-neutral-800 rounded-lg shadow-xs hover:border-primary/40 dark:hover:border-neutral-700 hover:shadow-xs transition duration-200 cursor-pointer active:cursor-grabbing group"
                 >
                   <div className="flex justify-between items-start mb-1 gap-2">
-                    <span className="text-[11px] font-bold text-slate-800 dark:text-white line-clamp-1 group-hover:text-indigo-600 transition-colors">
+                    <span className="text-[11px] font-bold text-slate-800 dark:text-white line-clamp-1 group-hover:text-primary transition-colors">
                       {task.title}
                     </span>
                     <span className="text-[9px] bg-slate-50 dark:bg-neutral-800 text-slate-500 dark:text-neutral-400 px-1.5 py-0.5 rounded border border-slate-100 dark:border-neutral-700/60 font-mono font-semibold shrink-0">
@@ -472,7 +472,7 @@ export const SchedulerSidebar: React.FC<SchedulerSidebarProps> = ({
               type="checkbox"
               checked={settings.showWeekends}
               onChange={(e) => onUpdateSettings({ showWeekends: e.target.checked })}
-              className="accent-indigo-600 w-3.5 h-3.5 cursor-pointer"
+              className="accent-primary w-3.5 h-3.5 cursor-pointer"
             />
           </label>
           <label className="flex items-center justify-between cursor-pointer text-slate-600 dark:text-neutral-300">
@@ -481,7 +481,7 @@ export const SchedulerSidebar: React.FC<SchedulerSidebarProps> = ({
               type="checkbox"
               checked={settings.showBackgroundEvents}
               onChange={(e) => onUpdateSettings({ showBackgroundEvents: e.target.checked })}
-              className="accent-indigo-600 w-3.5 h-3.5 cursor-pointer"
+              className="accent-primary w-3.5 h-3.5 cursor-pointer"
             />
           </label>
         </div>

--- a/apps/web/src/components/primitives/scheduler/scheduler-timeline-view.tsx
+++ b/apps/web/src/components/primitives/scheduler/scheduler-timeline-view.tsx
@@ -115,25 +115,24 @@ const CATEGORY_STYLES: Record<
 };
 
 // Unified style getters for perfect symmetry across Grid and Timeline views
-const getResourceBgStyle = (isActive: boolean) =>
-  isActive ? "bg-indigo-50/50 dark:bg-indigo-950/25" : "";
+const getResourceBgStyle = (isActive: boolean) => (isActive ? "bg-primary/10" : "");
 
 const getResourceHeaderStyle = (isActive: boolean, borderPos: "r" | "b") => {
   if (!isActive) return "bg-white dark:bg-neutral-900";
   const borderClass =
     borderPos === "r"
-      ? "border-r-[1.5px] border-r-indigo-500/70"
-      : "border-b-[1.5px] border-b-indigo-500/70";
-  return `bg-indigo-50/90 dark:bg-indigo-950/45 font-semibold text-indigo-950 dark:text-indigo-150 ${borderClass} shadow-inner`;
+      ? "border-r-[1.5px] border-r-primary/70"
+      : "border-b-[1.5px] border-b-primary/70";
+  return `bg-primary/10 font-semibold text-foreground ${borderClass} shadow-inner`;
 };
 
 const getEventCardHighlightStyle = (isEventHovered: boolean, isResourceHovered: boolean) => {
   if (isEventHovered) {
-    return "ring-[1.5px] ring-indigo-500/75 dark:ring-indigo-400/85 scale-[1.012] z-35 shadow-md brightness-105";
+    return "ring-[1.5px] ring-primary/75 scale-[1.012] z-35 shadow-md brightness-105";
   }
   if (isResourceHovered) {
     // Symmetrical subtle highlight for sibling cards when resource is hovered
-    return "ring-[1.2px] ring-indigo-500/40 dark:ring-indigo-400/50 scale-[1.006] z-30 shadow-xs brightness-[100.5%]";
+    return "ring-[1.2px] ring-primary/40 scale-[1.006] z-30 shadow-xs brightness-[100.5%]";
   }
   return "";
 };
@@ -951,7 +950,7 @@ export const SchedulerTimelineView: React.FC<SchedulerTimelineViewProps> = ({
       {/* Search and Filters Header */}
       <div className="flex flex-col sm:flex-row items-center justify-between gap-4 p-4 border-b border-slate-100 dark:border-neutral-800 bg-white dark:bg-neutral-900 shadow-3xs shrink-0">
         <div className="flex items-center gap-2.5 w-full sm:w-auto">
-          <Boxes className="text-indigo-600 dark:text-indigo-400" size={18} />
+          <Boxes className="text-primary" size={18} />
           <h3 className="font-bold text-sm text-slate-800 dark:text-white leading-none">
             {label.resourcePlanner || "Resource Planner"}
           </h3>
@@ -1002,7 +1001,7 @@ export const SchedulerTimelineView: React.FC<SchedulerTimelineViewProps> = ({
               placeholder={label.searchResources || "Search resources..."}
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="w-full pl-8 pr-3 py-1.5 text-xs bg-slate-50 dark:bg-neutral-800/60 border border-slate-200 dark:border-neutral-700 rounded-lg placeholder-slate-400 dark:placeholder-neutral-500 text-slate-800 dark:text-white focus:outline-hidden focus:ring-1 focus:ring-indigo-500 transition-all font-medium"
+              className="w-full pl-8 pr-3 py-1.5 text-xs bg-slate-50 dark:bg-neutral-800/60 border border-slate-200 dark:border-neutral-700 rounded-lg placeholder-slate-400 dark:placeholder-neutral-500 text-slate-800 dark:text-white focus:outline-hidden focus:ring-1 focus:ring-primary transition-all font-medium"
             />
           </div>
         </div>
@@ -1039,14 +1038,14 @@ export const SchedulerTimelineView: React.FC<SchedulerTimelineViewProps> = ({
                     });
                     setGridSelectedIds(allLeafIds);
                   }}
-                  className="text-[10px] font-bold text-indigo-600 dark:text-indigo-400 hover:underline cursor-pointer"
+                  className="text-[10px] font-bold text-primary hover:underline cursor-pointer"
                 >
                   All
                 </button>
                 <span className="text-[10px] text-slate-300 dark:text-neutral-700">|</span>
                 <button
                   onClick={() => setGridSelectedIds(new Set())}
-                  className="text-[10px] font-bold text-indigo-600 dark:text-indigo-400 hover:underline cursor-pointer"
+                  className="text-[10px] font-bold text-primary hover:underline cursor-pointer"
                 >
                   Clear
                 </button>
@@ -1086,7 +1085,7 @@ export const SchedulerTimelineView: React.FC<SchedulerTimelineViewProps> = ({
                         onMouseLeave={() => setHoveredResourceId(null)}
                         className={`flex items-center group py-1 rounded-lg transition-all cursor-pointer ${
                           hoveredResourceId === rId
-                            ? "bg-indigo-50/70 dark:bg-indigo-950/35 border-l-[1.5px] border-l-indigo-500/70 font-semibold text-indigo-950 dark:text-indigo-150 shadow-3xs"
+                            ? "bg-primary/10 border-l-[1.5px] border-l-primary/70 font-semibold text-foreground shadow-3xs"
                             : "hover:bg-slate-100/60 dark:hover:bg-neutral-800/40"
                         }`}
                         style={{ paddingLeft: `${node.depth * 14 + 6}px` }}
@@ -1124,7 +1123,7 @@ export const SchedulerTimelineView: React.FC<SchedulerTimelineViewProps> = ({
                               }
                             }}
                             onChange={() => handleToggleGridCheck(rId, node.hasChildren)}
-                            className="h-3.5 w-3.5 rounded border-slate-300 dark:border-neutral-700 text-indigo-600 dark:text-indigo-500 focus:ring-indigo-500 cursor-pointer accent-indigo-600 transition"
+                            className="h-3.5 w-3.5 rounded border-slate-300 dark:border-neutral-700 text-primary focus:ring-primary cursor-pointer accent-primary transition"
                           />
                         </div>
 
@@ -1159,7 +1158,7 @@ export const SchedulerTimelineView: React.FC<SchedulerTimelineViewProps> = ({
                         >
                           {resourceEvents.map((event) => {
                             const isSelectedEvent = hoveredEventId === event.id;
-                            const resColor = node.resource.color || "#6366f1";
+                            const resColor = node.resource.color || "#f0a205";
                             return (
                               <div
                                 key={event.id}
@@ -1211,10 +1210,10 @@ export const SchedulerTimelineView: React.FC<SchedulerTimelineViewProps> = ({
             title={gridSidebarOpen ? "Collapse Resources" : "Expand Resources"}
           >
             {/* Minimal vertical line hover highlight */}
-            <div className="absolute inset-y-0 left-0 w-[1.5px] bg-indigo-500/0 group-hover/strip:bg-indigo-500/20 transition-all rounded-r" />
+            <div className="absolute inset-y-0 left-0 w-[1.5px] bg-primary/0 group-hover/strip:bg-primary/20 transition-all rounded-r" />
 
             {/* Subtle center capsule toggle element - perfectly centered, inside strip with comfortable clearance */}
-            <div className="w-4 h-9 flex items-center justify-center bg-white dark:bg-neutral-800 border border-slate-200 dark:border-neutral-700/80 rounded-md shadow-3xs text-slate-400 group-hover/strip:text-indigo-600 dark:group-hover/strip:text-indigo-400 transition-all font-bold pointer-events-none shrink-0 z-35 relative">
+            <div className="w-4 h-9 flex items-center justify-center bg-white dark:bg-neutral-800 border border-slate-200 dark:border-neutral-700/80 rounded-md shadow-3xs text-slate-400 group-hover/strip:text-primary transition-all font-bold pointer-events-none shrink-0 z-35 relative">
               {gridSidebarOpen ? <ChevronLeft size={10} /> : <ChevronRight size={10} />}
             </div>
           </div>
@@ -1253,7 +1252,7 @@ export const SchedulerTimelineView: React.FC<SchedulerTimelineViewProps> = ({
                           slottedDate.setHours(hourIndex);
                           onCellClick(slottedDate, true);
                         }}
-                        className="w-[90px] h-12 p-3 font-mono text-[11px] text-slate-400 dark:text-neutral-500 border-r border-slate-100 dark:border-neutral-800 flex items-center justify-center font-bold hover:bg-indigo-50/20 dark:hover:bg-neutral-800/40 cursor-pointer transition select-none"
+                        className="w-[90px] h-12 p-3 font-mono text-[11px] text-slate-400 dark:text-neutral-500 border-r border-slate-100 dark:border-neutral-800 flex items-center justify-center font-bold hover:bg-primary/10 cursor-pointer transition select-none"
                         style={{ width: `${SLOT_WIDTH}px` }}
                       >
                         {hourText}
@@ -1263,7 +1262,7 @@ export const SchedulerTimelineView: React.FC<SchedulerTimelineViewProps> = ({
                     {/* Hover active indicator time text badge inside top hours ruler */}
                     {timelineHover && !timelineSelection && (
                       <div
-                        className="absolute bg-indigo-600 text-white font-mono text-[9px] px-1.5 py-0.5 rounded shadow-sm z-50 pointer-events-none opacity-95 whitespace-nowrap animate-fade-in"
+                        className="absolute bg-primary text-primary-foreground font-mono text-[9px] px-1.5 py-0.5 rounded shadow-sm z-50 pointer-events-none opacity-95 whitespace-nowrap animate-fade-in"
                         style={{
                           left: `${(timelineHover.minutes - dayStartHour * 60) * (SLOT_WIDTH / 60)}px`,
                           transform: "translateX(-50%)",
@@ -1290,7 +1289,7 @@ export const SchedulerTimelineView: React.FC<SchedulerTimelineViewProps> = ({
                   {/* Global vertical dashed line across all resource rows */}
                   {timelineHover && !timelineSelection && (
                     <div
-                      className="absolute top-0 bottom-0 border-l border-dashed border-indigo-500/50 pointer-events-none z-30"
+                      className="absolute top-0 bottom-0 border-l border-dashed border-primary/50 pointer-events-none z-30"
                       style={{
                         left: `${220 + (timelineHover.minutes - dayStartHour * 60) * (SLOT_WIDTH / 60)}px`,
                       }}
@@ -1330,7 +1329,7 @@ export const SchedulerTimelineView: React.FC<SchedulerTimelineViewProps> = ({
                           onMouseLeave={() => setHoveredResourceId(null)}
                           className={`flex items-stretch bg-white dark:bg-neutral-900 border-b border-dashed border-slate-100 dark:border-neutral-800/40 transition-colors min-h-[76px] hover:bg-slate-50/35 dark:hover:bg-neutral-900/15 group/row ${
                             dragOverRowId === resource.id
-                              ? "bg-indigo-50/15 dark:bg-indigo-950/25 ring-2 ring-indigo-500/20 ring-inset"
+                              ? "bg-primary/10 ring-2 ring-primary/20 ring-inset"
                               : ""
                           } ${getResourceBgStyle(isResourceHovered)}`}
                           style={{ height: `${Math.max(ROW_MIN_HEIGHT, rowHeight)}px` }}
@@ -1366,7 +1365,7 @@ export const SchedulerTimelineView: React.FC<SchedulerTimelineViewProps> = ({
                           <div
                             className={`shrink-0 flex-none relative overflow-hidden h-full cursor-pointer transition-colors ${
                               isResourceHovered
-                                ? "bg-indigo-50/50 dark:bg-indigo-950/25"
+                                ? "bg-primary/10"
                                 : "hover:bg-slate-50/20 dark:hover:bg-neutral-800/10"
                             }`}
                             style={{ width: `${hoursScale.length * SLOT_WIDTH}px` }}
@@ -1439,17 +1438,17 @@ export const SchedulerTimelineView: React.FC<SchedulerTimelineViewProps> = ({
 
                               return (
                                 <div
-                                  className="absolute top-0 bottom-0 bg-indigo-500/20 border-x-2 border-indigo-500/50 pointer-events-none z-30 animate-pulse"
+                                  className="absolute top-0 bottom-0 bg-primary/20 border-x-2 border-primary/50 pointer-events-none z-30 animate-pulse"
                                   style={{
                                     left: `${leftPercent}%`,
                                     width: `${widthPercent}%`,
                                   }}
                                 >
-                                  <span className="absolute left-1 top-0.5 bg-indigo-600 text-white font-mono text-[9px] px-1 py-0.2 rounded shadow-xs select-none opacity-95 whitespace-nowrap">
+                                  <span className="absolute left-1 top-0.5 bg-primary text-primary-foreground font-mono text-[9px] px-1 py-0.2 rounded shadow-xs select-none opacity-95 whitespace-nowrap">
                                     Start:{" "}
                                     {format(startD, timeFormat === "24h" ? "HH:mm" : "h:mm a")}
                                   </span>
-                                  <span className="absolute right-1 bottom-0.5 bg-indigo-600 text-white font-mono text-[9px] px-1 py-0.2 rounded shadow-xs select-none opacity-95 whitespace-nowrap">
+                                  <span className="absolute right-1 bottom-0.5 bg-primary text-primary-foreground font-mono text-[9px] px-1 py-0.2 rounded shadow-xs select-none opacity-95 whitespace-nowrap">
                                     End: {format(endD, timeFormat === "24h" ? "HH:mm" : "h:mm a")}
                                   </span>
                                 </div>
@@ -1636,7 +1635,7 @@ export const SchedulerTimelineView: React.FC<SchedulerTimelineViewProps> = ({
                                           e.stopPropagation();
                                         }}
                                         draggable={false}
-                                        className="absolute left-0 top-0 bottom-0 w-2.5 cursor-ew-resize hover:bg-indigo-500/15 active:bg-indigo-500/30 z-30 transition-colors"
+                                        className="absolute left-0 top-0 bottom-0 w-2.5 cursor-ew-resize hover:bg-primary/15 active:bg-primary/30 z-30 transition-colors"
                                         title="Drag to change start time"
                                       />
                                       <div
@@ -1656,7 +1655,7 @@ export const SchedulerTimelineView: React.FC<SchedulerTimelineViewProps> = ({
                                           e.stopPropagation();
                                         }}
                                         draggable={false}
-                                        className="absolute right-0 top-0 bottom-0 w-2.5 cursor-ew-resize hover:bg-indigo-500/15 active:bg-indigo-500/30 z-30 transition-colors"
+                                        className="absolute right-0 top-0 bottom-0 w-2.5 cursor-ew-resize hover:bg-primary/15 active:bg-primary/30 z-30 transition-colors"
                                         title="Drag to change end time"
                                       />
                                     </>
@@ -1712,7 +1711,7 @@ export const SchedulerTimelineView: React.FC<SchedulerTimelineViewProps> = ({
                   {/* Global hover dashed line spanning all columns */}
                   {gridHover && !gridSelection && (
                     <div
-                      className="absolute left-14 right-0 border-t border-dashed border-indigo-500/50 pointer-events-none z-30"
+                      className="absolute left-14 right-0 border-t border-dashed border-primary/50 pointer-events-none z-30"
                       style={{
                         top: `calc(56px + ${hasAnyAllDayEvents ? "56px" : "0px"} + ${((gridHover.minutes - dayStartHour * 60) / 60) * GRID_HOUR_HEIGHT}px)`,
                       }}
@@ -1765,7 +1764,7 @@ export const SchedulerTimelineView: React.FC<SchedulerTimelineViewProps> = ({
                       {/* Hover active indicator time text badge inside side ruler */}
                       {gridHover && !gridSelection && (
                         <div
-                          className="absolute right-1.5 bg-indigo-600 text-white font-mono text-[9px] px-1 py-0.5 rounded shadow-sm z-30 pointer-events-none opacity-95 whitespace-nowrap animate-fade-in"
+                          className="absolute right-1.5 bg-primary text-primary-foreground font-mono text-[9px] px-1 py-0.5 rounded shadow-sm z-30 pointer-events-none opacity-95 whitespace-nowrap animate-fade-in"
                           style={{
                             top: `${((gridHover.minutes - dayStartHour * 60) / 60) * GRID_HOUR_HEIGHT}px`,
                             transform: "translateY(-50%)",
@@ -1803,7 +1802,7 @@ export const SchedulerTimelineView: React.FC<SchedulerTimelineViewProps> = ({
                           onMouseLeave={() => setHoveredResourceId(null)}
                           className={`w-[210px] shrink-0 border-r border-slate-100/85 dark:border-neutral-800/80 flex flex-col relative transition-colors ${
                             dragOverRowId === col.resource.id
-                              ? "bg-indigo-50/15 dark:bg-indigo-950/20 ring-1 ring-indigo-500/20 ring-inset"
+                              ? "bg-primary/10 ring-1 ring-primary/20 ring-inset"
                               : ""
                           } ${getResourceBgStyle(isColHovered)}`}
                         >
@@ -1961,17 +1960,17 @@ export const SchedulerTimelineView: React.FC<SchedulerTimelineViewProps> = ({
 
                               return (
                                 <div
-                                  className="absolute left-0 right-0 bg-indigo-500/20 border-y-2 border-indigo-500/50 pointer-events-none z-30 animate-pulse"
+                                  className="absolute left-0 right-0 bg-primary/20 border-y-2 border-primary/50 pointer-events-none z-30 animate-pulse"
                                   style={{
                                     top: `${topPx}px`,
                                     height: `${heightPx}px`,
                                   }}
                                 >
-                                  <span className="absolute top-0.5 left-1 bg-indigo-600 text-white font-mono text-[9px] px-1 py-0.2 rounded shadow-xs select-none opacity-95 whitespace-nowrap">
+                                  <span className="absolute top-0.5 left-1 bg-primary text-primary-foreground font-mono text-[9px] px-1 py-0.2 rounded shadow-xs select-none opacity-95 whitespace-nowrap">
                                     Start:{" "}
                                     {format(startD, timeFormat === "24h" ? "HH:mm" : "h:mm a")}
                                   </span>
-                                  <span className="absolute bottom-0.5 right-1 bg-indigo-600 text-white font-mono text-[9px] px-1 py-0.2 rounded shadow-xs select-none opacity-95 whitespace-nowrap">
+                                  <span className="absolute bottom-0.5 right-1 bg-primary text-primary-foreground font-mono text-[9px] px-1 py-0.2 rounded shadow-xs select-none opacity-95 whitespace-nowrap">
                                     End: {format(endD, timeFormat === "24h" ? "HH:mm" : "h:mm a")}
                                   </span>
                                 </div>
@@ -2116,7 +2115,7 @@ export const SchedulerTimelineView: React.FC<SchedulerTimelineViewProps> = ({
                                           e.stopPropagation();
                                         }}
                                         draggable={false}
-                                        className="absolute left-0 right-0 top-0 h-2 cursor-ns-resize hover:bg-indigo-500/15 active:bg-indigo-500/30 z-30 transition-colors"
+                                        className="absolute left-0 right-0 top-0 h-2 cursor-ns-resize hover:bg-primary/15 active:bg-primary/30 z-30 transition-colors"
                                         title="Drag top edge to resize"
                                       />
                                       <div
@@ -2136,7 +2135,7 @@ export const SchedulerTimelineView: React.FC<SchedulerTimelineViewProps> = ({
                                           e.stopPropagation();
                                         }}
                                         draggable={false}
-                                        className="absolute left-0 right-0 bottom-0 h-2 cursor-ns-resize hover:bg-indigo-500/15 active:bg-indigo-500/30 z-30 transition-colors"
+                                        className="absolute left-0 right-0 bottom-0 h-2 cursor-ns-resize hover:bg-primary/15 active:bg-primary/30 z-30 transition-colors"
                                         title="Drag bottom edge to resize"
                                       />
                                     </>

--- a/apps/web/src/components/primitives/scheduler/scheduler-week-view.tsx
+++ b/apps/web/src/components/primitives/scheduler/scheduler-week-view.tsx
@@ -485,7 +485,7 @@ export const SchedulerWeekView: React.FC<SchedulerWeekViewProps> = ({
                   <span
                     className={`mt-1 text-sm font-extrabold w-7 h-7 flex items-center justify-center rounded-full ${
                       isTodayDate
-                        ? "bg-indigo-600 text-white shadow-md shadow-indigo-500/15"
+                        ? "bg-primary text-primary-foreground shadow-md shadow-primary/15"
                         : "text-gray-800 dark:text-neutral-200"
                     }`}
                   >
@@ -578,7 +578,7 @@ export const SchedulerWeekView: React.FC<SchedulerWeekViewProps> = ({
             {/* Hover active indicator time text badge inside side ruler */}
             {hoveredTime && !selectionStart && (
               <div
-                className="absolute right-1.5 bg-indigo-600 text-white font-mono text-[9px] px-1 py-0.5 rounded shadow-sm z-30 pointer-events-none opacity-95 whitespace-nowrap animate-fade-in"
+                className="absolute right-1.5 bg-primary text-primary-foreground font-mono text-[9px] px-1 py-0.5 rounded shadow-sm z-30 pointer-events-none opacity-95 whitespace-nowrap animate-fade-in"
                 style={{
                   top: `${((hoveredTime.minutes - dayStartHour * 60) / 60) * HOUR_HEIGHT}px`,
                   transform: "translateY(-50%)",
@@ -596,7 +596,7 @@ export const SchedulerWeekView: React.FC<SchedulerWeekViewProps> = ({
           {/* Global hover dashed line spanning all columns */}
           {hoveredTime && !selectionStart && (
             <div
-              className="absolute left-14 right-0 border-t border-dashed border-indigo-500/50 pointer-events-none z-30"
+              className="absolute left-14 right-0 border-t border-dashed border-primary/50 pointer-events-none z-30"
               style={{ top: `${((hoveredTime.minutes - dayStartHour * 60) / 60) * HOUR_HEIGHT}px` }}
             />
           )}
@@ -706,16 +706,16 @@ export const SchedulerWeekView: React.FC<SchedulerWeekViewProps> = ({
 
                     return (
                       <div
-                        className="absolute left-0 right-0 bg-indigo-500/20 border-y-2 border-indigo-500/50 pointer-events-none z-30 animate-pulse"
+                        className="absolute left-0 right-0 bg-primary/20 border-y-2 border-primary/50 pointer-events-none z-30 animate-pulse"
                         style={style}
                       >
                         {isStartDay && (
-                          <span className="absolute top-0.5 left-1 bg-indigo-600 text-white font-mono text-[9px] px-1 py-0.2 rounded shadow-xs select-none opacity-95 whitespace-nowrap">
+                          <span className="absolute top-0.5 left-1 bg-primary text-primary-foreground font-mono text-[9px] px-1 py-0.2 rounded shadow-xs select-none opacity-95 whitespace-nowrap">
                             Start: {format(range.start, timeFormat === "24h" ? "HH:mm" : "h:mm a")}
                           </span>
                         )}
                         {isEndDay && (
-                          <span className="absolute bottom-0.5 right-1 bg-indigo-600 text-white font-mono text-[9px] px-1 py-0.2 rounded shadow-xs select-none opacity-95 whitespace-nowrap">
+                          <span className="absolute bottom-0.5 right-1 bg-primary text-primary-foreground font-mono text-[9px] px-1 py-0.2 rounded shadow-xs select-none opacity-95 whitespace-nowrap">
                             End: {format(range.end, timeFormat === "24h" ? "HH:mm" : "h:mm a")}
                           </span>
                         )}
@@ -747,11 +747,11 @@ export const SchedulerWeekView: React.FC<SchedulerWeekViewProps> = ({
                       return (
                         <div
                           key={hr}
-                          className="w-full border-b border-gray-100/30 dark:border-neutral-800/5 hover:bg-indigo-500/[0.04] dark:hover:bg-indigo-400/[0.04] cursor-pointer pointer-events-auto transition duration-75 flex items-start pl-1 text-[8px] font-mono font-medium text-slate-350 dark:text-neutral-650 tracking-wider group"
+                          className="w-full border-b border-gray-100/30 dark:border-neutral-800/5 hover:bg-primary/[0.04] cursor-pointer pointer-events-auto transition duration-75 flex items-start pl-1 text-[8px] font-mono font-medium text-slate-350 dark:text-neutral-650 tracking-wider group"
                           style={{ height: `${HOUR_HEIGHT}px` }}
                           id={`week-hour-slot-${day.getDay()}-${hr}`}
                         >
-                          <span className="opacity-0 group-hover:opacity-100 mt-1 text-indigo-600 dark:text-indigo-400 font-semibold transition-opacity duration-100 font-mono">
+                          <span className="opacity-0 group-hover:opacity-100 mt-1 text-primary font-semibold transition-opacity duration-100 font-mono">
                             {LABELS_MAP[locale]?.hoverAddAt || "+ Add"}{" "}
                             {isThisHourHovered
                               ? formatPreciseMins(hoveredTime!.minutes)
@@ -782,8 +782,7 @@ export const SchedulerWeekView: React.FC<SchedulerWeekViewProps> = ({
                           "bg-rose-500/5 hover:bg-rose-500/10 border-rose-500/10 text-rose-500",
                         unavailable:
                           "bg-neutral-500/5 hover:bg-neutral-500/10 border-neutral-500/10 text-neutral-400",
-                        focus:
-                          "bg-indigo-500/5 hover:bg-indigo-505/15 border-indigo-500/10 text-indigo-500",
+                        focus: "bg-primary/5 hover:bg-primary/15 border-primary/10 text-primary",
                       };
 
                       const bgStartStr = formatInTimezone(
@@ -973,11 +972,11 @@ export const SchedulerWeekView: React.FC<SchedulerWeekViewProps> = ({
                               setIsResizeHandleActive(false);
                               handleResizePointerUp(e, event.id);
                             }}
-                            className="absolute bottom-0 left-0 right-0 h-2 bg-transparent group-hover/card:bg-indigo-300/20 active:bg-indigo-500/30 cursor-ns-resize transition duration-150 flex items-center justify-center pointer-events-auto"
+                            className="absolute bottom-0 left-0 right-0 h-2 bg-transparent group-hover/card:bg-primary/20 active:bg-primary/30 cursor-ns-resize transition duration-150 flex items-center justify-center pointer-events-auto"
                             title="Drag bottom to resize duration"
                           >
                             {/* Visual resizing indicator grip bars */}
-                            <span className="w-4 h-[2px] bg-indigo-500/40 rounded" />
+                            <span className="w-4 h-[2px] bg-primary/40 rounded" />
                           </div>
                         )}
                       </div>

--- a/apps/web/src/components/primitives/scheduler/scheduler-year-view.tsx
+++ b/apps/web/src/components/primitives/scheduler/scheduler-year-view.tsx
@@ -213,7 +213,7 @@ export const SchedulerYearView: React.FC<SchedulerYearViewProps> = ({
               {/* Localized Month Name & Click Zoom action */}
               <button
                 onClick={() => onNavigateToMonth?.(monthDate)}
-                className="text-sm font-bold text-slate-800 dark:text-neutral-200 hover:text-indigo-600 dark:hover:text-indigo-400 transition cursor-pointer font-sans text-left mb-3 shrink-0 flex items-center justify-between"
+                className="text-sm font-bold text-slate-800 dark:text-neutral-200 hover:text-primary transition cursor-pointer font-sans text-left mb-3 shrink-0 flex items-center justify-between"
               >
                 <span>{formatInTimezone(monthDate, "MMMM", timezone, locale)}</span>
                 <span className="text-[10px] bg-slate-100 hover:bg-slate-200 dark:bg-neutral-800 dark:hover:bg-neutral-700 px-2 py-0.5 rounded-md text-slate-500 dark:text-neutral-400 transition ml-2 font-medium">
@@ -299,15 +299,11 @@ export const SchedulerYearView: React.FC<SchedulerYearViewProps> = ({
                       }}
                       className={`relative border-r border-b border-gray-50/50 dark:border-neutral-800/30 p-1 flex flex-col justify-between min-h-[46px] select-none cursor-pointer duration-100 ${
                         isSelected
-                          ? "bg-indigo-50/70 dark:bg-indigo-950/30 shadow-[inset_0_0_0_1.5px_rgba(99,102,241,0.4)] dark:shadow-[inset_0_0_0_1.5px_rgba(129,140,248,0.4)] z-30"
+                          ? "bg-primary/10 ring-2 ring-inset ring-primary/40 z-30"
                           : isCurrentMonth
                             ? "bg-transparent text-gray-800 dark:text-neutral-200"
                             : "bg-gray-50/20 dark:bg-neutral-950/10 text-gray-300 dark:text-neutral-700 opacity-40"
-                      } ${
-                        isDragOver
-                          ? "bg-indigo-50 dark:bg-indigo-950/20 shadow-sm duration-0 scale-[0.98]"
-                          : ""
-                      } ${
+                      } ${isDragOver ? "bg-primary/10 shadow-sm duration-0 scale-[0.98]" : ""} ${
                         hasBackgroundBlocked && showBackgroundEvents
                           ? "bg-rose-50/5 dark:bg-rose-950/5"
                           : ""
@@ -319,7 +315,7 @@ export const SchedulerYearView: React.FC<SchedulerYearViewProps> = ({
                         <span
                           className={`text-[9px] font-bold h-4 w-4 flex items-center justify-center rounded-full ${
                             isTodayDate
-                              ? "bg-indigo-600 text-white font-extrabold shadow-3xs"
+                              ? "bg-primary text-primary-foreground font-extrabold shadow-3xs"
                               : isCurrentMonth
                                 ? "text-gray-700 dark:text-neutral-300"
                                 : "text-gray-300 dark:text-neutral-700"
@@ -345,7 +341,7 @@ export const SchedulerYearView: React.FC<SchedulerYearViewProps> = ({
                                 const dayStr = `${monthIndex}-${format(day, "yyyy-MM-dd")}`;
                                 setOpenTooltipDay((prev) => (prev === dayStr ? null : dayStr));
                               }}
-                              className="w-full text-center py-1 px-1 rounded-md bg-indigo-50 hover:bg-indigo-100 dark:bg-indigo-950/40 dark:hover:bg-indigo-900/50 font-sans text-[8px] font-bold text-indigo-600 dark:text-indigo-400 border border-indigo-100/50 dark:border-indigo-900/40 transition duration-150 cursor-pointer shadow-3xs"
+                              className="w-full text-center py-1 px-1 rounded-md bg-primary/10 hover:bg-primary/15 font-sans text-[8px] font-bold text-primary border border-primary/20 transition duration-150 cursor-pointer shadow-3xs"
                             >
                               +{cellEvents.length}
                             </button>
@@ -357,7 +353,7 @@ export const SchedulerYearView: React.FC<SchedulerYearViewProps> = ({
                                     <span>
                                       {formatInTimezone(day, "MMM d, yyyy", timezone, locale)}
                                     </span>
-                                    <span className="text-[10px] bg-indigo-50 dark:bg-indigo-950 px-1.5 py-0.5 rounded-full text-indigo-600 dark:text-indigo-400 font-bold">
+                                    <span className="text-[10px] bg-primary/10 px-1.5 py-0.5 rounded-full text-primary font-bold">
                                       {cellEvents.length}
                                     </span>
                                   </div>
@@ -383,7 +379,7 @@ export const SchedulerYearView: React.FC<SchedulerYearViewProps> = ({
                                     })}
                                   </div>
                                   <button
-                                    className="bg-indigo-600 hover:bg-indigo-700 text-white text-[10px] py-1.5 px-3 rounded-lg font-bold w-full transition-colors cursor-pointer mt-1"
+                                    className="bg-primary hover:bg-primary/90 text-primary-foreground text-[10px] py-1.5 px-3 rounded-lg font-bold w-full transition-colors cursor-pointer mt-1"
                                     onClick={(e) => {
                                       e.stopPropagation();
                                       setOpenTooltipDay(null);


### PR DESCRIPTION
Replace leftover indigo/purple/fuchsia UI chrome (buttons, focus rings, hover/selection states, today markers, drag highlights, resize handles) with the app's amber primary/accent theme, while preserving the intentional 6-category event color system.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated scheduler component color theme to use a consistent primary color across all calendar views (day, week, month, year, timeline, list) and interactive elements including dialogs, popovers, and sidebars.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->