### PR TITLE
feat(warehouse): use URL-safe route keys instead of UUIDs in movement…

### DIFF
--- a/apps/web/src/app/[locale]/dashboard/warehouse/inventory/movements/_components/inventory-movement-detail-panel.tsx
+++ b/apps/web/src/app/[locale]/dashboard/warehouse/inventory/movements/_components/inventory-movement-detail-panel.tsx
@@ -8,6 +8,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Link, useRouter } from "@/i18n/navigation";
 import type { InventoryMovementDetail } from "@/lib/warehouse/inventory-types";
+import { getMovementDetailHref, getMovementRouteKey } from "@/lib/warehouse/movement-route-key";
 import { RichTextRenderer } from "@/components/primitives/rich-text/rich-text-renderer";
 import { normalizeRichText } from "@/components/primitives/rich-text/rich-text-utils";
 import {
@@ -145,14 +146,7 @@ export function InventoryMovementDetailPanel({
           )}
           {showOpenPageAction && (
             <Button asChild type="button" variant="outline" size="sm">
-              <Link
-                href={{
-                  pathname: "/dashboard/warehouse/inventory/movements/[movementId]",
-                  params: {
-                    movementId: detail.document_number ?? detail.draft_number ?? detail.id,
-                  },
-                }}
-              >
+              <Link href={getMovementDetailHref(detail)}>
                 <ExternalLink className="mr-1.5 h-3.5 w-3.5" />
                 {t("openMovement")}
               </Link>
@@ -167,7 +161,7 @@ export function InventoryMovementDetailPanel({
           <Button asChild variant="outline" size="sm">
             <Link
               href={
-                `/dashboard/warehouse/inventory/movements/${detail.document_number ?? detail.draft_number ?? detail.id}/edit` as any
+                `/dashboard/warehouse/inventory/movements/${getMovementRouteKey(detail)}/edit` as any
               }
             >
               <Pencil className="mr-1.5 h-3.5 w-3.5" />

--- a/apps/web/src/app/[locale]/dashboard/warehouse/inventory/movements/_components/inventory-movements-client.tsx
+++ b/apps/web/src/app/[locale]/dashboard/warehouse/inventory/movements/_components/inventory-movements-client.tsx
@@ -43,8 +43,8 @@ async function listFetcher(params: DataViewListParams) {
   return result.data;
 }
 
-async function detailFetcher(identifier: string) {
-  const result = await getInventoryMovementAction({ identifier });
+async function detailFetcher(routeKey: string) {
+  const result = await getInventoryMovementAction({ identifier: routeKey });
   if (!result.success || !("data" in result))
     throw new Error("error" in result ? result.error : "unauthorized");
   return result.data;
@@ -191,7 +191,7 @@ export function InventoryMovementsClient({
         queryKey={["inventory-movements"]}
         listFetcher={listFetcher}
         detailFetcher={detailFetcher}
-        getRowId={(row) => row.document_number ?? row.draft_number ?? row.id}
+        getRowId={(row) => row.route_key}
         renderDetail={(detail) => (
           <InventoryMovementDetailPanel
             detail={detail}

--- a/apps/web/src/app/[locale]/dashboard/warehouse/inventory/movements/new/_components/movement-editor/use-movement-submission.ts
+++ b/apps/web/src/app/[locale]/dashboard/warehouse/inventory/movements/new/_components/movement-editor/use-movement-submission.ts
@@ -9,6 +9,7 @@ import {
   saveAndPostDraftMovementAction,
 } from "@/app/actions/warehouse/inventory";
 import type { CounterpartyDetails } from "@/lib/warehouse/inventory-types";
+import { toMovementRouteKey } from "@/lib/warehouse/movement-route-key";
 import type { LineDraft, MovementFormInitialValues, ValidationResult } from "./types";
 
 export function useMovementSubmission(
@@ -56,9 +57,9 @@ export function useMovementSubmission(
 
       startTransition(async () => {
         const ls = buildLines();
-        const detailPath = (displayId: string) => ({
+        const detailPath = (routeKey: string) => ({
           pathname: "/dashboard/warehouse/inventory/movements/[movementId]" as const,
-          params: { movementId: displayId },
+          params: { movementId: routeKey },
         });
 
         if (isEdit && initialValues) {
@@ -77,14 +78,17 @@ export function useMovementSubmission(
             toast.error(r.error ?? t("failed"));
             return;
           }
-          const displayNumber =
-            r.data?.document_number ?? r.data?.draft_number ?? initialValues.draftNumber;
+          const routeKey =
+            r.data?.route_key ??
+            toMovementRouteKey(
+              r.data?.document_number ?? r.data?.draft_number ?? initialValues.draftNumber
+            );
           toast.success(
             andPost
               ? t("documentPosted", { number: r.data?.document_number ?? "" })
               : t("draftSaved")
           );
-          router.push(detailPath(displayNumber));
+          router.push(detailPath(routeKey));
         } else {
           const bp = {
             movement_type_code: typeCode,
@@ -102,7 +106,9 @@ export function useMovementSubmission(
               return;
             }
             toast.success(t("documentPosted", { number: r.data?.document_number ?? "" }));
-            router.push(detailPath(r.data?.document_number ?? r.data?.draft_number));
+            router.push(
+              detailPath(r.data?.route_key ?? toMovementRouteKey(r.data?.document_number))
+            );
           } else {
             const r = (await createDraftMovementAction(bp)) as any;
             if (!r.success) {
@@ -110,7 +116,7 @@ export function useMovementSubmission(
               return;
             }
             toast.success(t("draftCreated", { number: r.data?.draft_number ?? "" }));
-            router.push(detailPath(r.data?.draft_number));
+            router.push(detailPath(r.data?.route_key ?? toMovementRouteKey(r.data?.draft_number)));
           }
         }
       });

--- a/apps/web/src/lib/warehouse/inventory-types.ts
+++ b/apps/web/src/lib/warehouse/inventory-types.ts
@@ -403,6 +403,7 @@ export type InventoryMovementListRow = {
   id: string;
   draft_number: string | null;
   document_number: string | null;
+  route_key: string;
   document_type_code: string | null;
   movement_type_code: string;
   movement_type_name: string;

--- a/apps/web/src/lib/warehouse/movement-route-key.ts
+++ b/apps/web/src/lib/warehouse/movement-route-key.ts
@@ -1,0 +1,41 @@
+export function toMovementRouteKey(displayNumber: string): string {
+  return displayNumber
+    .trim()
+    .toUpperCase()
+    .replace(/[/\\]+/g, "-")
+    .replace(/-{2,}/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+export function getMovementDisplayNumber(movement: {
+  status: string;
+  document_number: string | null;
+  draft_number: string | null;
+}): string {
+  if (movement.status === "posted" && movement.document_number) {
+    return movement.document_number;
+  }
+  return movement.draft_number ?? "";
+}
+
+export function getMovementRouteKey(movement: {
+  status: string;
+  document_number: string | null;
+  draft_number: string | null;
+  route_key?: string | null;
+}): string {
+  if (movement.route_key) return movement.route_key;
+  return toMovementRouteKey(getMovementDisplayNumber(movement));
+}
+
+export function getMovementDetailHref(movement: {
+  status: string;
+  document_number: string | null;
+  draft_number: string | null;
+  route_key?: string | null;
+}) {
+  return {
+    pathname: "/dashboard/warehouse/inventory/movements/[movementId]" as const,
+    params: { movementId: getMovementRouteKey(movement) },
+  };
+}

--- a/apps/web/src/server/services/inventory-movements.service.ts
+++ b/apps/web/src/server/services/inventory-movements.service.ts
@@ -11,6 +11,7 @@ import type {
   InventoryPickerItem,
   LocationVariantStock,
 } from "@/lib/warehouse/inventory-types";
+import { toMovementRouteKey } from "@/lib/warehouse/movement-route-key";
 export type {
   CreateDraftMovementInput,
   InventoryMovementDetail,
@@ -20,6 +21,19 @@ export type {
 export type ServiceResult<T> = { success: true; data: T } | { success: false; error: string };
 
 export class InventoryMovementsService {
+  private static async _saveRouteKey(
+    supabase: SupabaseClient,
+    movementId: string,
+    displayNumber: string
+  ) {
+    const routeKey = toMovementRouteKey(displayNumber);
+    await supabase
+      .from("inventory_movement_headers")
+      .update({ route_key: routeKey } as any)
+      .eq("id", movementId);
+    return routeKey;
+  }
+
   private static async _saveCounterpartyDetails(
     supabase: SupabaseClient,
     movementId: string,
@@ -54,8 +68,9 @@ export class InventoryMovementsService {
     });
     if (error) return { success: false, error: error.message };
     const result = data as any;
+    const routeKey = await this._saveRouteKey(supabase, result.movement_id, result.draft_number);
     await this._saveCounterpartyDetails(supabase, result.movement_id, input.counterparty_details);
-    return { success: true, data: result };
+    return { success: true, data: { ...result, route_key: routeKey } };
   }
 
   static async finalizePosting(
@@ -68,7 +83,16 @@ export class InventoryMovementsService {
       p_actor_user_id: userId,
     });
     if (error) return { success: false, error: error.message };
-    return { success: true, data: data as any };
+    const result = data as any;
+    if (result.document_number) {
+      const routeKey = await this._saveRouteKey(
+        supabase,
+        result.movement_id,
+        result.document_number
+      );
+      return { success: true, data: { ...result, route_key: routeKey } };
+    }
+    return { success: true, data: result };
   }
 
   static async createAndFinalize(
@@ -93,8 +117,13 @@ export class InventoryMovementsService {
     });
     if (error) return { success: false, error: error.message };
     const result = data as any;
+    const routeKey = await this._saveRouteKey(
+      supabase,
+      result.movement_id,
+      result.document_number ?? result.draft_number
+    );
     await this._saveCounterpartyDetails(supabase, result.movement_id, input.counterparty_details);
-    return { success: true, data: result };
+    return { success: true, data: { ...result, route_key: routeKey } };
   }
 
   static async saveDraft(
@@ -219,6 +248,7 @@ export class InventoryMovementsService {
         id: h.id,
         draft_number: h.draft_number,
         document_number: h.document_number,
+        route_key: h.route_key ?? toMovementRouteKey(h.document_number ?? h.draft_number ?? h.id),
         document_type_code: h.document_type_code,
         movement_type_code: h.movement_type_code ?? "",
         movement_type_name: mvtType?.name_pl ?? mvtType?.name ?? h.movement_type_code ?? "",
@@ -254,9 +284,7 @@ export class InventoryMovementsService {
     if (isUuid) {
       query = query.eq("id", movementIdentifier);
     } else {
-      query = query.or(
-        `draft_number.eq.${movementIdentifier},document_number.eq.${movementIdentifier}`
-      );
+      query = query.or(`route_key.eq.${movementIdentifier},draft_number.eq.${movementIdentifier}`);
     }
     const { data: header, error: headerError } = await query.maybeSingle();
 
@@ -404,6 +432,7 @@ export class InventoryMovementsService {
         id: h.id,
         draft_number: h.draft_number,
         document_number: h.document_number,
+        route_key: h.route_key ?? toMovementRouteKey(h.document_number ?? h.draft_number ?? h.id),
         document_type_code: h.document_type_code,
         movement_type_code: h.movement_type_code ?? "",
         movement_type_name: mvtType?.name_pl ?? mvtType?.name ?? h.movement_type_code ?? "",

--- a/apps/web/supabase-target/supabase/migrations/20260625110000_add_movement_route_key.sql
+++ b/apps/web/supabase-target/supabase/migrations/20260625110000_add_movement_route_key.sql
@@ -1,0 +1,13 @@
+ALTER TABLE inventory_movement_headers
+ADD COLUMN IF NOT EXISTS route_key TEXT;
+
+UPDATE inventory_movement_headers
+SET route_key = COALESCE(
+  REPLACE(document_number, '/', '-'),
+  draft_number
+)
+WHERE route_key IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_imh_route_key_org
+ON inventory_movement_headers (organization_id, route_key)
+WHERE route_key IS NOT NULL AND deleted_at IS NULL;


### PR DESCRIPTION
… URLs

Add route_key column to inventory_movement_headers storing URL-safe identifiers (PZ/2026/000015 → PZ-2026-000015, DRF-000016 stays as-is).

- Add shared helpers in movement-route-key.ts: toMovementRouteKey, getMovementDisplayNumber, getMovementRouteKey, getMovementDetailHref
- Service saves route_key after create/post RPCs, resolves detail by route_key with UUID fallback
- DataView getRowId returns route_key, detailFetcher queries by it
- Detail panel links use getMovementDetailHref/getMovementRouteKey
- Submission hook navigates using route_key from RPC results
- UI still displays real numbers with slashes (PZ/2026/000015)
- Migration adds column, backfills existing rows, adds unique index

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inventory movements now use stable route keys for opening, editing, and sharing detail pages.
  * Movement lists and detail views can recognize movements by the new route key, improving navigation consistency.

* **Bug Fixes**
  * Fixed movement links so drafts and posted records open the correct page more reliably.
  * Improved movement creation and posting flows to send users to the right detail screen after save.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->