### PR TITLE
feat(warehouse): launch audit wizard pre-scoped from location detail …

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -6740,6 +6740,8 @@
       "bentoView": "Bento grid view",
       "streamlinedView": "Streamlined view",
       "edit": "Edit",
+      "auditLocation": "Audit location",
+      "auditSelected": "Audit selected ({count})",
       "quickAddChild": "Quick add child",
       "duplicate": "Duplicate",
       "locateOnMap": "Locate on map",

--- a/apps/web/messages/pl.json
+++ b/apps/web/messages/pl.json
@@ -6714,6 +6714,8 @@
       "bentoView": "Widok siatki bento",
       "streamlinedView": "Widok uproszczony",
       "edit": "Edytuj",
+      "auditLocation": "Audytuj lokalizację",
+      "auditSelected": "Audytuj zaznaczone ({count})",
       "quickAddChild": "Szybko dodaj dziecko",
       "duplicate": "Duplikuj",
       "locateOnMap": "Znajdź na mapie",

--- a/apps/web/src/app/[locale]/dashboard/warehouse/audits/new/_components/audit-wizard/index.tsx
+++ b/apps/web/src/app/[locale]/dashboard/warehouse/audits/new/_components/audit-wizard/index.tsx
@@ -8,7 +8,7 @@ import { useRouter } from "@/i18n/navigation";
 import { Button } from "@/components/ui/button";
 import { LoadingOverlay } from "@/components/branding";
 import { useUiStoreV2 } from "@/lib/stores/v2/ui-store";
-import { useWizardState } from "./use-wizard-state";
+import { useWizardState, type WizardInitialState } from "./use-wizard-state";
 import { useWizardScopePreview } from "./use-wizard-scope-preview";
 import { useWizardSubmission } from "./use-wizard-submission";
 import { WizardStepIndicator } from "./wizard-step-indicator";
@@ -24,12 +24,19 @@ interface AuditWizardProps {
   locations: WizardLocationOption[];
   suppliers: WizardSupplierOption[];
   stockIndex?: WizardStockIndexRow[];
+  initialState?: WizardInitialState;
 }
 
