### PR TITLE
fix(warehouse): make locations page usable on mobile/tablet

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -6682,7 +6682,8 @@
       "warningTitle": "{count} active warnings",
       "noLocations": "No locations",
       "locked": "Locked",
-      "editMode": "Edit mode"
+      "editMode": "Edit mode",
+      "backToList": "Back to list"
     },
     "tabs": {
       "information": "Information",

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -6656,7 +6656,8 @@
       "warningTitle": "{count} aktywnych ostrzeżeń",
       "noLocations": "Brak lokalizacji",
       "locked": "Zablokowane",
-      "editMode": "Tryb edycji"
+      "editMode": "Tryb edycji",
+      "backToList": "Powrót do listy"
     },
     "tabs": {
       "information": "Informacje",

--- a/apps/web/src/app/[locale]/dashboard/warehouse/locations/_ambra/components/locations/LocationsPage.tsx
+++ b/apps/web/src/app/[locale]/dashboard/warehouse/locations/_ambra/components/locations/LocationsPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import dynamic from "next/dynamic";
 import { useTranslations } from "next-intl";
 import {
@@ -452,6 +452,19 @@ export default function LocationsPage({
   const selectedLocationId =
     controlledSelectedId !== undefined ? controlledSelectedId : internalSelectedId;
   const setSelectedLocationId = controlledOnSelect ?? setInternalSelectedId;
+  // Below `lg` (1024px, covers phones and tablets) the sidebar tree and the
+  // detail panel can't sit side by side without squeezing the detail panel
+  // into nothing — show one pane at a time instead, switching automatically
+  // based on whether a location is selected. Desktop (>=1024px) is
+  // completely unaffected: both panes always render exactly as before.
+  const [isCompactViewport, setIsCompactViewport] = useState(false);
+  useEffect(() => {
+    const mql = window.matchMedia("(max-width: 1023px)");
+    const onChange = () => setIsCompactViewport(mql.matches);
+    onChange();
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, []);
   const [expandedIds, setExpandedIds] = useState<string[]>(["l1", "l2"]);
   const [searchQuery, setSearchQuery] = useState("");
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
@@ -1026,7 +1039,11 @@ export default function LocationsPage({
       </AnimatePresence>
 
       {/* Sidebar: Location Tree */}
-      <div className="relative z-10 flex w-[360px] shrink-0 flex-col overflow-hidden border-r border-border bg-card">
+      <div
+        className={`relative z-10 w-full shrink-0 flex-col overflow-hidden border-r border-border bg-card lg:w-[360px] ${
+          isCompactViewport && selectedLocationId ? "hidden" : "flex"
+        }`}
+      >
         <div className="border-b border-border bg-card px-3 py-3">
           <div className="flex items-center gap-2">
             <div className="relative flex-1">
@@ -1174,7 +1191,20 @@ export default function LocationsPage({
       </div>
 
       {/* Main Content Area: Location Detail */}
-      <div className="relative flex min-w-0 flex-1 flex-col overflow-hidden bg-background">
+      <div
+        className={`relative min-w-0 flex-1 flex-col overflow-hidden bg-background ${
+          isCompactViewport && !selectedLocationId ? "hidden" : "flex"
+        }`}
+      >
+        {isCompactViewport && (
+          <button
+            onClick={() => setSelectedLocationId(null)}
+            className="flex items-center gap-1.5 border-b border-border bg-card px-3 py-2.5 text-[11px] font-bold uppercase tracking-wide text-muted-foreground transition-colors hover:text-foreground lg:hidden"
+          >
+            <ChevronRight className="h-3.5 w-3.5 rotate-180" />
+            {t("tree.backToList")}
+          </button>
+        )}
         <AnimatePresence mode="wait">
           {selectedLocation ? (
             <motion.div


### PR DESCRIPTION
The sidebar location tree and the detail panel sat in a fixed-width side-by-side flex row with no responsive handling at all, so on mobile/tablet the 360px tree took the whole viewport and the detail panel was squeezed out entirely.

Below 1024px, show one pane at a time instead — the tree (full width) when nothing is selected, or the detail panel (full width) once a location is picked — driven by the page's existing selectedLocationId state, plus a small "back to list" bar to return to the tree. Desktop (>=1024px) renders exactly as before; only the two outer wrapper divs gained responsive classes, no internal component logic changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a responsive compact layout for warehouse locations on smaller screens.
  * Added a “Back to list” action to return from location details to the location list.
  * Added English and Polish translations for the new label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->