### PR TITLE
feat(warehouse): use display numbers instead of UUIDs in movement URLs

### DIFF
--- a/apps/web/src/app/[locale]/dashboard/warehouse/inventory/movements/_components/inventory-movement-detail-panel.tsx
+++ b/apps/web/src/app/[locale]/dashboard/warehouse/inventory/movements/_components/inventory-movement-detail-panel.tsx
@@ -148,7 +148,9 @@ export function InventoryMovementDetailPanel({
               <Link
                 href={{
                   pathname: "/dashboard/warehouse/inventory/movements/[movementId]",
-                  params: { movementId: detail.id },
+                  params: {
+                    movementId: detail.document_number ?? detail.draft_number ?? detail.id,
+                  },
                 }}
               >
                 <ExternalLink className="mr-1.5 h-3.5 w-3.5" />
@@ -163,7 +165,11 @@ export function InventoryMovementDetailPanel({
       {isDraft && canOperate && (
         <div className="flex gap-2 border-b pb-3">
           <Button asChild variant="outline" size="sm">
-            <Link href={`/dashboard/warehouse/inventory/movements/${detail.id}/edit` as any}>
+            <Link
+              href={
+                `/dashboard/warehouse/inventory/movements/${detail.document_number ?? detail.draft_number ?? detail.id}/edit` as any
+              }
+            >
               <Pencil className="mr-1.5 h-3.5 w-3.5" />
               {td("editDraft")}
             </Link>

--- a/apps/web/src/app/[locale]/dashboard/warehouse/inventory/movements/_components/inventory-movements-client.tsx
+++ b/apps/web/src/app/[locale]/dashboard/warehouse/inventory/movements/_components/inventory-movements-client.tsx
@@ -43,8 +43,8 @@ async function listFetcher(params: DataViewListParams) {
   return result.data;
 }
 
-async function detailFetcher(id: string) {
-  const result = await getInventoryMovementAction({ id: id.replace("branch-transfer:", "") });
+async function detailFetcher(identifier: string) {
+  const result = await getInventoryMovementAction({ identifier });
   if (!result.success || !("data" in result))
     throw new Error("error" in result ? result.error : "unauthorized");
   return result.data;
@@ -191,7 +191,7 @@ export function InventoryMovementsClient({
         queryKey={["inventory-movements"]}
         listFetcher={listFetcher}
         detailFetcher={detailFetcher}
-        getRowId={(row) => row.id}
+        getRowId={(row) => row.document_number ?? row.draft_number ?? row.id}
         renderDetail={(detail) => (
           <InventoryMovementDetailPanel
             detail={detail}

--- a/apps/web/src/app/[locale]/dashboard/warehouse/inventory/movements/new/_components/movement-editor/use-movement-submission.ts
+++ b/apps/web/src/app/[locale]/dashboard/warehouse/inventory/movements/new/_components/movement-editor/use-movement-submission.ts
@@ -56,9 +56,9 @@ export function useMovementSubmission(
 
       startTransition(async () => {
         const ls = buildLines();
-        const detailPath = (movementId: string) => ({
+        const detailPath = (displayId: string) => ({
           pathname: "/dashboard/warehouse/inventory/movements/[movementId]" as const,
-          params: { movementId },
+          params: { movementId: displayId },
         });
 
         if (isEdit && initialValues) {
@@ -77,12 +77,14 @@ export function useMovementSubmission(
             toast.error(r.error ?? t("failed"));
             return;
           }
+          const displayNumber =
+            r.data?.document_number ?? r.data?.draft_number ?? initialValues.draftNumber;
           toast.success(
             andPost
               ? t("documentPosted", { number: r.data?.document_number ?? "" })
               : t("draftSaved")
           );
-          router.push(detailPath(initialValues.movementId));
+          router.push(detailPath(displayNumber));
         } else {
           const bp = {
             movement_type_code: typeCode,
@@ -100,7 +102,7 @@ export function useMovementSubmission(
               return;
             }
             toast.success(t("documentPosted", { number: r.data?.document_number ?? "" }));
-            router.push(detailPath(r.data?.movement_id));
+            router.push(detailPath(r.data?.document_number ?? r.data?.draft_number));
           } else {
             const r = (await createDraftMovementAction(bp)) as any;
             if (!r.success) {
@@ -108,7 +110,7 @@ export function useMovementSubmission(
               return;
             }
             toast.success(t("draftCreated", { number: r.data?.draft_number ?? "" }));
-            router.push(detailPath(r.data?.movement_id));
+            router.push(detailPath(r.data?.draft_number));
           }
         }
       });

--- a/apps/web/src/app/actions/warehouse/inventory/index.ts
+++ b/apps/web/src/app/actions/warehouse/inventory/index.ts
@@ -1261,15 +1261,18 @@ export async function getInventoryMovementAction(rawInput: unknown) {
     const branch = requireActiveBranch(auth);
     if (!branch.success) return branch;
 
-    const parsed = getByIdSchema.safeParse(rawInput);
-    if (!parsed.success) return { success: false, error: parsed.error.errors[0].message };
+    const input = rawInput as { id?: string; identifier?: string };
+    const identifier = input?.identifier || input?.id;
+    if (!identifier || typeof identifier !== "string") {
+      return { success: false, error: "Movement identifier is required" };
+    }
 
     const supabase = await createClient();
     return InventoryMovementsService.getMovementDetail(
       supabase,
       auth.context.app.activeOrgId,
       branch.branchId,
-      parsed.data.id
+      identifier
     );
   } catch (error) {
     return mapUnexpected(error);

--- a/apps/web/src/server/services/inventory-movements.service.ts
+++ b/apps/web/src/server/services/inventory-movements.service.ts
@@ -240,16 +240,25 @@ export class InventoryMovementsService {
     supabase: SupabaseClient,
     orgId: string,
     branchId: string,
-    movementId: string
+    movementIdentifier: string
   ): Promise<ServiceResult<InventoryMovementDetail>> {
-    const { data: header, error: headerError } = await supabase
+    const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+      movementIdentifier
+    );
+    let query = supabase
       .from("inventory_movement_headers")
       .select("*")
-      .eq("id", movementId)
       .eq("organization_id", orgId)
       .eq("branch_id", branchId)
-      .is("deleted_at", null)
-      .maybeSingle();
+      .is("deleted_at", null);
+    if (isUuid) {
+      query = query.eq("id", movementIdentifier);
+    } else {
+      query = query.or(
+        `draft_number.eq.${movementIdentifier},document_number.eq.${movementIdentifier}`
+      );
+    }
+    const { data: header, error: headerError } = await query.maybeSingle();
 
     if (headerError) return { success: false, error: headerError.message };
     if (!header) return { success: false, error: "Movement not found" };
@@ -281,7 +290,7 @@ export class InventoryMovementsService {
         .select(
           "id, line_number, variant_id, unit_id, quantity, unit_cost, source_location_id, destination_location_id, snapshot_product_name, snapshot_sku, snapshot_unit_code, snapshot_source_location_name, snapshot_destination_location_name"
         )
-        .eq("movement_id", movementId)
+        .eq("movement_id", h.id)
         .is("deleted_at", null)
         .order("line_number"),
       h.movement_type_id
@@ -294,7 +303,7 @@ export class InventoryMovementsService {
       (supabase as any)
         .from("inventory_movement_audit_log")
         .select("id, action, old_status, new_status, actor_user_id, actor_user_name, created_at")
-        .eq("movement_id", movementId)
+        .eq("movement_id", h.id)
         .order("created_at", { ascending: true }),
     ]);
 


### PR DESCRIPTION
Movements now use draft_number (DRF-000016) or document_number (PZ/2026/000001) in URLs and dataview selection instead of exposing database UUIDs.

- Service getMovementDetail accepts either UUID or display number, auto-detects format and queries by draft_number/document_number
- DataView getRowId returns display number
- Detail panel links and submission hook navigate using display number
- Action accepts flexible identifier param

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inventory movement details can now be opened using either the movement ID or a human-readable document/draft number.
  * Detail pages and edit links now route more reliably to the correct movement record.
* **Bug Fixes**
  * Improved movement detail loading so related line items and activity logs always match the selected movement.
  * Fixed row selection in movement lists to use the most relevant identifier when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->