-export function AuditWizard({ branchId, locations, suppliers, stockIndex = [] }: AuditWizardProps) {
+export function AuditWizard({
+  branchId,
+  locations,
+  suppliers,
+  stockIndex = [],
+  initialState,
+}: AuditWizardProps) {
   const t = useTranslations("warehouseInventory.audits.wizard");
   const router = useRouter();
-  const state = useWizardState(locations);
+  const state = useWizardState(locations, initialState);
   const preview = useWizardScopePreview(state, suppliers, stockIndex);
   const { launch, isPending } = useWizardSubmission(branchId);
 

--- a/apps/web/src/app/[locale]/dashboard/warehouse/audits/new/_components/audit-wizard/use-wizard-state.ts
+++ b/apps/web/src/app/[locale]/dashboard/warehouse/audits/new/_components/audit-wizard/use-wizard-state.ts
@@ -11,11 +11,19 @@ import type { WizardLocationOption } from "./types";
  * guidance (§14): recomputing subtree expansion on every keystroke of
  * unrelated fields would be wasteful once the location count grows.
  */
-export function useWizardState(allLocations: WizardLocationOption[]) {
-  const [step, setStep] = useState<1 | 2 | 3 | 4>(1);
-  const [countType, setCountType] = useState<CountSessionType>("location");
+export interface WizardInitialState {
+  step?: 1 | 2 | 3 | 4;
+  countType?: CountSessionType;
+  selectedLocationIds?: string[];
+}
 
-  const [selectedLocationIds, setSelectedLocationIds] = useState<string[]>([]);
+export function useWizardState(allLocations: WizardLocationOption[], initial?: WizardInitialState) {
+  const [step, setStep] = useState<1 | 2 | 3 | 4>(initial?.step ?? 1);
+  const [countType, setCountType] = useState<CountSessionType>(initial?.countType ?? "location");
+
+  const [selectedLocationIds, setSelectedLocationIds] = useState<string[]>(
+    initial?.selectedLocationIds ?? []
+  );
   const [includeChildren, setIncludeChildren] = useState(true);
 
   const [selectedSupplierId, setSelectedSupplierId] = useState<string | null>(null);

--- a/apps/web/src/app/[locale]/dashboard/warehouse/audits/new/page.tsx
+++ b/apps/web/src/app/[locale]/dashboard/warehouse/audits/new/page.tsx
@@ -8,9 +8,35 @@ import { WarehouseLocationsService } from "@/server/services/warehouse-locations
 import { InventoryProductsService } from "@/server/services/inventory-products.service";
 import { flattenLocationTreeDepthFirst } from "@/lib/warehouse/location-tree";
 import { AuditWizard } from "./_components/audit-wizard";
+import type { CountSessionType } from "@/lib/warehouse/count-session-types";
 
-export default async function NewWarehouseAuditPage() {
+type PageProps = {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export default async function NewWarehouseAuditPage({ searchParams }: PageProps) {
   const locale = await getLocale();
+  const params = searchParams ? await searchParams : {};
+  const asString = (v: string | string[] | undefined) => (Array.isArray(v) ? v[0] : v);
+  const rawStep = Number(asString(params.step));
+  const rawCountType = asString(params.countType);
+  const locationId = asString(params.locationId);
+  const rawLocationIds = params.locationIds;
+  const locationIds = Array.isArray(rawLocationIds)
+    ? rawLocationIds
+    : rawLocationIds
+      ? rawLocationIds.split(",").filter(Boolean)
+      : locationId
+        ? [locationId]
+        : [];
+  const initialState =
+    rawStep === 2 && locationIds.length > 0
+      ? {
+          step: 2 as const,
+          countType: (rawCountType === "supplier" ? "supplier" : "location") as CountSessionType,
+          selectedLocationIds: locationIds,
+        }
+      : undefined;
   const context = await loadDashboardContextV2();
 
   if (!context?.app.activeOrgId) return redirect({ href: "/sign-in", locale });
@@ -110,6 +136,7 @@ export default async function NewWarehouseAuditPage() {
       locations={locations}
       suppliers={suppliers}
       stockIndex={stockIndex}
+      initialState={initialState}
     />
   );
 }

--- a/apps/web/src/app/[locale]/dashboard/warehouse/locations/_ambra/components/locations/LocationsPage.tsx
+++ b/apps/web/src/app/[locale]/dashboard/warehouse/locations/_ambra/components/locations/LocationsPage.tsx
@@ -3,6 +3,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import dynamic from "next/dynamic";
 import { useTranslations } from "next-intl";
+import { useRouter } from "@/i18n/navigation";
 import {
   LogicalLocation,
   LocationRole,
@@ -76,6 +77,7 @@ import {
   Package,
   Circle,
   Activity,
+  ClipboardCheck,
 } from "lucide-react";
 
 import {
@@ -446,6 +448,7 @@ export default function LocationsPage({
   onQrUnassigned,
 }: LocationsPageProps) {
   const t = useTranslations("ambraLocations");
+  const router = useRouter();
   const [internalSelectedId, setInternalSelectedId] = useState<string | null>(
     controlledSelectedId ?? (locations[0]?.id || null)
   );
@@ -1253,6 +1256,22 @@ export default function LocationsPage({
                     >
                       <Pencil className="w-4 h-4" />
                       {t("actions.edit")}
+                    </button>
+                    <button
+                      onClick={() =>
+                        router.push({
+                          pathname: "/dashboard/warehouse/audits/new",
+                          query: {
+                            step: "2",
+                            countType: "location",
+                            locationId: selectedLocation.id,
+                          },
+                        })
+                      }
+                      className="flex items-center gap-2 px-4 py-2 rounded-xl border border-border bg-muted hover:bg-muted font-bold text-xs text-foreground/80 transition-all shadow-sm"
+                    >
+                      <ClipboardCheck className="w-4 h-4" />
+                      {t("actions.auditLocation")}
                     </button>
                     <div className="flex items-center gap-1.5 bg-background/50 p-1 rounded-xl border border-border/40">
                       <RibbonAction

--- a/apps/web/src/app/[locale]/dashboard/warehouse/locations/_components/locations-data-view.tsx
+++ b/apps/web/src/app/[locale]/dashboard/warehouse/locations/_components/locations-data-view.tsx
@@ -2,7 +2,8 @@
 
 import { useCallback, useMemo, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
-import { Check, LayoutGrid, LayoutList, Printer, X } from "lucide-react";
+import { Check, ClipboardCheck, LayoutGrid, LayoutList, Printer, X } from "lucide-react";
+import { useRouter } from "@/i18n/navigation";
 import { DataView } from "@/components/data-view/data-view";
 import { Button } from "@/components/ui/button";
 import type {
@@ -68,6 +69,7 @@ export function LocationsDataView({
 }: Props) {
   const t = useTranslations("warehouseLocations.listView");
   const tAmbra = useTranslations("ambraLocations");
+  const router = useRouter();
   const [isCompactMode, setIsCompactMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [printDialogOpen, setPrintDialogOpen] = useState(false);
@@ -155,17 +157,37 @@ export function LocationsDataView({
   const renderToolbarControls = useCallback(
     () =>
       selectedIds.length > 0 ? (
-        <Button
-          size="sm"
-          variant="outline"
-          onClick={() => setPrintDialogOpen(true)}
-          className="gap-1.5"
-        >
-          <Printer className="h-3.5 w-3.5" />
-          {t("printLabels", { count: selectedIds.length })}
-        </Button>
+        <>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => setPrintDialogOpen(true)}
+            className="gap-1.5"
+          >
+            <Printer className="h-3.5 w-3.5" />
+            {t("printLabels", { count: selectedIds.length })}
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() =>
+              router.push({
+                pathname: "/dashboard/warehouse/audits/new",
+                query: {
+                  step: "2",
+                  countType: "location",
+                  locationIds: selectedIds.join(","),
+                },
+              })
+            }
+            className="gap-1.5"
+          >
+            <ClipboardCheck className="h-3.5 w-3.5" />
+            {tAmbra("actions.auditSelected", { count: selectedIds.length })}
+          </Button>
+        </>
       ) : null,
-    [selectedIds, t]
+    [selectedIds, t, tAmbra, router]
   );
 
   const columns = useMemo<DataViewColumnDef<LocationListRow>[]>(
@@ -293,22 +315,40 @@ export function LocationsDataView({
             compact={isCompactMode}
             qrAssignment={detail.qrAssignment}
             headerActions={
-              <div className="flex items-center gap-1 bg-background/80 rounded-xl p-1 border border-border">
+              <>
+                <div className="flex items-center gap-1 bg-background/80 rounded-xl p-1 border border-border">
+                  <button
+                    onClick={() => setIsCompactMode(false)}
+                    className={`p-2 rounded-lg transition-all ${!isCompactMode ? "bg-primary/10 text-primary shadow-[inset_0_1px_0_0_rgba(255,255,255,0.1)] border border-primary/20" : "text-muted-foreground hover:text-foreground/80 border border-transparent"}`}
+                    title={tAmbra("actions.bentoView")}
+                  >
+                    <LayoutGrid className="w-4 h-4" />
+                  </button>
+                  <button
+                    onClick={() => setIsCompactMode(true)}
+                    className={`p-2 rounded-lg transition-all ${isCompactMode ? "bg-primary/10 text-primary shadow-[inset_0_1px_0_0_rgba(255,255,255,0.1)] border border-primary/20" : "text-muted-foreground hover:text-foreground/80 border border-transparent"}`}
+                    title={tAmbra("actions.streamlinedView")}
+                  >
+                    <LayoutList className="w-4 h-4" />
+                  </button>
+                </div>
                 <button
-                  onClick={() => setIsCompactMode(false)}
-                  className={`p-2 rounded-lg transition-all ${!isCompactMode ? "bg-primary/10 text-primary shadow-[inset_0_1px_0_0_rgba(255,255,255,0.1)] border border-primary/20" : "text-muted-foreground hover:text-foreground/80 border border-transparent"}`}
-                  title={tAmbra("actions.bentoView")}
+                  onClick={() =>
+                    router.push({
+                      pathname: "/dashboard/warehouse/audits/new",
+                      query: {
+                        step: "2",
+                        countType: "location",
+                        locationId: detail.location.id,
+                      },
+                    })
+                  }
+                  className="flex items-center gap-2 px-4 py-2 rounded-xl border border-border bg-muted hover:bg-muted font-bold text-xs text-foreground/80 transition-all shadow-sm"
                 >
-                  <LayoutGrid className="w-4 h-4" />
+                  <ClipboardCheck className="w-4 h-4" />
+                  {tAmbra("actions.auditLocation")}
                 </button>
-                <button
-                  onClick={() => setIsCompactMode(true)}
-                  className={`p-2 rounded-lg transition-all ${isCompactMode ? "bg-primary/10 text-primary shadow-[inset_0_1px_0_0_rgba(255,255,255,0.1)] border border-primary/20" : "text-muted-foreground hover:text-foreground/80 border border-transparent"}`}
-                  title={tAmbra("actions.streamlinedView")}
-                >
-                  <LayoutList className="w-4 h-4" />
-                </button>
-              </div>
+              </>
             }
           />
         )}


### PR DESCRIPTION
…panel

Add "Audit location" action to the locations tree and data-view detail panels, and an "Audit selected" bulk action in the data-view toolbar, both deep-linking into the audit wizard with step/countType/locationId(s) query params so the location scope is pre-selected on step 2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added options to start an inventory audit directly from a warehouse location.
  - Added support for auditing multiple selected locations at once.
  - Audit setup now preserves selected locations and session type when opened from location views.
  - Added navigation links for single-location and bulk audit workflows.

- **Localization**
  - Added English and Polish labels for auditing individual and selected locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->